### PR TITLE
Implements cut enumeration algorithm

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,3 +7,6 @@ v0.1 (not yet released)
 * Initial network interface
 
 * Network implementations: `aig_network`, `klut_network`
+
+* Algorithms: `cut_enumeration`
+  `#2 <https://github.com/lsils/mockturtle/pull/2>`_

--- a/docs/cut_enumeration.rst
+++ b/docs/cut_enumeration.rst
@@ -1,0 +1,81 @@
+Cut enumeration
+---------------
+
+A *cut* of a Boolean network is a pair :math:`(n,L)`, where :math:`n` is a
+node, called *root*, and :math:`L` is a set of nodes, called *leaves*, such
+that (i) each path from any primary input to :math:`n` passes through at least
+one leaf and (ii) for each leaf :math:`l \in L`, there is at least one path
+from a primary input to :math:`n` passing through :math:`l` and not through any
+other leaf.
+
+The function :cpp:func:`mockturtle::cut_enumeration` implements cut
+enumeration, which is an algorithm that computes all cuts of all nodes in a
+Boolean network.  Since the number of cuts is very large, the number of
+enumerated cuts is bounded by a parameter :math:`l` (`cut_size`) for the cut
+size and a parameter :math:`p` (`cut_limit`) for the maximum number of cuts for
+each node.  This technique is referred to as priority cuts as it selects the
+subset of all cuts with respect to some cost function, in our case the number
+of the cuts' leaves.  The returned cut sets are also irredundant and do not
+contain two cuts :math:`(n, L_1)` and :math:`(n, L_2)` such that :math:`L_1`
+dominates :math:`L_2`, i.e., :math:`L_1 \subseteq L_2`.
+
+The simplest way to enumerate cuts in some network ``ntk`` is by calling:
+
+.. code-block:: c++
+
+   auto cuts = cut_enumeration( ntk );
+
+   ntk.foreach_node( [&]( auto node ) {
+     std::cout << cuts.cut_set( ntk.node_to_index( node ) ) << "\n";
+   } );
+
+Parameters can be set to adjust the cut size and the number of maximum cuts
+for each node:
+
+.. code-block:: c++
+
+   cut_enumeration_params ps;
+   ps.cut_size = 6;
+   ps.cut_limit = 8;
+
+   auto cuts = cut_enumeration( ntk, ps );
+
+A template argument to `cut_enumeration` can enable truth table computation for
+each cut.  The truth table for each cut can be retrieved from the return value
+for `cut_enumeration`.  The following example enumerates all cuts and computes
+their truth tables.  Afterwards, the truth table for each cut is printed.  In
+the example, `Ntk` is the type of `ntk`.
+
+.. code-block:: c++
+
+   auto cuts = cut_enumeration<Ntk, true>( ntk ); /* true enables truth table computation */
+   ntk.foreach_node( [&]( auto n ) {
+     const auto index = ntk.node_to_index( n );
+     for ( auto const& set : cuts.cut_set( index ) )
+     {
+       for ( auto const& cut : set )
+       {
+         std::cout << "Cut " << *cut
+                   << " with truth table " << kitty::to_hex( cuts.truth_table( *cut ) )
+                   << "\n";
+       }
+     }
+   } );
+
+Parameters
+~~~~~~~~~~
+
+.. doxygenstruct:: mockturtle::cut_enumeration_params
+   :members:
+
+Return value
+~~~~~~~~~~~~
+
+.. doxygenstruct:: mockturtle::network_cuts
+   :members:
+
+Algorithm
+~~~~~~~~~
+
+.. doxygenfunction:: mockturtle::cut_enumeration
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,12 @@ Welcome to mockturtle's documentation!
 
 .. toctree::
    :maxdepth: 2
+   :caption: Algorithms
+
+   cut_enumeration
+
+.. toctree::
+   :maxdepth: 2
    :caption: Utilities
 
    util_data_structures

--- a/docs/util_data_structures.rst
+++ b/docs/util_data_structures.rst
@@ -13,3 +13,46 @@ Truth table cache
 
 .. doxygenclass:: mockturtle::truth_table_cache
    :members:
+
+Cuts
+~~~~
+
+.. doc_overview_table:: classmockturtle_1_1cut
+   :column: Method
+
+   operator=
+   set_leaves
+   signature
+   size
+   begin
+   end
+   operator->
+   data
+   subsumes
+   merge
+
+.. doxygenclass:: mockturtle::cut
+   :members:
+
+Cut sets
+~~~~~~~~
+
+.. doc_overview_table:: classmockturtle_1_1cut__set
+   :column: Method
+
+   cut_set
+   clear
+   add_cut
+   is_subsumed
+   insert
+   begin
+   end
+   size
+   operator[]
+   best
+   update_best
+   limit
+   operator<<
+
+.. doxygenclass:: mockturtle::cut_set
+   :members:

--- a/include/mockturtle/algorithms/cut_enumeration.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration.hpp
@@ -1,0 +1,521 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file cut_enumeration.hpp
+  \brief Cut enumeration
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+#include <kitty/constructors.hpp>
+#include <kitty/dynamic_truth_table.hpp>
+
+#include "../traits.hpp"
+#include "../utils/cuts.hpp"
+#include "../utils/mixed_radix.hpp"
+#include "../utils/truth_table_cache.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Parameters for cut_enumeration.
+ *
+ * The data structure `cut_enumeration_params` holds configurable parameters
+ * with default arguments for `cut_enumeration`.
+ */
+struct cut_enumeration_params
+{
+  /*! \brief Maximum number of leaves for a cut. */
+  uint32_t cut_size{4u};
+
+  /*! \brief Maximum number of cuts for a node. */
+  uint32_t cut_limit{25u};
+
+  /*! \brief Prune cuts by removing don't cares. */
+  bool minimize_truth_table{false};
+};
+
+static constexpr uint32_t max_cut_size = 8;
+
+template<bool ComputeTruth, typename T = empty_cut_data>
+struct cut_data;
+
+template<typename T>
+struct cut_data<true, T>
+{
+  uint32_t func_id;
+  T data;
+};
+
+template<typename T>
+struct cut_data<false, T>
+{
+  T data;
+};
+
+template<bool ComputeTruth, typename T>
+using cut_type = cut<max_cut_size, cut_data<ComputeTruth, T>>;
+
+/* forward declarations */
+/*! \cond PRIVATE */
+template<typename Ntk, bool ComputeTruth, typename CutData>
+struct network_cuts;
+
+template<typename Ntk, bool ComputeTruth, typename CutData>
+network_cuts<Ntk, ComputeTruth, CutData> cut_enumeration( Ntk const& ntk, cut_enumeration_params const& ps = {} );
+
+/* function to update a cut */
+template<bool ComputeTruth, typename CutData, typename Ntk>
+void cut_enumeration_update_cut( cut_type<ComputeTruth, CutData>& cut, network_cuts<Ntk, ComputeTruth, CutData> const& cuts, Ntk const& ntk, node<Ntk> const& n )
+{
+  (void)cut;
+  (void)cuts;
+  (void)ntk;
+  (void)n;
+}
+
+namespace detail
+{
+template<typename Ntk, bool ComputeTruth, typename CutData>
+class cut_enumeration_impl;
+}
+/*! \endcond */
+
+/*! \brief Cut database for a network.
+ *
+ * The function `cut_enumeration` returns an instance of type `network_cuts`
+ * which contains a cut database and can be queried to return all cuts of a
+ * node, or the function of a cut (if it was computed).
+ *
+ * An instance of type `network_cuts` can only be constructed from the
+ * `cut_enumeration` algorithm.
+ */
+template<typename Ntk, bool ComputeTruth, typename CutData>
+struct network_cuts
+{
+public:
+  static constexpr uint32_t max_cut_num = 26;
+  using cut_t = cut_type<ComputeTruth, CutData>;
+  using cut_set_t = cut_set<cut_t, max_cut_num>;
+  static constexpr bool compute_truth = ComputeTruth;
+
+private:
+  explicit network_cuts( std::size_t size ) : cuts( size )
+  {
+    kitty::dynamic_truth_table zero( 0u ), proj( 1u );
+    kitty::create_nth_var( proj, 0u );
+
+    truth_tables.insert( zero );
+    truth_tables.insert( proj );
+  }
+
+public:
+  /*! \brief Returns the cut set of a node */
+  cut_set_t& cut_set( std::size_t node_index ) { return cuts[node_index]; }
+
+  /*! \brief Returns the cut set of a node */
+  cut_set_t const& cut_set( std::size_t node_index ) const { return cuts[node_index]; }
+
+  /*! \brief Returns the truth table of a cut */
+  template<bool enabled = ComputeTruth, typename = std::enable_if_t<std::is_same_v<Ntk, Ntk> && enabled>>
+  auto truth_table( cut_t const& cut ) const
+  {
+    return truth_tables[cut->func_id];
+  }
+
+  /*! \brief Returns the total number of tuples that were tried to be merged */
+  auto total_tuples() const
+  {
+    return _total_tuples;
+  }
+
+  /*! \brief Returns the total number of cuts in the database. */
+  auto total_cuts() const
+  {
+    return _total_cuts;
+  }
+
+  /*! \brief Returns the number of nodes for which cuts are computed */
+  auto nodes_size() const
+  {
+    return cuts.size();
+  }
+
+  /* compute positions of leave indices in cut `sub` (subset) with respect to
+   * leaves in cut `sup` (super set).
+   *
+   * Example:
+   *   compute_truth_table_support( {1, 3, 6}, {0, 1, 2, 3, 6, 7} ) = {1, 3, 4}
+   */
+  std::vector<uint8_t> compute_truth_table_support( cut_t const& sub, cut_t const& sup ) const
+  {
+    std::vector<uint8_t> support;
+    support.reserve( sub.size() );
+
+    auto itp = sup.begin();
+    for ( auto i : sub )
+    {
+      itp = std::find( itp, sup.end(), i );
+      support.push_back( std::distance( sup.begin(), itp ) );
+    }
+
+    return support;
+  }
+
+private:
+  template<typename _Ntk, bool _ComputeTruth, typename _CutData>
+  friend class detail::cut_enumeration_impl;
+
+  template<typename _Ntk, bool _ComputeTruth, typename _CutData>
+  friend network_cuts<_Ntk, _ComputeTruth, _CutData> cut_enumeration( _Ntk const& ntk, cut_enumeration_params const& ps );
+
+private:
+  void add_zero_cut( std::size_t index )
+  {
+    auto& cut = cuts[index].add_cut( &index, &index ); /* fake iterator for emptyness */
+
+    if constexpr ( ComputeTruth )
+    {
+      cut->func_id = 0;
+    }
+  }
+
+  void add_unit_cut( std::size_t index )
+  {
+    auto& cut = cuts[index].add_cut( &index, &index + 1 );
+
+    if constexpr ( ComputeTruth )
+    {
+      cut->func_id = 2;
+    }
+  }
+
+private:
+  /* compressed representation of cuts */
+  std::vector<cut_set_t> cuts;
+
+  /* cut truth tables */
+  truth_table_cache<kitty::dynamic_truth_table> truth_tables;
+
+  /* statistics */
+  uint32_t _total_tuples{};
+  uint32_t _total_cuts{};
+};
+
+/*! \cond PRIVATE */
+namespace detail
+{
+
+template<typename Ntk, bool ComputeTruth, typename CutData>
+class cut_enumeration_impl
+{
+public:
+  using cut_t = typename network_cuts<Ntk, ComputeTruth, CutData>::cut_t;
+  using cut_set_t = typename network_cuts<Ntk, ComputeTruth, CutData>::cut_set_t;
+
+  explicit cut_enumeration_impl( Ntk const& ntk, cut_enumeration_params const& ps, network_cuts<Ntk, ComputeTruth, CutData>& cuts )
+      : ntk( ntk ),
+        ps( ps ),
+        cuts( cuts )
+  {
+  }
+
+public:
+  void run()
+  {
+    ntk.foreach_node( [this]( auto node ) {
+      const auto index = ntk.node_to_index( node );
+      if ( ntk.is_constant( node ) )
+      {
+        cuts.add_zero_cut( index );
+      }
+      else if ( ntk.is_pi( node ) )
+      {
+        cuts.add_unit_cut( index );
+      }
+      else
+      {
+        if constexpr ( Ntk::min_fanin_size == 2 && Ntk::max_fanin_size == 2 )
+        {
+          merge_cuts2( index );
+        }
+        else
+        {
+          merge_cuts( index );
+        }
+      }
+    } );
+  }
+
+private:
+  uint32_t compute_truth_table( std::size_t index, std::vector<cut_t const*> const& vcuts, cut_t& res )
+  {
+    std::vector<kitty::dynamic_truth_table> tt( vcuts.size() );
+    auto i = 0;
+    for ( auto const& cut : vcuts )
+    {
+      tt[i] = kitty::extend_to( cuts.truth_tables[( *cut )->func_id], res.size() );
+      const auto supp = cuts.compute_truth_table_support( *cut, res );
+      kitty::expand_inplace( tt[i], supp );
+      ++i;
+    }
+
+    auto tt_res = ntk.compute( index, tt.begin(), tt.end() );
+
+    if ( ps.minimize_truth_table )
+    {
+      const auto support = kitty::min_base_inplace( tt_res );
+      if ( support.size() != res.size() )
+      {
+        auto tt_res_shrink = shrink_to( tt_res, support.size() );
+        std::vector<uint32_t> leaves_before( res.begin(), res.end() );
+        std::vector<uint32_t> leaves_after( support.size() );
+
+        auto it_support = support.begin();
+        auto it_leaves = leaves_after.begin();
+        while ( it_support != support.end() )
+        {
+          *it_leaves++ = leaves_before[*it_support++];
+        }
+        res.set_leaves( leaves_after.begin(), leaves_after.end() );
+        return cuts.truth_tables.insert( tt_res_shrink );
+      }
+    }
+
+    return cuts.truth_tables.insert( tt_res );
+  }
+
+  void merge_cuts2( std::size_t index )
+  {
+    const auto fanin = 2;
+
+    uint32_t pairs{1};
+    ntk.foreach_fanin( index, [this, &pairs]( auto child, auto i ) {
+      lcuts[i] = &cuts.cut_set( ntk.node_to_index( ntk.get_node( child ) ) );
+      pairs *= lcuts[i]->size();
+    } );
+    lcuts[2] = &cuts.cut_set( index );
+    auto& rcuts = *lcuts[fanin];
+    rcuts.clear();
+
+    cut_t new_cut;
+
+    std::vector<cut_t const*> vcuts( fanin );
+
+    cuts._total_tuples += pairs;
+    for ( auto const& c1 : *lcuts[0] )
+    {
+      for ( auto const& c2 : *lcuts[1] )
+      {
+        if ( !c1->merge( *c2, new_cut, ps.cut_size ) )
+        {
+          continue;
+        }
+
+        if ( rcuts.is_dominated( new_cut ) )
+        {
+          continue;
+        }
+
+        cut_enumeration_update_cut( new_cut, cuts, ntk, index );
+
+        if constexpr ( ComputeTruth )
+        {
+          vcuts[0] = c1;
+          vcuts[1] = c2;
+          new_cut->func_id = compute_truth_table( index, vcuts, new_cut );
+        }
+
+        rcuts.insert( new_cut );
+      }
+    }
+
+    /* limit the maximum number of cuts */
+    rcuts.limit( ps.cut_limit - 1 );
+
+    cuts._total_cuts += rcuts.size();
+
+    if ( rcuts.size() > 1 || ( *rcuts.begin() )->size() > 1 )
+    {
+      cuts.add_unit_cut( index );
+    }
+  }
+
+  void merge_cuts( std::size_t index )
+  {
+    uint32_t pairs{1};
+    std::vector<uint32_t> cut_sizes;
+    ntk.foreach_fanin( index, [this, &pairs, &cut_sizes]( auto child, auto i ) {
+      lcuts[i] = &cuts.cut_set( ntk.node_to_index( ntk.get_node( child ) ) );
+      cut_sizes.push_back( lcuts[i]->size() );
+      pairs *= cut_sizes.back();
+    } );
+
+    const auto fanin = cut_sizes.size();
+    lcuts[fanin] = &cuts.cut_set( index );
+
+    auto& rcuts = *lcuts[fanin == 1 ? 0 : fanin];
+
+    if ( fanin > 1 )
+    {
+      rcuts.clear();
+
+      cut_t new_cut, tmp_cut;
+
+      std::vector<cut_t const*> vcuts( fanin );
+
+      cuts._total_tuples += pairs;
+      foreach_mixed_radix_tuple( cut_sizes.begin(), cut_sizes.end(), [&]( auto begin, auto end ) {
+        auto it = vcuts.begin();
+        auto i = 0u;
+        while ( begin != end )
+        {
+          *it++ = &( ( *lcuts[i++] )[*begin++] );
+        }
+
+        if ( !vcuts[0]->merge( *vcuts[1], new_cut, ps.cut_size ) )
+        {
+          return true; /* continue */
+        }
+
+        for ( i = 2; i < fanin; ++i )
+        {
+          tmp_cut = new_cut;
+          if ( !vcuts[i]->merge( tmp_cut, new_cut, ps.cut_size ) )
+          {
+            return true; /* continue */
+          }
+        }
+
+        if ( rcuts.is_dominated( new_cut ) )
+        {
+          return true; /* continue */
+        }
+
+        cut_enumeration_update_cut( new_cut, cuts, ntk, index );
+
+        if constexpr ( ComputeTruth )
+        {
+          new_cut->func_id = compute_truth_table( index, vcuts, new_cut );
+        }
+
+        rcuts.insert( new_cut );
+
+        return true;
+      } );
+
+      /* limit the maximum number of cuts */
+      rcuts.limit( ps.cut_limit - 1 );
+    }
+
+    cuts._total_cuts += rcuts.size();
+
+    if ( rcuts.size() > 1 || ( *rcuts.begin() )->size() > 1 )
+    {
+      cuts.add_unit_cut( index );
+    }
+  }
+
+private:
+  Ntk const& ntk;
+  cut_enumeration_params const& ps;
+  network_cuts<Ntk, ComputeTruth, CutData>& cuts;
+
+  std::array<cut_set_t*, Ntk::max_fanin_size + 1> lcuts;
+};
+} /* namespace detail */
+/*! \endcond */
+
+/*! \brief Cut enumeration.
+ *
+ * This function implements the cut enumeration algorithm.  The algorithm
+ * traverses all nodes in topological order and computes a node's cuts based
+ * on its fanins' cuts.  Dominated cuts are filtered and are not added to the
+ * cut set.  For each node a unit cut is added to the end of each cut set.
+ *
+ * The template parameter `ComputeTruth` controls whether truth tables should
+ * be computed for each cut.  Computing truth tables slows down the execution
+ * time of the algorithm.
+ *
+ * The number of computed cuts is controlled via the `cut_limit` parameter.
+ * To decide which cuts are collected in each node's cut set, cuts are sorted.
+ * Unit cuts do not participate in the sorting and are always added to the end
+ * of each cut set.
+ *
+ * The algorithm can be configured by speciying the template argument `CutData`
+ * which holds the application specific data assigned to each cut.  Examples
+ * on how to specify custom cost functions for sorting cuts based on the
+ * application specific cut data can be found in the files contained in the
+ * directory `include/mockturtle/algorithms/cut_enumeration`.
+ *
+ * **Required network functions:**
+ * - `is_constant`
+ * - `is_pi`
+ * - `size`
+ * - `get_node`
+ * - `node_to_index`
+ * - `foreach_node`
+ * - `foreach_fanin`
+ *
+   \verbatim embed:rst
+
+   .. warning::
+
+      This algorithm expects the nodes in the network to be in topological
+      order.
+
+   .. note::
+
+      The implementation of this algorithm was heavily inspired but cut
+      enumeration implementations in ABC.
+   \endverbatim
+ */
+template<typename Ntk, bool ComputeTruth = false, typename CutData = empty_cut_data>
+network_cuts<Ntk, ComputeTruth, CutData> cut_enumeration( Ntk const& ntk, cut_enumeration_params const& ps )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
+  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
+  static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+  static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+  static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
+  static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
+
+  network_cuts<Ntk, ComputeTruth, CutData> res( ntk.size() );
+  detail::cut_enumeration_impl<Ntk, ComputeTruth, CutData> p( ntk, ps, res );
+  p.run();
+  return res;
+}
+
+} /* namespace mockturtle */

--- a/include/mockturtle/algorithms/cut_enumeration/gia_cut.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration/gia_cut.hpp
@@ -1,0 +1,72 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file gia_cut.hpp
+  \brief Cut enumeration as in giaCut.c
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "../cut_enumeration.hpp"
+
+namespace mockturtle
+{
+
+struct cut_enumeration_gia_cut
+{
+  uint32_t num_tree_leaves;
+};
+
+template<bool ComputeTruth>
+bool operator<( cut_type<ComputeTruth, cut_enumeration_gia_cut> const& c1, cut_type<ComputeTruth, cut_enumeration_gia_cut> const& c2 )
+{
+  if ( c1->data.num_tree_leaves < c2->data.num_tree_leaves )
+  {
+    return true;
+  }
+  if ( c1->data.num_tree_leaves > c2->data.num_tree_leaves )
+  {
+    return false;
+  }
+  return c1.size() < c2.size();
+}
+
+template<bool ComputeTruth, typename Ntk>
+void cut_enumeration_update_cut( cut_type<ComputeTruth, cut_enumeration_gia_cut>& cut, network_cuts<Ntk, cut_enumeration_gia_cut, ComputeTruth> const& cuts, Ntk const& ntk, node<Ntk> const& n )
+{
+  (void)n;
+  cut->data.num_tree_leaves = std::count_if( cut.begin(), cut.end(),
+                                             [&ntk]( auto index ) {
+                                               return ntk.fanout_size( index ) == 1;
+                                             } );
+}
+
+}

--- a/include/mockturtle/algorithms/cut_enumeration/gia_cut.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration/gia_cut.hpp
@@ -60,7 +60,7 @@ bool operator<( cut_type<ComputeTruth, cut_enumeration_gia_cut> const& c1, cut_t
 }
 
 template<bool ComputeTruth, typename Ntk>
-void cut_enumeration_update_cut( cut_type<ComputeTruth, cut_enumeration_gia_cut>& cut, network_cuts<Ntk, cut_enumeration_gia_cut, ComputeTruth> const& cuts, Ntk const& ntk, node<Ntk> const& n )
+void cut_enumeration_update_cut( cut_type<ComputeTruth, cut_enumeration_gia_cut>& cut, network_cuts<Ntk, ComputeTruth, cut_enumeration_gia_cut> const& cuts, Ntk const& ntk, node<Ntk> const& n )
 {
   (void)n;
   cut->data.num_tree_leaves = std::count_if( cut.begin(), cut.end(),

--- a/include/mockturtle/algorithms/cut_enumeration/mf_cut.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration/mf_cut.hpp
@@ -60,7 +60,7 @@ bool operator<( cut_type<ComputeTruth, cut_enumeration_mf_cut> const& c1, cut_ty
 }
 
 template<bool ComputeTruth, typename Ntk>
-void cut_enumeration_update_cut( cut_type<ComputeTruth, cut_enumeration_mf_cut>& cut, network_cuts<Ntk, cut_enumeration_mf_cut, ComputeTruth> const& cuts, Ntk const& ntk, node<Ntk> const& n )
+void cut_enumeration_update_cut( cut_type<ComputeTruth, cut_enumeration_mf_cut>& cut, network_cuts<Ntk, ComputeTruth, cut_enumeration_mf_cut> const& cuts, Ntk const& ntk, node<Ntk> const& n )
 {
   // TODO assume that fanin size is > 1
   uint32_t delay{0};

--- a/include/mockturtle/algorithms/cut_enumeration/mf_cut.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration/mf_cut.hpp
@@ -1,0 +1,89 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file mf_cut.hpp
+  \brief Cut enumeration for MF mapping (see giaMf.c)
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+
+#include "../cut_enumeration.hpp"
+
+namespace mockturtle
+{
+
+struct cut_enumeration_mf_cut
+{
+  uint32_t delay{0};
+  float flow{0};
+};
+
+template<bool ComputeTruth>
+bool operator<( cut_type<ComputeTruth, cut_enumeration_mf_cut> const& c1, cut_type<ComputeTruth, cut_enumeration_mf_cut> const& c2 )
+{
+  constexpr auto eps{0.005f};
+  if ( c1->data.flow < c2->data.flow - eps ) return true;
+  if ( c1->data.flow > c2->data.flow + eps ) return false;
+  if ( c1->data.delay < c2->data.delay ) return true;
+  if ( c1->data.delay > c2->data.delay ) return false;
+  return c1.size() < c2.size();
+}
+
+template<bool ComputeTruth, typename Ntk>
+void cut_enumeration_update_cut( cut_type<ComputeTruth, cut_enumeration_mf_cut>& cut, network_cuts<Ntk, cut_enumeration_mf_cut, ComputeTruth> const& cuts, Ntk const& ntk, node<Ntk> const& n )
+{
+  // TODO assume that fanin size is > 1
+  uint32_t delay{0};
+  float flow{1.0};
+
+  for ( auto leaf : cut )
+  {
+    const auto& best_leaf_cut = cuts.cut_set( leaf )[0];
+    delay = std::max( delay, best_leaf_cut->data.delay );
+    flow += best_leaf_cut->data.flow;
+  }
+
+  cut->data.delay = 1 + delay;
+  cut->data.flow = flow / ntk.fanout_size( n );
+}
+
+template<int MaxLeaves>
+std::ostream& operator<<( std::ostream& os, cut<MaxLeaves, cut_data<false, cut_enumeration_mf_cut>> const& c )
+{
+  os << "{ ";
+  std::copy( c.begin(), c.end(), std::ostream_iterator<uint32_t>( os, " " ) );
+  os << "}, D = " << std::setw( 3 ) << c->data.delay << " A = " << c->data.flow;
+  return os;
+}
+
+}

--- a/include/mockturtle/utils/cuts.hpp
+++ b/include/mockturtle/utils/cuts.hpp
@@ -1,0 +1,542 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file cuts.hpp
+  \brief Data structure for cuts
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <iostream>
+#include <iterator>
+
+namespace mockturtle
+{
+
+struct empty_cut_data
+{
+};
+
+/*! \brief A data-structure to hold a cut.
+ *
+ * The cut class is specialized via two template arguments, `MaxLeaves` and `T`.
+ * `MaxLeaves` controls the maximum number of leaves a cut can hold.  To
+ * guarantee an efficient implementation, this value should be \f$k \cdot l\f$,
+ * where \f$k\f$ is the maximum cut size and \f$l\f$ is the maximum fanin size
+ * of a gate in the logic network.  The second template argument `T` can be a
+ * type for which a data entry is created in the cut to store additional data,
+ * e.g., to compute the cost of a cut.  It defaults to `empty_cut_data`, which
+ * is an empty struct that does not consume memory.
+ *
+   \verbatim embed:rst
+  
+   Example
+   
+   .. code-block:: c++
+   
+      std::vector<uint32_t> data{1, 2, 3, 4};
+  
+      cut<10> cut1;
+      cut1.set_leaves( data.begin(), data.end() );
+  
+      cut<10, uint32_t> cut2;
+      cut2.set_leaves( data.begin(), data.end() );
+      cut2.data() = 42u;
+  
+      struct cut_data { uint32_t costs; };
+      cut<20, cut_data> c3;
+      c3.set_leaves( std::vector<uint32_t>{1, 2, 3} );
+      c3->costs = 37u;
+   \endverbatim
+ */
+template<int MaxLeaves, typename T = empty_cut_data>
+class cut
+{
+public:
+  /*! \brief Assignment operator.
+   *
+   * Copies leaves, length, signature, and data.
+   *
+   * \param other Other cut
+   */
+  cut& operator=( cut const& other );
+
+  /*! \brief Sets leaves (using iterators).
+   *
+   * \param begin Begin iterator to leaves
+   * \param end End iterator to leaves (exclusive)
+   */
+  template<typename Iterator>
+  void set_leaves( Iterator begin, Iterator end );
+
+  /*! \brief Sets leaves (using container).
+   *
+   * Convenience function, which extracts the begin and end iterators from the
+   * container.
+   */
+  template<typename Container>
+  void set_leaves( Container const& c );
+
+  /*! \brief Signature of the cut. */
+  auto signature() const { return _signature; }
+
+  /*! \brief Returns the size of the cut (number of leaves). */
+  auto size() const { return _length; }
+
+  /*! \brief Begin iterator (constant). */
+  auto begin() const { return _leaves.begin(); }
+
+  /*! \brief End iterator (constant). */
+  auto end() const { return _cend; }
+
+  /*! \brief Begin iterator (mutable). */
+  auto begin() { return _leaves.begin(); }
+
+  /*! \brief End iterator (mutable). */
+  auto end() { return _end; }
+
+  /*! \brief Access to data (mutable). */
+  T* operator->() { return &_data; }
+
+  /*! \brief Access to data (constant). */
+  T const* operator->() const { return &_data; }
+
+  /*! \brief Access to data (mutable). */
+  T& data() { return _data; }
+
+  /*! \brief Access to data (constant). */
+  T const& data() const { return _data; }
+
+  /*! \brief Checks whether the cut is a subset of another cut.
+   *
+   * If \f$L_1\f$ are the leaves of the current cut and \f$L_2\f$ are the leaves
+   * of `that`, then this method returns true if and only if
+   * \f$L_1 \subseteq L_2\f$.
+   * 
+   * \param that Other cut
+   */
+  bool dominates( cut const& that ) const;
+
+  /*! \brief Merges two cuts.
+   *
+   * This method merges two cuts and stores the result in `res`.  The merge of
+   * two cuts is the union \f$L_1 \cup L_2\f$ of the two leaf sets \f$L_1\f$ of
+   * the cut and \f$L_2\f$ of `that`.  The merge is only successful if the
+   * union has not more than `cut_size` elements.  In that case, the function
+   * returns `false`, otherwise `true`.
+   * 
+   * \param that Other cut
+   * \param res Resulting cut
+   * \param cut_size Maximum cut size
+   * \return True, if resulting cut is small enough
+   */
+  bool merge( cut const& that, cut& res, uint32_t cut_size ) const;
+
+private:
+  std::array<uint32_t, MaxLeaves> _leaves;
+  uint32_t _length;
+  uint64_t _signature;
+  typename std::array<uint32_t, MaxLeaves>::const_iterator _cend;
+  typename std::array<uint32_t, MaxLeaves>::iterator _end;
+
+  T _data;
+};
+
+/*! \brief Compare two cuts.
+ *
+ * Default comparison function for two cuts.  A cut is smaller than another
+ * cut, if it has fewer leaves.
+ *
+ * This function should be specialized for custom cuts, if additional data
+ * changes the cost of a cut.
+ */
+template<int MaxLeaves, typename T>
+bool operator<( cut<MaxLeaves, T> const& c1, cut<MaxLeaves, T> const& c2 )
+{
+  return c1.size() < c2.size();
+}
+
+/*! \brief Prints a cut.
+ */
+template<int MaxLeaves, typename T>
+std::ostream& operator<<( std::ostream& os, cut<MaxLeaves, T> const& c )
+{
+  os << "{ ";
+  std::copy( c.begin(), c.end(), std::ostream_iterator<uint32_t>( os, " " ) );
+  os << "}";
+  return os;
+}
+
+template<int MaxLeaves, typename T>
+cut<MaxLeaves, T>& cut<MaxLeaves, T>::operator=( cut<MaxLeaves, T> const& other )
+{
+  if ( &other != this )
+  {
+    _cend = _end = std::copy( other.begin(), other.end(), _leaves.begin() );
+    _length = other._length;
+    _signature = other._signature;
+    _data = other._data;
+  }
+  return *this;
+}
+
+template<int MaxLeaves, typename T>
+template<typename Iterator>
+void cut<MaxLeaves, T>::set_leaves( Iterator begin, Iterator end )
+{
+  _cend = _end = std::copy( begin, end, _leaves.begin() );
+  _length = std::distance( begin, end );
+  _signature = 0;
+
+  while ( begin != end )
+  {
+    _signature |= UINT64_C( 1 ) << ( *begin++ & 0x3f );
+  }
+}
+
+template<int MaxLeaves, typename T>
+template<typename Container>
+void cut<MaxLeaves, T>::set_leaves( Container const& c )
+{
+  set_leaves( std::begin( c ), std::end( c ) );
+}
+
+template<int MaxLeaves, typename T>
+bool cut<MaxLeaves, T>::dominates( cut const& that ) const
+{
+  /* quick check for counter example */
+  if ( _length > that._length || ( _signature & that._signature ) != _signature )
+  {
+    return false;
+  }
+
+  if ( _length == that._length )
+  {
+    return std::equal( begin(), end(), that.begin() );
+  }
+
+  if ( _length == 0 )
+  {
+    return true;
+  }
+
+  // this is basically
+  //     return std::includes( that.begin(), that.end(), begin(), end() )
+  // but it turns out that this code is faster compared to the standard
+  // implementation.
+  for ( auto it2 = that.begin(), it1 = begin(); it2 != that.end(); ++it2 )
+  {
+    if ( *it2 > *it1 )
+    {
+      return false;
+    }
+    if ( ( *it2 == *it1 ) && ( ++it1 == end() ) )
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+template<int MaxLeaves, typename T>
+bool cut<MaxLeaves, T>::merge( cut const& that, cut& res, uint32_t cut_size ) const
+{
+  if ( _length + that._length > cut_size && static_cast<uint32_t>( __builtin_popcount( _signature | that._signature ) ) > cut_size )
+  {
+    return false;
+  }
+
+  auto it = std::set_union( begin(), end(), that.begin(), that.end(), res.begin() );
+  if ( auto length = std::distance( res.begin(), it ); length <= cut_size )
+  {
+    res._cend = res._end = it;
+    res._length = length;
+    res._signature = _signature | that._signature;
+    return true;
+  }
+  return false;
+}
+
+/*! \brief A data-structure to hold a set of cuts.
+ *
+ * The aim of a cut set is to contain cuts and maintain two propeties.  First,
+ * all cuts are ordered according to the `<` operator, and second, all cuts
+ * are irredundant, i.e., no cut in the set dominates another cut in the set.
+ * 
+ * The cut set is defined using the `CutType` of cuts it should hold and a
+ * maximum number of cuts it can hold.  No check is performed whether a cut set
+ * is full, and therefore the caller must not insert cuts into a full set.
+ *
+   \verbatim embed:rst
+  
+   Example
+   
+   .. code-block:: c++
+   
+      cut_set<cut<10>, 30> cuts;
+
+      cut<10> c1, c2, c3, c4;
+
+      c1.set_leaves( {1, 2, 3} );
+      c2.set_leaves( {4, 5} );
+      c3.set_leaves( {1, 2} );
+      c4.set_leaves( {1, 3, 4} );
+
+      cuts.insert( c1 );
+      cuts.insert( c2 );
+      cuts.insert( c3 );
+      cuts.insert( c4 );
+
+      assert( cuts.size() == 3 );
+
+      std::cout << cuts << std::endl;
+
+      // will print:
+      //   { 4, 5 }
+      //   { 1, 2 }
+      //   { 1, 3, 4 }
+   \endverbatim
+ */
+template<typename CutType, int MaxCuts>
+class cut_set
+{
+public:
+  /*! \brief Standard constructor.
+   */
+  cut_set();
+
+  /*! \brief Clears a cut set.
+   */
+  void clear();
+
+  /*! \brief Adds a cut to the end of the set.
+   *
+   * This function should only be called to create a set of cuts which is known
+   * to be sorted and irredundant (i.e., no cut in the set dominates another
+   * cut).
+   * 
+   * \param begin Begin iterator to leaf indexes
+   * \param end End iterator (exclusive) to leaf indexes
+   * \return Reference to the added cut
+   */
+  template<typename Iterator>
+  CutType& add_cut( Iterator begin, Iterator end );
+
+  /*! \brief Checks whether cut is dominates by any cut in the set.
+   *
+   * \param cut Cut outside of the set
+   */
+  bool is_dominated( CutType const& cut ) const;
+
+  /*! \brief Inserts a cut into a set.
+   *
+   * This method will insert a cut into a set and maintain an order.  Before the
+   * cut is inserted into the correct position, it will remove all cuts that are
+   * dominated by `cut`.
+   * 
+   * If `cut` is dominated by any of the cuts in the set, it will still be
+   * inserted.  The caller is responsible to check whether `cut` is dominated
+   * before inserting it into the set.
+   * 
+   * \param cut Cut to insert.
+   */
+  void insert( CutType const& cut );
+
+  /*! \brief Begin iterator (constant). 
+   *
+   * The iterator will point to a cut pointer.
+   */
+  auto begin() const { return _pcuts.begin(); }
+
+  /*! \brief End iterator (constant). */
+  auto end() const { return _pcend; }
+
+  /*! \brief Begin iterator (mutable).
+   *
+   * The iterator will point to a cut pointer.
+   */
+  auto begin() { return _pcuts.begin(); }
+
+  /*! \brief End iterator (mutable). */
+  auto end() { return _pend; }
+
+  /*! \brief Number of cuts in the set. */
+  auto size() const { return _pcend - _pcuts.begin(); }
+
+  /*! \brief Returns reference to cut at index.
+   *
+   * This function does not return the cut pointer but dereferences it and
+   * returns a reference.  The function does not check whether index is in the
+   * valid range.
+   *
+   * \param index Index
+   */
+  auto const& operator[]( std::size_t index ) const { return *_pcuts[index]; }
+
+  /*! \brief Returns the best cut, i.e., the first cut.
+   */
+  auto const& best() const { return *_pcuts[0]; }
+
+  /*! \brief Updates the best cut.
+   *
+   * This method will set the cut at index `index` to be the best cut.  All
+   * cuts before `index` will be moved one position higher.
+   *
+   * \param index Index of new best cut
+   */
+  void update_best( uint32_t index );
+
+  /*! \brief Resize the cut set, if it is too large.
+   *
+   * This method will resize the cut set to `size` only if the cut set has more
+   * than `size` elements.  Otherwise, the size will remain the same.
+   */
+  void limit( std::size_t size );
+
+  /*! \brief Prints a cut set. */
+  friend std::ostream& operator<<( std::ostream& os, cut_set const& set )
+  {
+    for ( auto const& c : set )
+    {
+      os << *c << "\n";
+    }
+    return os;
+  }
+
+private:
+  std::array<CutType, MaxCuts> _cuts;
+  std::array<CutType*, MaxCuts> _pcuts;
+  typename std::array<CutType*, MaxCuts>::const_iterator _pcend{_pcuts.begin()};
+  typename std::array<CutType*, MaxCuts>::iterator _pend{_pcuts.begin()};
+};
+
+template<typename CutType, int MaxCuts>
+cut_set<CutType, MaxCuts>::cut_set()
+{
+  clear();
+}
+
+template<typename CutType, int MaxCuts>
+void cut_set<CutType, MaxCuts>::clear()
+{
+  _pcend = _pend = _pcuts.begin();
+  auto pit = _pcuts.begin();
+  for ( auto& c : _cuts )
+  {
+    *pit++ = &c;
+  }
+}
+
+template<typename CutType, int MaxCuts>
+template<typename Iterator>
+CutType& cut_set<CutType, MaxCuts>::add_cut( Iterator begin, Iterator end )
+{
+  assert( _pend != _pcuts.end() );
+
+  auto& cut = **_pend++;
+  cut.set_leaves( begin, end );
+
+  ++_pcend;
+  return cut;
+}
+
+template<typename CutType, int MaxCuts>
+bool cut_set<CutType, MaxCuts>::is_dominated( CutType const& cut ) const
+{
+  return std::find_if( _pcuts.begin(), _pcend, [&cut]( auto const* other ) { return other->dominates( cut ); } ) != _pcend;
+}
+
+template<typename CutType, int MaxCuts>
+void cut_set<CutType, MaxCuts>::insert( CutType const& cut )
+{
+  /* remove elements that are dominated by new cut */
+  _pcend = _pend = std::stable_partition( _pcuts.begin(), _pend, [&cut]( auto const* other ) { return !cut.dominates( *other ); } );
+
+  /* insert cut in a sorted way */
+  auto ipos = std::lower_bound( _pcuts.begin(), _pend, &cut, []( auto a, auto b ) { return *a < *b; } );
+
+  /* too many cuts, we need to remove one */
+  if ( _pend == _pcuts.end() )
+  {
+    /* cut to be inserted is worse than all the others, return */
+    if ( ipos == _pend )
+    {
+      return;
+    }
+    else
+    {
+      /* remove last cut */
+      --_pend;
+      --_pcend;
+    }
+  }
+
+  /* copy cut */
+  auto& icut = *_pend;
+  icut->set_leaves( cut.begin(), cut.end() );
+  icut->data() = cut.data();
+
+  if ( ipos != _pend )
+  {
+    auto it = _pend;
+    while ( it > ipos )
+    {
+      std::swap( *it, *( it - 1 ) );
+      --it;
+    }
+  }
+
+  /* update iterators */
+  _pcend++;
+  _pend++;
+}
+
+template<typename CutType, int MaxCuts>
+void cut_set<CutType, MaxCuts>::update_best( uint32_t index )
+{
+  auto* best = _pcuts[0];
+  for ( auto i = 0; i < index; ++i )
+  {
+    _pcuts[i] = _pcuts[i + 1];
+  }
+  _pcuts[index] = best;
+}
+
+template<typename CutType, int MaxCuts>
+void cut_set<CutType, MaxCuts>::limit( std::size_t size )
+{
+  if ( std::distance( _pcuts.begin(), _pend ) > static_cast<long>( size ) )
+  {
+    _pcend = _pend = _pcuts.begin() + size;
+  }
+}
+
+} /* namespace mockturtle */

--- a/include/mockturtle/utils/cuts.hpp
+++ b/include/mockturtle/utils/cuts.hpp
@@ -523,7 +523,7 @@ template<typename CutType, int MaxCuts>
 void cut_set<CutType, MaxCuts>::update_best( uint32_t index )
 {
   auto* best = _pcuts[0];
-  for ( auto i = 0; i < index; ++i )
+  for ( auto i = 0u; i < index; ++i )
   {
     _pcuts[i] = _pcuts[i + 1];
   }

--- a/include/mockturtle/utils/mixed_radix.hpp
+++ b/include/mockturtle/utils/mixed_radix.hpp
@@ -1,0 +1,99 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file mixed_radix.hpp
+  \brief Mixed radix loop
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <type_traits>
+#include <vector>
+
+namespace mockturtle
+{
+
+/*! \brief Mixed radix enumeration.
+ *
+ * The iterator pair `begin` and `end` represent a list of radixes, which are
+ * used to enumerate all combinations of indexes.
+ *
+ * For example if the radixes are \f$2, 3, 3\f$, then the callable `fn` is
+ * called on the index lists \f$0, 0, 0\f$, \f$0, 0, 1\f$, \f$0, 0, 2\f$,
+ * \f$\dots\f$, \f$1, 2, 1\f$, \f$1, 2, 2\f$.
+ *
+ * The callable `fn` expects two parameters which are an interator pair of the
+ * indexes.  If it returns a `bool`, the iteration is stopped, if the return
+ * value is `false`.
+ *
+ * \param begin Begin iterator of radixes
+ * \param end End iterator of radixes
+ * \param fn Callable
+ */
+template<typename Iterator, typename Fn>
+void foreach_mixed_radix_tuple( Iterator begin, Iterator end, Fn&& fn )
+{
+  constexpr auto is_bool_f = std::is_invocable_r_v<bool, Fn, std::vector<uint32_t>::iterator, std::vector<uint32_t>::iterator>;
+  constexpr auto is_void_f = std::is_invocable_r_v<void, Fn, std::vector<uint32_t>::iterator, std::vector<uint32_t>::iterator>;
+
+  static_assert( is_bool_f || is_void_f );
+
+  std::vector<uint32_t> positions( std::distance( begin, end ), 0u );
+
+  while ( true )
+  {
+    if constexpr ( is_bool_f )
+    {
+      if ( !fn( positions.begin(), positions.end() ) )
+      {
+        return;
+      }
+    }
+    else
+    {
+      fn( positions.begin(), positions.end() );
+    }
+
+    auto itm = end - 1;
+    auto itp = positions.end() - 1;
+    while ( itm >= begin && *itp == ( *itm - 1 ) )
+    {
+      *itp-- = 0;
+      --itm;
+    }
+
+    if ( itm < begin )
+    {
+      break;
+    }
+
+    (*itp)++;
+  }
+}
+
+}

--- a/test/algorithms/cut_enumeration.cpp
+++ b/test/algorithms/cut_enumeration.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "enumerate cuts for an AIG", "[cut_enumeration]" )
     if ( aig.is_constant( n ) )
       return;
 
-    auto const& set = cuts.cut_set( aig.node_to_index( n ) );
+    auto const& set = cuts.cuts( aig.node_to_index( n ) );
     CHECK( to_vector( set[set.size() - 1] ) == std::vector<uint32_t>{aig.node_to_index( n )} );
   } );
 
@@ -39,23 +39,23 @@ TEST_CASE( "enumerate cuts for an AIG", "[cut_enumeration]" )
   const auto i3 = aig.node_to_index( aig.get_node( f3 ) );
   const auto i4 = aig.node_to_index( aig.get_node( f4 ) );
 
-  CHECK( cuts.cut_set( i1 ).size() == 2 );
-  CHECK( cuts.cut_set( i2 ).size() == 3 );
-  CHECK( cuts.cut_set( i3 ).size() == 3 );
-  CHECK( cuts.cut_set( i4 ).size() == 5 );
+  CHECK( cuts.cuts( i1 ).size() == 2 );
+  CHECK( cuts.cuts( i2 ).size() == 3 );
+  CHECK( cuts.cuts( i3 ).size() == 3 );
+  CHECK( cuts.cuts( i4 ).size() == 5 );
 
-  CHECK( to_vector( cuts.cut_set( i1 )[0] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i1 )[0] ) == std::vector<uint32_t>{1, 2} );
 
-  CHECK( to_vector( cuts.cut_set( i2 )[0] ) == std::vector<uint32_t>{1, 3} );
-  CHECK( to_vector( cuts.cut_set( i2 )[1] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i2 )[0] ) == std::vector<uint32_t>{1, 3} );
+  CHECK( to_vector( cuts.cuts( i2 )[1] ) == std::vector<uint32_t>{1, 2} );
 
-  CHECK( to_vector( cuts.cut_set( i3 )[0] ) == std::vector<uint32_t>{2, 3} );
-  CHECK( to_vector( cuts.cut_set( i3 )[1] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i3 )[0] ) == std::vector<uint32_t>{2, 3} );
+  CHECK( to_vector( cuts.cuts( i3 )[1] ) == std::vector<uint32_t>{1, 2} );
 
-  CHECK( to_vector( cuts.cut_set( i4 )[0] ) == std::vector<uint32_t>{4, 5} );
-  CHECK( to_vector( cuts.cut_set( i4 )[1] ) == std::vector<uint32_t>{1, 2} );
-  CHECK( to_vector( cuts.cut_set( i4 )[2] ) == std::vector<uint32_t>{2, 3, 4} );
-  CHECK( to_vector( cuts.cut_set( i4 )[3] ) == std::vector<uint32_t>{1, 3, 5} );
+  CHECK( to_vector( cuts.cuts( i4 )[0] ) == std::vector<uint32_t>{4, 5} );
+  CHECK( to_vector( cuts.cuts( i4 )[1] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i4 )[2] ) == std::vector<uint32_t>{2, 3, 4} );
+  CHECK( to_vector( cuts.cuts( i4 )[3] ) == std::vector<uint32_t>{1, 3, 5} );
 }
 
 TEST_CASE( "enumerate smaller cuts for an AIG", "[cut_enumeration]" )
@@ -83,21 +83,21 @@ TEST_CASE( "enumerate smaller cuts for an AIG", "[cut_enumeration]" )
   const auto i3 = aig.node_to_index( aig.get_node( f3 ) );
   const auto i4 = aig.node_to_index( aig.get_node( f4 ) );
 
-  CHECK( cuts.cut_set( i1 ).size() == 2 );
-  CHECK( cuts.cut_set( i2 ).size() == 3 );
-  CHECK( cuts.cut_set( i3 ).size() == 3 );
-  CHECK( cuts.cut_set( i4 ).size() == 3 );
+  CHECK( cuts.cuts( i1 ).size() == 2 );
+  CHECK( cuts.cuts( i2 ).size() == 3 );
+  CHECK( cuts.cuts( i3 ).size() == 3 );
+  CHECK( cuts.cuts( i4 ).size() == 3 );
 
-  CHECK( to_vector( cuts.cut_set( i1 )[0] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i1 )[0] ) == std::vector<uint32_t>{1, 2} );
 
-  CHECK( to_vector( cuts.cut_set( i2 )[0] ) == std::vector<uint32_t>{1, 3} );
-  CHECK( to_vector( cuts.cut_set( i2 )[1] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i2 )[0] ) == std::vector<uint32_t>{1, 3} );
+  CHECK( to_vector( cuts.cuts( i2 )[1] ) == std::vector<uint32_t>{1, 2} );
 
-  CHECK( to_vector( cuts.cut_set( i3 )[0] ) == std::vector<uint32_t>{2, 3} );
-  CHECK( to_vector( cuts.cut_set( i3 )[1] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i3 )[0] ) == std::vector<uint32_t>{2, 3} );
+  CHECK( to_vector( cuts.cuts( i3 )[1] ) == std::vector<uint32_t>{1, 2} );
 
-  CHECK( to_vector( cuts.cut_set( i4 )[0] ) == std::vector<uint32_t>{4, 5} );
-  CHECK( to_vector( cuts.cut_set( i4 )[1] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cuts( i4 )[0] ) == std::vector<uint32_t>{4, 5} );
+  CHECK( to_vector( cuts.cuts( i4 )[1] ) == std::vector<uint32_t>{1, 2} );
 }
 
 TEST_CASE( "compute truth tables of AIG cuts", "[cut_enumeration]" )
@@ -119,18 +119,18 @@ TEST_CASE( "compute truth tables of AIG cuts", "[cut_enumeration]" )
   const auto i3 = aig.node_to_index( aig.get_node( f3 ) );
   const auto i4 = aig.node_to_index( aig.get_node( f4 ) );
 
-  CHECK( cuts.cut_set( i1 ).size() == 2 );
-  CHECK( cuts.cut_set( i2 ).size() == 3 );
-  CHECK( cuts.cut_set( i3 ).size() == 3 );
-  CHECK( cuts.cut_set( i4 ).size() == 5 );
+  CHECK( cuts.cuts( i1 ).size() == 2 );
+  CHECK( cuts.cuts( i2 ).size() == 3 );
+  CHECK( cuts.cuts( i3 ).size() == 3 );
+  CHECK( cuts.cuts( i4 ).size() == 5 );
 
-  CHECK( cuts.truth_table( cuts.cut_set( i1 )[0] )._bits[0] == 0x8 );
-  CHECK( cuts.truth_table( cuts.cut_set( i2 )[0] )._bits[0] == 0x2 );
-  CHECK( cuts.truth_table( cuts.cut_set( i2 )[1] )._bits[0] == 0x2 );
-  CHECK( cuts.truth_table( cuts.cut_set( i3 )[0] )._bits[0] == 0x2 );
-  CHECK( cuts.truth_table( cuts.cut_set( i3 )[1] )._bits[0] == 0x4 );
-  CHECK( cuts.truth_table( cuts.cut_set( i4 )[0] )._bits[0] == 0x1 );
-  CHECK( cuts.truth_table( cuts.cut_set( i4 )[1] )._bits[0] == 0x9 );
-  CHECK( cuts.truth_table( cuts.cut_set( i4 )[2] )._bits[0] == 0x0d );
-  CHECK( cuts.truth_table( cuts.cut_set( i4 )[3] )._bits[0] == 0x0d );
+  CHECK( cuts.truth_table( cuts.cuts( i1 )[0] )._bits[0] == 0x8 );
+  CHECK( cuts.truth_table( cuts.cuts( i2 )[0] )._bits[0] == 0x2 );
+  CHECK( cuts.truth_table( cuts.cuts( i2 )[1] )._bits[0] == 0x2 );
+  CHECK( cuts.truth_table( cuts.cuts( i3 )[0] )._bits[0] == 0x2 );
+  CHECK( cuts.truth_table( cuts.cuts( i3 )[1] )._bits[0] == 0x4 );
+  CHECK( cuts.truth_table( cuts.cuts( i4 )[0] )._bits[0] == 0x1 );
+  CHECK( cuts.truth_table( cuts.cuts( i4 )[1] )._bits[0] == 0x9 );
+  CHECK( cuts.truth_table( cuts.cuts( i4 )[2] )._bits[0] == 0x0d );
+  CHECK( cuts.truth_table( cuts.cuts( i4 )[3] )._bits[0] == 0x0d );
 }

--- a/test/algorithms/cut_enumeration.cpp
+++ b/test/algorithms/cut_enumeration.cpp
@@ -1,0 +1,136 @@
+#include <catch.hpp>
+
+#include <iostream>
+
+#include <mockturtle/algorithms/cut_enumeration.hpp>
+#include <mockturtle/networks/aig.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "enumerate cuts for an AIG", "[cut_enumeration]" )
+{
+  aig_network aig;
+
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( f1, a );
+  const auto f3 = aig.create_nand( f1, b );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  const auto cuts = cut_enumeration( aig );
+
+  const auto to_vector = []( auto const& cut ) {
+    return std::vector<uint32_t>( cut.begin(), cut.end() );
+  };
+
+  /* all unit cuts are in the back */
+  aig.foreach_node( [&]( auto n ) {
+    if ( aig.is_constant( n ) )
+      return;
+
+    auto const& set = cuts.cut_set( aig.node_to_index( n ) );
+    CHECK( to_vector( set[set.size() - 1] ) == std::vector<uint32_t>{aig.node_to_index( n )} );
+  } );
+
+  const auto i1 = aig.node_to_index( aig.get_node( f1 ) );
+  const auto i2 = aig.node_to_index( aig.get_node( f2 ) );
+  const auto i3 = aig.node_to_index( aig.get_node( f3 ) );
+  const auto i4 = aig.node_to_index( aig.get_node( f4 ) );
+
+  CHECK( cuts.cut_set( i1 ).size() == 2 );
+  CHECK( cuts.cut_set( i2 ).size() == 3 );
+  CHECK( cuts.cut_set( i3 ).size() == 3 );
+  CHECK( cuts.cut_set( i4 ).size() == 5 );
+
+  CHECK( to_vector( cuts.cut_set( i1 )[0] ) == std::vector<uint32_t>{1, 2} );
+
+  CHECK( to_vector( cuts.cut_set( i2 )[0] ) == std::vector<uint32_t>{1, 3} );
+  CHECK( to_vector( cuts.cut_set( i2 )[1] ) == std::vector<uint32_t>{1, 2} );
+
+  CHECK( to_vector( cuts.cut_set( i3 )[0] ) == std::vector<uint32_t>{2, 3} );
+  CHECK( to_vector( cuts.cut_set( i3 )[1] ) == std::vector<uint32_t>{1, 2} );
+
+  CHECK( to_vector( cuts.cut_set( i4 )[0] ) == std::vector<uint32_t>{4, 5} );
+  CHECK( to_vector( cuts.cut_set( i4 )[1] ) == std::vector<uint32_t>{1, 2} );
+  CHECK( to_vector( cuts.cut_set( i4 )[2] ) == std::vector<uint32_t>{2, 3, 4} );
+  CHECK( to_vector( cuts.cut_set( i4 )[3] ) == std::vector<uint32_t>{1, 3, 5} );
+}
+
+TEST_CASE( "enumerate smaller cuts for an AIG", "[cut_enumeration]" )
+{
+  aig_network aig;
+
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( f1, a );
+  const auto f3 = aig.create_nand( f1, b );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  cut_enumeration_params ps;
+  ps.cut_size = 2;
+  const auto cuts = cut_enumeration( aig, ps );
+
+  const auto to_vector = []( auto const& cut ) {
+    return std::vector<uint32_t>( cut.begin(), cut.end() );
+  };
+
+  const auto i1 = aig.node_to_index( aig.get_node( f1 ) );
+  const auto i2 = aig.node_to_index( aig.get_node( f2 ) );
+  const auto i3 = aig.node_to_index( aig.get_node( f3 ) );
+  const auto i4 = aig.node_to_index( aig.get_node( f4 ) );
+
+  CHECK( cuts.cut_set( i1 ).size() == 2 );
+  CHECK( cuts.cut_set( i2 ).size() == 3 );
+  CHECK( cuts.cut_set( i3 ).size() == 3 );
+  CHECK( cuts.cut_set( i4 ).size() == 3 );
+
+  CHECK( to_vector( cuts.cut_set( i1 )[0] ) == std::vector<uint32_t>{1, 2} );
+
+  CHECK( to_vector( cuts.cut_set( i2 )[0] ) == std::vector<uint32_t>{1, 3} );
+  CHECK( to_vector( cuts.cut_set( i2 )[1] ) == std::vector<uint32_t>{1, 2} );
+
+  CHECK( to_vector( cuts.cut_set( i3 )[0] ) == std::vector<uint32_t>{2, 3} );
+  CHECK( to_vector( cuts.cut_set( i3 )[1] ) == std::vector<uint32_t>{1, 2} );
+
+  CHECK( to_vector( cuts.cut_set( i4 )[0] ) == std::vector<uint32_t>{4, 5} );
+  CHECK( to_vector( cuts.cut_set( i4 )[1] ) == std::vector<uint32_t>{1, 2} );
+}
+
+TEST_CASE( "compute truth tables of AIG cuts", "[cut_enumeration]" )
+{
+  aig_network aig;
+
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( f1, a );
+  const auto f3 = aig.create_nand( f1, b );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  const auto cuts = cut_enumeration<aig_network, true>( aig );
+
+  const auto i1 = aig.node_to_index( aig.get_node( f1 ) );
+  const auto i2 = aig.node_to_index( aig.get_node( f2 ) );
+  const auto i3 = aig.node_to_index( aig.get_node( f3 ) );
+  const auto i4 = aig.node_to_index( aig.get_node( f4 ) );
+
+  CHECK( cuts.cut_set( i1 ).size() == 2 );
+  CHECK( cuts.cut_set( i2 ).size() == 3 );
+  CHECK( cuts.cut_set( i3 ).size() == 3 );
+  CHECK( cuts.cut_set( i4 ).size() == 5 );
+
+  CHECK( cuts.truth_table( cuts.cut_set( i1 )[0] )._bits[0] == 0x8 );
+  CHECK( cuts.truth_table( cuts.cut_set( i2 )[0] )._bits[0] == 0x2 );
+  CHECK( cuts.truth_table( cuts.cut_set( i2 )[1] )._bits[0] == 0x2 );
+  CHECK( cuts.truth_table( cuts.cut_set( i3 )[0] )._bits[0] == 0x2 );
+  CHECK( cuts.truth_table( cuts.cut_set( i3 )[1] )._bits[0] == 0x4 );
+  CHECK( cuts.truth_table( cuts.cut_set( i4 )[0] )._bits[0] == 0x1 );
+  CHECK( cuts.truth_table( cuts.cut_set( i4 )[1] )._bits[0] == 0x9 );
+  CHECK( cuts.truth_table( cuts.cut_set( i4 )[2] )._bits[0] == 0x0d );
+  CHECK( cuts.truth_table( cuts.cut_set( i4 )[3] )._bits[0] == 0x0d );
+}

--- a/test/utils/cuts.cpp
+++ b/test/utils/cuts.cpp
@@ -1,0 +1,190 @@
+#include <catch.hpp>
+
+#include <vector>
+
+#include <mockturtle/utils/cuts.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "create cuts", "[cuts]" )
+{
+  std::vector<uint32_t> v{1, 2, 4, 5};
+
+  cut<51> c;
+  c.set_leaves( v.begin(), v.begin() + 2 );
+
+  CHECK( c.size() == 2 );
+  CHECK( std::equal( v.begin(), v.begin() + 2, c.begin(), c.end() ) );
+  CHECK( c.signature() == 6 );
+
+  cut<51> c2;
+  c2.set_leaves( std::vector<uint32_t>{1, 2, 3, 4, 5} );
+
+  CHECK( c2.size() == 5 );
+}
+
+TEST_CASE( "access data", "[cuts]" )
+{
+  std::vector<uint32_t> v{1, 2, 4, 5};
+
+  cut<51, uint32_t> c1;
+  c1.set_leaves( v.begin(), v.end() );
+  c1.data() = 42;
+
+  CHECK( c1.size() == 4 );
+  CHECK( c1.data() == 42 );
+
+  struct S
+  {
+    uint8_t a;
+    uint8_t b;
+  };
+
+  cut<51, S> c2;
+  c2.set_leaves( v.begin(), v.end() );
+  c2->a = 12;
+  c2->b = 13;
+
+  CHECK( c2.size() == 4 );
+  CHECK( c2->a + c2->b == 25 );
+}
+
+TEST_CASE( "dominate cuts", "[cuts]" )
+{
+  std::vector<uint32_t> v{1, 2, 4, 5};
+  cut<51> c1, c2, c3;
+
+  c1.set_leaves( v.begin(), v.begin() + 2 );
+  c2.set_leaves( v.begin() + 2, v.begin() + 4 );
+  c3.set_leaves( v.begin(), v.begin() + 4 );
+
+  CHECK( c1.dominates( c1 ) );
+  CHECK( !c1.dominates( c2 ) );
+  CHECK( c1.dominates( c3 ) );
+  CHECK( !c2.dominates( c1 ) );
+  CHECK( c2.dominates( c2 ) );
+  CHECK( c2.dominates( c3 ) );
+  CHECK( !c3.dominates( c1 ) );
+  CHECK( !c3.dominates( c2 ) );
+  CHECK( c3.dominates( c3 ) );
+}
+
+TEST_CASE( "merge cuts", "[cuts]" )
+{
+  std::vector<uint32_t> v{1, 2, 3, 4};
+
+  cut<51> c1, c2, c3, r12, r13, r12t, r13f;
+
+  c1.set_leaves( v.begin(), v.begin() + 2 );
+  c2.set_leaves( v.begin() + 1, v.begin() + 3 );
+  c3.set_leaves( v.begin() + 2, v.begin() + 4 );
+
+  CHECK( c1.merge( c2, r12, 4 ) );
+  CHECK( c1.merge( c3, r13, 4 ) );
+  CHECK( c1.merge( c2, r12t, 3 ) );
+  CHECK( !c1.merge( c3, r13f, 3 ) );
+
+  CHECK( r12.size() == 3 );
+  CHECK( r13.size() == 4 );
+  CHECK( r12t.size() == 3 );
+}
+
+TEST_CASE( "create cut set", "[cuts]" )
+{
+  using cut_type = cut<10, uint32_t>;
+
+  std::vector<uint32_t> v{1, 2, 3, 4, 5};
+  cut_set<cut_type, 25> set;
+  set.add_cut( v.begin(), v.begin() + 2 ).data() = 23;
+  set.add_cut( v.begin() + 2, v.end() ).data() = 37;
+
+  std::vector<uint32_t> v2;
+  uint32_t sum{};
+  for ( auto const& c : set )
+  {
+    std::copy( c->begin(), c->end(), std::back_inserter( v2 ) );
+    sum += c->data();
+  }
+
+  CHECK( v == v2 );
+  CHECK( sum == 60 );
+}
+
+TEST_CASE( "insert a cut", "[cuts]" )
+{
+  using cut_type = cut<10>;
+
+  cut_type c1, c2, c3, c4;
+  c1.set_leaves( std::vector<uint32_t>{1, 2, 3} );
+  c2.set_leaves( std::vector<uint32_t>{1, 2, 3, 4} );
+  c3.set_leaves( std::vector<uint32_t>{1, 2} );
+  c4.set_leaves( std::vector<uint32_t>{3} );
+
+  cut_set<cut_type, 25> set;
+
+  CHECK( set.size() == 0u );
+  CHECK( !set.is_dominated( c1 ) );
+
+  set.insert( c1 );
+  CHECK( set.size() == 1u );
+  CHECK( set.is_dominated( c2 ) );
+  CHECK( !set.is_dominated( c3 ) );
+
+  set.insert( c3 );
+  CHECK( set.size() == 1u );
+
+  auto it = set.begin();
+  CHECK( ( *it )->size() == 2 );
+  CHECK( std::vector<uint32_t>( ( *it )->begin(), ( *it )->end() ) == std::vector<uint32_t>{1, 2} );
+
+  CHECK( !set.is_dominated( c4 ) );
+  set.insert( c4 );
+  CHECK( set.size() == 2u );
+  it = set.begin();
+  CHECK( std::vector<uint32_t>( ( *it )->begin(), ( *it )->end() ) == std::vector<uint32_t>{3} );
+  ++it;
+  CHECK( std::vector<uint32_t>( ( *it )->begin(), ( *it )->end() ) == std::vector<uint32_t>{1, 2} );
+}
+
+TEST_CASE( "insert a cut2", "[cuts]" )
+{
+  using cut_type = cut<10>;
+
+  cut_type c1, c2, c3, c4, c5;
+  c1.set_leaves( std::vector<uint32_t>{3, 6} );
+  c2.set_leaves( std::vector<uint32_t>{1, 2, 3} );
+  c3.set_leaves( std::vector<uint32_t>{1, 2, 3, 8} );
+  c4.set_leaves( std::vector<uint32_t>{3, 4, 5} );
+  c5.set_leaves( std::vector<uint32_t>{7, 8} );
+
+  cut_set<cut_type, 25> set;
+
+  CHECK( !set.is_dominated( c1 ) );
+  set.insert( c1 );
+  CHECK( set.size() == 1 );
+
+  CHECK( !set.is_dominated( c2 ) );
+  set.insert( c2 );
+  CHECK( set.size() == 2 );
+
+  CHECK( set.is_dominated( c3 ) );
+  CHECK( set.size() == 2 );
+}
+
+TEST_CASE( "merge three cuts", "[cuts]" )
+{
+  using cut_type = cut<10>;
+
+  cut_type c1, c2, c3, cr, ct;
+  c1.set_leaves( std::vector{2u, 4u, 6u} );
+  c2.set_leaves( std::vector{3u, 5u, 7u} );
+  c3.set_leaves( std::vector{1u, 2u, 9u} );
+
+  c1.merge( c2, cr, 10 );
+  CHECK( std::vector<uint32_t>( cr.begin(), cr.end() ) == std::vector{2u, 3u, 4u, 5u, 6u, 7u} );
+
+  //ct.set_leaves( std::vector<uint32_t>( cr.begin(), cr.end() ) );
+  ct = cr;
+  ct.merge( c3, cr, 10 );
+  CHECK( std::vector<uint32_t>( cr.begin(), cr.end() ) == std::vector{1u, 2u, 3u, 4u, 5u, 6u, 7u, 9u} );
+}

--- a/test/utils/mixed_radix.cpp
+++ b/test/utils/mixed_radix.cpp
@@ -1,0 +1,32 @@
+#include <catch.hpp>
+
+#include <mockturtle/utils/mixed_radix.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "mixed radix loop", "[mixed_radixs]" )
+{
+  uint32_t m[] = {3, 2, 4};
+  uint32_t count = 0u;
+  foreach_mixed_radix_tuple( m, m + 3, [&count]( auto, auto ) {
+    ++count;
+  });
+
+  CHECK( count == 24u );
+  count = 0u;
+
+  foreach_mixed_radix_tuple( m, m + 3, [&count]( auto, auto ) {
+    ++count;
+    return true;
+  });
+
+  CHECK( count == 24u );
+  count = 0u;
+
+  foreach_mixed_radix_tuple( m, m + 3, [&count]( auto, auto ) {
+    ++count;
+    return false;
+  });
+
+  CHECK( count == 1u );
+}


### PR DESCRIPTION
This implements a generic cut enumeration algorithm `cut_enumeration` and introduces two utility data structures called `cut` and `cut_set` which are used by this algorithm. The behaviour of the cut enumeration algorithm can be controlled by a cut type. Two implementations of cut types are implemented, which resemble the cut enumeration used by `giaCuts.c` and `giaMf.c` in ABC.
