### PR TITLE
New resynthesis method for node_resynthesis based on Akers synthesis

### DIFF
--- a/docs/node_resynthesis.rst
+++ b/docs/node_resynthesis.rst
@@ -1,6 +1,8 @@
 Node resynthesis
 ----------------
 
+**Header:** ``mockturtle/algorithms/node_resynthesis.hpp``
+
 The following example shows how to resynthesize a `k`-LUT network derived from
 an AIG using LUT mapping into an MIG using precomputed optimum networks.  In
 this case the maximum number of variables for a node function is 4.
@@ -23,4 +25,14 @@ this case the maximum number of variables for a node function is 4.
    mig_npn_resynthesis resyn;
    const auto mig = node_resynthesis<mig_network>( klut, resyn );
 
+Algorithm
+~~~~~~~~~
+
 .. doxygenfunction:: mockturtle::node_resynthesis
+
+Resynthesis functions
+~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygenclass:: mockturtle::akers_resynthesis
+
+.. doxygenclass:: mockturtle::mig_npn_resynthesis

--- a/include/mockturtle/algorithms/akers_synthesis.hpp
+++ b/include/mockturtle/algorithms/akers_synthesis.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <kitty/bit_operations.hpp>
+#include <kitty/cube.hpp>
 #include <kitty/dynamic_truth_table.hpp>
 
 #include "../traits.hpp"
@@ -22,7 +23,7 @@ namespace mockturtle
 - is_const0
 */
 
-kitty::cube operator&( kitty::cube a, kitty::cube b )
+inline kitty::cube operator&( kitty::cube a, kitty::cube b )
 {
   assert( a.num_literals() == b.num_literals() );
   kitty::cube c;
@@ -33,7 +34,7 @@ kitty::cube operator&( kitty::cube a, kitty::cube b )
   return c;
 }
 
-bool is_subset_of( kitty::cube a, kitty::cube b )
+inline bool is_subset_of( kitty::cube a, kitty::cube b )
 {
   assert( a.num_literals() == b.num_literals() );
   for ( auto h = 0; h < a.num_literals(); h++ )
@@ -46,7 +47,7 @@ bool is_subset_of( kitty::cube a, kitty::cube b )
   return true;
 }
 
-bool all_zeros( kitty::cube a )
+inline bool all_zeros( kitty::cube a )
 {
   for ( auto g = 0; g < a.num_literals(); g++ )
   {
@@ -316,7 +317,7 @@ public:
   unsigned char next_gate_id = 'z' + 0x21;
 };
 
-std::ostream& operator<<( std::ostream& os, const unitized_table& table )
+inline std::ostream& operator<<( std::ostream& os, const unitized_table& table )
 {
   os << table.columns << std::endl;
 
@@ -335,7 +336,7 @@ std::ostream& operator<<( std::ostream& os, const unitized_table& table )
   return os;
 }
 
-bool operator==( unitized_table const& table, unitized_table const& original_table )
+inline bool operator==( unitized_table const& table, unitized_table const& original_table )
 {
   if ( table.rows.size() != original_table.rows.size() )
     return false;

--- a/include/mockturtle/algorithms/node_resynthesis/akers.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/akers.hpp
@@ -1,0 +1,75 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file akers.hpp
+  \brief Resynthesis with Akers synthesis
+
+  \author Mathias Soeken
+  \author Eleonora Testa
+*/
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+#include <kitty/dynamic_truth_table.hpp>
+
+#include "../../algorithms/akers_synthesis.hpp"
+#include "../../networks/mig.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Resynthesis function based on Akers synthesis.
+ *
+ * This resynthesis function can be passed to ``node_resynthesis``.  It will
+ * call Akers synthesis on each node.
+ *
+   \verbatim embed:rst
+  
+   Example
+   
+   .. code-block:: c++
+   
+      const klut_network klut = ...;
+      akers_resynthesis resyn;
+      const auto mig = node_resynthesis<mig_network>( klut, resyn );
+   \endverbatim
+ */
+class akers_resynthesis
+{
+public:
+  template<typename LeavesIterator>
+  mig_network::signal operator()( mig_network& mig, kitty::dynamic_truth_table const& function, LeavesIterator begin, LeavesIterator end )
+  {
+    return akers_synthesis( mig, function, function, begin, end );
+  }
+};
+
+} /* namespace mockturtle */

--- a/include/mockturtle/algorithms/node_resynthesis/mig_npn.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/mig_npn.hpp
@@ -50,7 +50,25 @@
 namespace mockturtle
 {
 
-struct mig_npn_resynthesis
+/*! \brief Resynthesis function based on pre-computed size-optimum MIGs.
+ *
+ * This resynthesis function can be passed to ``node_resynthesis``.  It will
+ * produce an MIG based on pre-computed size-optimum MIGs with up to at most 4
+ * variables.  Consequently, the nodes' fan-in sizes in the input network
+ * must not exceed 4.
+ *
+   \verbatim embed:rst
+  
+   Example
+   
+   .. code-block:: c++
+   
+      const klut_network klut = ...;
+      mig_npn_resynthesis resyn;
+      const auto mig = node_resynthesis<mig_network>( klut, resyn );
+   \endverbatim
+ */
+class mig_npn_resynthesis
 {
 public:
   mig_npn_resynthesis()

--- a/test/algorithms/node_resynthesis.cpp
+++ b/test/algorithms/node_resynthesis.cpp
@@ -1,6 +1,7 @@
 #include <catch.hpp>
 
 #include <mockturtle/algorithms/node_resynthesis.hpp>
+#include <mockturtle/algorithms/node_resynthesis/akers.hpp>
 #include <mockturtle/algorithms/node_resynthesis/mig_npn.hpp>
 #include <mockturtle/networks/klut.hpp>
 #include <mockturtle/networks/mig.hpp>
@@ -23,6 +24,37 @@ TEST_CASE( "Node resynthesis with optimum networks", "[node_resynthesis]" )
   klut.create_po( f );
 
   mig_npn_resynthesis resyn;
+  const auto mig = node_resynthesis<mig_network>( klut, resyn );
+
+  CHECK( mig.size() == 5 );
+  CHECK( mig.num_pis() == 3 );
+  CHECK( mig.num_pos() == 1 );
+  CHECK( mig.num_gates() == 1 );
+
+  mig.foreach_po( [&]( auto const& f ) {
+    CHECK( !mig.is_complemented( f ) );
+  } );
+
+  mig.foreach_node( [&]( auto n ) {
+    mig.foreach_fanin( n, [&]( auto const& f ) {
+      CHECK( !mig.is_complemented( f ) );
+    } );
+  } );
+}
+
+TEST_CASE( "Node resynthesis with Akers resynthesis", "[node_resynthesis]" )
+{
+  kitty::dynamic_truth_table maj( 3 );
+  kitty::create_majority( maj );
+
+  klut_network klut;
+  const auto a = klut.create_pi();
+  const auto b = klut.create_pi();
+  const auto c = klut.create_pi();
+  const auto f = klut.create_node( {a, b, c}, maj );
+  klut.create_po( f );
+
+  akers_resynthesis resyn;
   const auto mig = node_resynthesis<mig_network>( klut, resyn );
 
   CHECK( mig.size() == 5 );


### PR DESCRIPTION
This PR adds another resynthesis method `akers_resynthesis` that can be used with `node_resynthesis`.