### PR TITLE
parents_view

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,11 +21,12 @@ v0.1 (not yet released)
   `#24 <https://github.com/lsils/mockturtle/pull/24>`_
   `#25 <https://github.com/lsils/mockturtle/pull/25>`_
 
-* Views: `topo_view`, `immutable_view`, `mapping_view`, `depth_view`, `cut_view`
+* Views: `topo_view`, `immutable_view`, `mapping_view`, `depth_view`, `cut_view`, `parents_view`
   `#3 <https://github.com/lsils/mockturtle/pull/3>`_
   `#7 <https://github.com/lsils/mockturtle/pull/7>`_
   `#16 <https://github.com/lsils/mockturtle/pull/16>`_
   `#20 <https://github.com/lsils/mockturtle/pull/20>`_
+  `#27 <https://github.com/lsils/mockturtle/pull/27>`_
 
 * I/O: `aiger_reader`, `bench_reader`, `write_bench`
   `#6 <https://github.com/lsils/mockturtle/pull/6>`_

--- a/include/mockturtle/interface.hpp
+++ b/include/mockturtle/interface.hpp
@@ -58,7 +58,7 @@ public:
   /*! \brief Type representing a signal.
    *
    * A ``signal`` can be seen as a pointer to a node, or an outgoing edge of
-   * a node towards its parants.  Depending on the kind of logic network, it
+   * a node towards its parents.  Depending on the kind of logic network, it
    * may carry additional information such as a complement attribute.
    */
   struct signal

--- a/include/mockturtle/views/depth_view.hpp
+++ b/include/mockturtle/views/depth_view.hpp
@@ -44,10 +44,10 @@ namespace mockturtle
 
 /*! \brief Implements `depth` and `get_level` methods for networks.
  *
- * This method computes the level of each node and thefore also the depth of the
- * network.  It implements the network interface methods `get_level` and
- * `depth`.  The levels are computed at construction and can be recomputed by
- * calling the `update` method.
+ * This method computes the level of each node and also the depth of
+ * the network.  It implements the network interface methods
+ * `get_level` and `depth`.  The levels are computed at construction
+ * and can be recomputed by calling the `update` method.
  *
  * **Required network functions:**
  * - `size`
@@ -74,7 +74,7 @@ namespace mockturtle
       std::cout << "Depth: " << aig_depth.depth() << "\n";
    \endverbatim
  */
-template<typename Ntk, bool has_depth_interface = has_depth_v<Ntk>&& has_level_v<Ntk>>
+template<typename Ntk, bool has_depth_interface = has_depth_v<Ntk> && has_level_v<Ntk>>
 class depth_view
 {
 };

--- a/include/mockturtle/views/depth_view.hpp
+++ b/include/mockturtle/views/depth_view.hpp
@@ -44,7 +44,7 @@ namespace mockturtle
 
 /*! \brief Implements `depth` and `get_level` methods for networks.
  *
- * This method computes the level of each node and also the depth of
+ * This view computes the level of each node and also the depth of
  * the network.  It implements the network interface methods
  * `get_level` and `depth`.  The levels are computed at construction
  * and can be recomputed by calling the `update` method.

--- a/include/mockturtle/views/parents_view.hpp
+++ b/include/mockturtle/views/parents_view.hpp
@@ -1,0 +1,121 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file parents_view.hpp
+  \brief Implements parents for a network
+
+  \author Heinz Riener
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "../traits.hpp"
+#include "../utils/node_map.hpp"
+#include "immutable_view.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Implements `foreach_parent` methods for networks.
+ *
+ * This method computes the parents of each node and of the network.
+ * It implements the network interface method `foreach_parent`.  The
+ * parents are computed at construction and can be recomputed by
+ * calling the `update` method.
+ *
+ * **Required network functions:**
+ * - `foreach_node`
+ * - `foreach_fanin`
+ *
+ */
+template<typename Ntk, bool has_parents_interface = has_foreach_parent_v<Ntk>>
+class parents_view
+{
+};
+
+template<typename Ntk>
+class parents_view<Ntk, true> : public Ntk
+{
+public:
+  parents_view( Ntk const& ntk ) : Ntk( ntk )
+  {
+  }
+};
+
+template<typename Ntk>
+class parents_view<Ntk, false> : public Ntk
+{
+public:
+  using storage = typename Ntk::storage;
+  using node    = typename Ntk::node;
+  using signal  = typename Ntk::signal;
+
+  parents_view( Ntk const& ntk ) : Ntk( ntk ), _parents( ntk )
+  {
+    static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+    static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+    static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
+
+    update();
+  }
+
+  template<typename Fn>
+  void foreach_parent( node const& n, Fn&& fn ) const
+  {
+    detail::foreach_element( _parents[n].begin(), _parents[n].end(), fn );
+  }
+
+  void update()
+  {
+    compute_parents();
+  }
+
+private:
+  void compute_parents()
+  {
+    _parents.reset();
+
+    this->foreach_node( [&]( auto const& n ){
+        this->foreach_fanin( n, [&]( auto const& c ){
+            auto& parents = _parents[ c ];
+            if ( std::find( parents.begin(), parents.end(), n ) == parents.end() )
+            {
+              parents.push_back( n );
+            }
+          });
+      });
+  }
+
+  node_map<std::vector<node>, Ntk> _parents;
+};
+
+template<class T>
+parents_view(T const&) -> parents_view<T>;
+
+} // namespace mockturtle

--- a/include/mockturtle/views/parents_view.hpp
+++ b/include/mockturtle/views/parents_view.hpp
@@ -44,7 +44,7 @@ namespace mockturtle
 
 /*! \brief Implements `foreach_parent` methods for networks.
  *
- * This method computes the parents of each node and of the network.
+ * This view computes the parents of each node of the network.
  * It implements the network interface method `foreach_parent`.  The
  * parents are computed at construction and can be recomputed by
  * calling the `update` method.

--- a/test/views/parents_view.cpp
+++ b/test/views/parents_view.cpp
@@ -1,0 +1,79 @@
+#include <catch.hpp>
+
+#include <set>
+
+#include <mockturtle/traits.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/mig.hpp>
+#include <mockturtle/networks/klut.hpp>
+#include <mockturtle/views/parents_view.hpp>
+
+using namespace mockturtle;
+
+template<typename Ntk>
+void test_parents_view()
+{
+  CHECK( is_network_type_v<Ntk> );
+  CHECK( !has_foreach_parent_v<Ntk> );
+
+  using parent_ntk = parents_view<Ntk>;
+
+  CHECK( is_network_type_v<parent_ntk> );
+  CHECK( has_foreach_parent_v<parent_ntk> );
+
+  using parent_parent_ntk = parents_view<parent_ntk>;
+
+  CHECK( is_network_type_v<parent_parent_ntk> );
+  CHECK( has_foreach_parent_v<parent_parent_ntk> );
+};
+
+TEST_CASE( "create different parentsw views", "[parents_view]" )
+{
+  test_parents_view<aig_network>();
+  test_parents_view<mig_network>();
+  test_parents_view<klut_network>();
+}
+
+TEST_CASE( "compute parents for AIG", "[parents_view]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( a, f1 );
+  const auto f3 = aig.create_nand( b, f1 );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  parents_view parent_aig{aig};
+
+  {
+    std::set<node<aig_network>> nodes;
+    parent_aig.foreach_parent( aig.get_node( a ), [&]( const auto& p ){ nodes.insert( p ); } );
+    CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f1 ), aig.get_node( f2 ) } );
+  }
+
+  {
+    std::set<node<aig_network>> nodes;
+    parent_aig.foreach_parent( aig.get_node( b ), [&]( const auto& p ){ nodes.insert( p ); } );
+    CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f1 ), aig.get_node( f3 ) } );
+  }
+
+  {
+    std::set<node<aig_network>> nodes;
+    parent_aig.foreach_parent( aig.get_node( f1 ), [&]( const auto& p ){ nodes.insert( p ); } );
+    CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f2 ), aig.get_node( f3 ) } );
+  }
+
+  {
+    std::set<node<aig_network>> nodes;
+    parent_aig.foreach_parent( aig.get_node( f2 ), [&]( const auto& p ){ nodes.insert( p ); } );
+    CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f4 ) } );
+  }
+
+  {
+    std::set<node<aig_network>> nodes;
+    parent_aig.foreach_parent( aig.get_node( f3 ), [&]( const auto& p ){ nodes.insert( p ); } );
+    CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f4 ) } );
+  }
+}


### PR DESCRIPTION
`parent_view` implements the `foreach_parent` method for a network:
- The view computes the parents of each node of the network.  It implements the network interface method `foreach_parent`.  The parents are computed at construction and can be recomputed by calling the `update` method.
