### PR TITLE
Simulate all node values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ v0.1 (not yet released)
   `#1 <https://github.com/lsils/mockturtle/pull/1>`_
   `#4 <https://github.com/lsils/mockturtle/pull/4>`_
 
-* Algorithms: `cut_enumeration`, `lut_mapping`, `akers_synthesis`, `collapse_mapped_network`, `mig_algebraic_depth_rewriting`, `cleanup_dangling`, `node_resynthesis`, `reconv_cut`, `simulate`
+* Algorithms: `cut_enumeration`, `lut_mapping`, `akers_synthesis`, `collapse_mapped_network`, `mig_algebraic_depth_rewriting`, `cleanup_dangling`, `node_resynthesis`, `reconv_cut`, `simulate`, `simulate_nodes`
   `#2 <https://github.com/lsils/mockturtle/pull/2>`_
   `#7 <https://github.com/lsils/mockturtle/pull/7>`_
   `#9 <https://github.com/lsils/mockturtle/pull/9>`_
@@ -20,6 +20,7 @@ v0.1 (not yet released)
   `#17 <https://github.com/lsils/mockturtle/pull/17>`_
   `#24 <https://github.com/lsils/mockturtle/pull/24>`_
   `#25 <https://github.com/lsils/mockturtle/pull/25>`_
+  `#28 <https://github.com/lsils/mockturtle/pull/28>`_
 
 * Views: `topo_view`, `immutable_view`, `mapping_view`, `depth_view`, `cut_view`, `parents_view`
   `#3 <https://github.com/lsils/mockturtle/pull/3>`_

--- a/docs/simulation.rst
+++ b/docs/simulation.rst
@@ -31,13 +31,28 @@ Complete simulation with truth tables.
    aig_network aig = ...;
 
    default_simulator<kitty::dynamic_truth_table> sim( aig.num_pis() );
-   const auto tts = simulate<>( aig, sim );
+   const auto tts = simulate<kitty::dynamic_truth_table>( aig, sim );
 
    ntk.foreach_po( [&]( auto const&, auto i ) {
      std::cout << fmt::format( "truth table of output {} is {}\n", i, kitty::to_hex( tts[i] ) );
    } );
 
+Simulate values for all nodes.
+
+.. code-block:: c++
+
+   aig_network aig = ...;
+
+   default_simulator<kitty::dynamic_truth_table> sim( aig.num_pis() );
+   const auto tts = simulate_nodes<kitty::dynamic_truth_table>( aig, sim );
+
+   ntk.foreach_node( [&]( auto const& n, auto i ) {
+     std::cout << fmt::format( "truth table of node {} is {}\n", i, tts[n] );
+   } );
+
 .. doxygenfunction:: mockturtle::simulate
+  
+.. doxygenfunction:: mockturtle::simulate_nodes
 
 Simulators
 ~~~~~~~~~~


### PR DESCRIPTION
This PR implements an algorithm `simulate_nodes` which simulates all node values. The algorithm `simulate` (which returns simulation values for all output signals) now uses the `simulate_nodes` function.