### PR TITLE
Fanout_view.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,7 +31,7 @@ v0.1 (not yet released)
     - View for mapped networks (`mapping_view`) `#7 <https://github.com/lsils/mockturtle/pull/7>`_
     - View compute depth and node levels (`depth_view`) `#16 <https://github.com/lsils/mockturtle/pull/16>`_
     - Cut view (`cut_view`) `#20 <https://github.com/lsils/mockturtle/pull/20>`_
-    - Access parents from a node (`parents_view`) `#27 <https://github.com/lsils/mockturtle/pull/27>`_
+    - Access fanout of a node (`fanout_view`) `#27 <https://github.com/lsils/mockturtle/pull/27>`_ `#49 <https://github.com/lsils/mockturtle/pull/49>`_
     - Compute MFFC of a node (`mffc_view`) `#34 <https://github.com/lsils/mockturtle/pull/34>`_
     - Compute window around a node (`window_view`) `#41 <https://github.com/lsils/mockturtle/pull/41>`_
 * I/O:

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -58,6 +58,14 @@ algorithm.  Several views are implemented in mockturtle.
 .. doxygenclass:: mockturtle::immutable_view
    :members:
 
+`fanout_view`: Compute fanout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Header:** ``mockturtle/views/fanout_view.hpp``
+
+.. doxygenclass:: mockturtle::fanout_view
+   :members:
+
 `window_view`: Network view on a window
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/mockturtle/generators/modular_arithmetic.hpp
+++ b/include/mockturtle/generators/modular_arithmetic.hpp
@@ -206,10 +206,10 @@ inline void montgomery_multiplication_inplace( Ntk& ntk, std::vector<signal<Ntk>
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
 
   const auto n = ( 1 << a.size() ) - c;
-  const auto nbits = static_cast<int64_t>( std::ceil( std::log2( n ) ) );
+  const auto nbits = static_cast<uint64_t>( std::ceil( std::log2( n ) ) );
 
   auto [r, np] = detail::compute_montgomery_parameters<int64_t>( n );
-  const auto rbits = static_cast<int64_t>( std::log2( r ) );
+  const auto rbits = static_cast<uint64_t>( std::log2( r ) );
 
   const auto f2 = constant_word( ntk, ( r * r ) % n, rbits );
 

--- a/include/mockturtle/interface.hpp
+++ b/include/mockturtle/interface.hpp
@@ -416,9 +416,9 @@ public:
   template<typename Fn>
   void foreach_fanin( node const& n, Fn&& fn ) const;
 
-  /*! \brief Calls ``fn`` on every parent of a node.
+  /*! \brief Calls ``fn`` on every fanout of a node.
    *
-   * The method gives no guarantee on the order of the parents.  The parameter
+   * The method gives no guarantee on the order of the fanout.  The parameter
    * ``fn`` is any callable that must have one of the following signatures.
    * - ``void(node const&)``
    * - ``void(node const&, uint32_t)``
@@ -430,7 +430,7 @@ public:
    * then it can interrupt the iteration by returning ``false``.
    */
   template<typename Fn>
-  void foreach_parent( node const& n, Fn&& fn ) const;
+  void foreach_fanout( node const& n, Fn&& fn ) const;
 #pragma endregion
 
 #pragma region Simulate values

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -367,6 +367,41 @@ public:
     // reset fan-in of old node
     _storage->nodes[old_node].data[0].h1 = 0;
   }
+
+  void substitute_node( std::vector<node> const& parents, node const& old_node, signal const& new_signal )
+  {
+    for ( auto& p : parents )
+    {
+      auto& n = _storage->nodes[ p ];
+      for ( auto& child : n.children )
+      {
+        if ( child.index == old_node )
+        {
+          child.index = new_signal.index;
+          child.weight ^= new_signal.complement;
+
+          // increment fan-in of new node
+          _storage->nodes[new_signal.index].data[0].h1++;
+        }
+      }
+    }
+
+    /* check outputs */
+    for ( auto& output : _storage->outputs )
+    {
+      if ( output.index == old_node )
+      {
+        output.index = new_signal.index;
+        output.weight ^= new_signal.complement;
+
+        // increment fan-in of new node
+        _storage->nodes[new_signal.index].data[0].h1++;
+      }
+    }
+
+    // reset fan-in of old node
+    _storage->nodes[old_node].data[0].h1 = 0;
+  }
 #pragma endregion
 
 #pragma region Structural properties

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -770,19 +770,19 @@ template<class Ntk>
 inline constexpr bool has_foreach_fanin_v = has_foreach_fanin<Ntk>::value;
 #pragma endregion
 
-#pragma region has_foreach_parent
+#pragma region has_foreach_fanout
 template<class Ntk, class = void>
-struct has_foreach_parent : std::false_type
+struct has_foreach_fanout : std::false_type
 {
 };
 
 template<class Ntk>
-struct has_foreach_parent<Ntk, std::void_t<decltype( std::declval<Ntk>().foreach_parent( std::declval<node<Ntk>>(), std::declval<void( node<Ntk>, uint32_t )>() ) )>> : std::true_type
+struct has_foreach_fanout<Ntk, std::void_t<decltype( std::declval<Ntk>().foreach_fanout( std::declval<node<Ntk>>(), std::declval<void( node<Ntk>, uint32_t )>() ) )>> : std::true_type
 {
 };
 
 template<class Ntk>
-inline constexpr bool has_foreach_parent_v = has_foreach_parent<Ntk>::value;
+inline constexpr bool has_foreach_fanout_v = has_foreach_fanout<Ntk>::value;
 #pragma endregion
 
 #pragma region has_compute

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -151,6 +151,21 @@ public:
     data.resize( ntk.size(), init_value );
   }
 
+  /*! \brief Resizes the map.
+   *
+   * This function should be called, if the node_map's size needs to
+   * be changed without clearing its data.
+   *
+   * \param init_value Initialization value after resize
+   */
+  void resize(  T const& init_value = {} )
+  {
+    if ( ntk.size() > data.size() )
+    {
+      data.resize( ntk.size(), init_value );
+    }
+  }
+
 private:
   Ntk const& ntk;
   std::vector<T> data;

--- a/include/mockturtle/views/parents_view.hpp
+++ b/include/mockturtle/views/parents_view.hpp
@@ -96,6 +96,21 @@ public:
     compute_parents();
   }
 
+  void parents( node const& n ) const
+  {
+    return _parents[ n ];
+  }
+
+  void set_parents( node const& n, std::vector<node> const& parents )
+  {
+    _parents[ n ] = parents;
+  }
+
+  void add_parent( node const& n, node const& p )
+  {
+    _parents[ n ].push_back( p );
+  }
+
 private:
   void compute_parents()
   {

--- a/include/mockturtle/views/window_view.hpp
+++ b/include/mockturtle/views/window_view.hpp
@@ -41,7 +41,7 @@
 
 #include "../traits.hpp"
 #include "../networks/detail/foreach.hpp"
-#include "../views/parents_view.hpp"
+#include "../views/fanout_view.hpp"
 #include "immutable_view.hpp"
 
 namespace mockturtle
@@ -69,7 +69,7 @@ public:
     static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
     static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
     static_assert( has_make_signal_v<Ntk>, "Ntk does not implement the make_signal method" );
-    static_assert( has_foreach_parent_v<Ntk>, "Ntk does not implement the foreach_parent method" );
+    static_assert( has_foreach_fanout_v<Ntk>, "Ntk does not implement the foreach_fanout method" );
 
     /* constants */
     add_node( this->get_node( this->get_constant( false ) ) );
@@ -191,7 +191,7 @@ private:
       new_nodes.clear();
       for ( const auto& n : _nodes )
       {
-        ntk.foreach_parent( n, [&]( auto const& p ){
+        ntk.foreach_fanout( n, [&]( auto const& p ){
             /* skip node if it is already in _nodes */
             if ( std::find( _nodes.begin(), _nodes.end(), p ) != _nodes.end() ) return;
 
@@ -245,7 +245,7 @@ private:
         continue;
       }
 
-      ntk.foreach_parent( n, [&]( auto const& p ){
+      ntk.foreach_fanout( n, [&]( auto const& p ){
           if ( std::find( _nodes.begin(), _nodes.end(), p ) == _nodes.end() )
           {
             auto s = this->make_signal( n );

--- a/test/views/fanout_view.cpp
+++ b/test/views/fanout_view.cpp
@@ -6,35 +6,35 @@
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/mig.hpp>
 #include <mockturtle/networks/klut.hpp>
-#include <mockturtle/views/parents_view.hpp>
+#include <mockturtle/views/fanout_view.hpp>
 
 using namespace mockturtle;
 
 template<typename Ntk>
-void test_parents_view()
+void test_fanout_view()
 {
   CHECK( is_network_type_v<Ntk> );
-  CHECK( !has_foreach_parent_v<Ntk> );
+  CHECK( !has_foreach_fanout_v<Ntk> );
 
-  using parent_ntk = parents_view<Ntk>;
+  using fanout_ntk = fanout_view<Ntk>;
 
-  CHECK( is_network_type_v<parent_ntk> );
-  CHECK( has_foreach_parent_v<parent_ntk> );
+  CHECK( is_network_type_v<fanout_ntk> );
+  CHECK( has_foreach_fanout_v<fanout_ntk> );
 
-  using parent_parent_ntk = parents_view<parent_ntk>;
+  using fanout_fanout_ntk = fanout_view<fanout_ntk>;
 
-  CHECK( is_network_type_v<parent_parent_ntk> );
-  CHECK( has_foreach_parent_v<parent_parent_ntk> );
+  CHECK( is_network_type_v<fanout_fanout_ntk> );
+  CHECK( has_foreach_fanout_v<fanout_fanout_ntk> );
 };
 
-TEST_CASE( "create different parentsw views", "[parents_view]" )
+TEST_CASE( "create different fanoutw views", "[fanout_view]" )
 {
-  test_parents_view<aig_network>();
-  test_parents_view<mig_network>();
-  test_parents_view<klut_network>();
+  test_fanout_view<aig_network>();
+  test_fanout_view<mig_network>();
+  test_fanout_view<klut_network>();
 }
 
-TEST_CASE( "compute parents for AIG", "[parents_view]" )
+TEST_CASE( "compute fanout for AIG", "[fanout_view]" )
 {
   aig_network aig;
   const auto a = aig.create_pi();
@@ -45,35 +45,35 @@ TEST_CASE( "compute parents for AIG", "[parents_view]" )
   const auto f4 = aig.create_nand( f2, f3 );
   aig.create_po( f4 );
 
-  parents_view parent_aig{aig};
+  fanout_view fanout_aig{aig};
 
   {
     std::set<node<aig_network>> nodes;
-    parent_aig.foreach_parent( aig.get_node( a ), [&]( const auto& p ){ nodes.insert( p ); } );
+    fanout_aig.foreach_fanout( aig.get_node( a ), [&]( const auto& p ){ nodes.insert( p ); } );
     CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f1 ), aig.get_node( f2 ) } );
   }
 
   {
     std::set<node<aig_network>> nodes;
-    parent_aig.foreach_parent( aig.get_node( b ), [&]( const auto& p ){ nodes.insert( p ); } );
+    fanout_aig.foreach_fanout( aig.get_node( b ), [&]( const auto& p ){ nodes.insert( p ); } );
     CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f1 ), aig.get_node( f3 ) } );
   }
 
   {
     std::set<node<aig_network>> nodes;
-    parent_aig.foreach_parent( aig.get_node( f1 ), [&]( const auto& p ){ nodes.insert( p ); } );
+    fanout_aig.foreach_fanout( aig.get_node( f1 ), [&]( const auto& p ){ nodes.insert( p ); } );
     CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f2 ), aig.get_node( f3 ) } );
   }
 
   {
     std::set<node<aig_network>> nodes;
-    parent_aig.foreach_parent( aig.get_node( f2 ), [&]( const auto& p ){ nodes.insert( p ); } );
+    fanout_aig.foreach_fanout( aig.get_node( f2 ), [&]( const auto& p ){ nodes.insert( p ); } );
     CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f4 ) } );
   }
 
   {
     std::set<node<aig_network>> nodes;
-    parent_aig.foreach_parent( aig.get_node( f3 ), [&]( const auto& p ){ nodes.insert( p ); } );
+    fanout_aig.foreach_fanout( aig.get_node( f3 ), [&]( const auto& p ){ nodes.insert( p ); } );
     CHECK( nodes == std::set<node<aig_network>>{ aig.get_node( f4 ) } );
   }
 }

--- a/test/views/window_view.cpp
+++ b/test/views/window_view.cpp
@@ -2,7 +2,7 @@
 
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/traits.hpp>
-#include <mockturtle/views/parents_view.hpp>
+#include <mockturtle/views/fanout_view.hpp>
 #include <mockturtle/views/window_view.hpp>
 #include <mockturtle/algorithms/reconv_cut.hpp>
 
@@ -24,12 +24,12 @@ TEST_CASE( "create window view on AIG", "[window_view]" )
   CHECK( aig.num_pos() == 1 );
   CHECK( aig.num_gates() == 4 );
 
-  parents_view<aig_network> parents_ntk( aig );
-  parents_ntk.clear_visited();
+  fanout_view<aig_network> fanout_ntk( aig );
+  fanout_ntk.clear_visited();
 
   const auto pivot1 = aig.get_node( f3 );
   auto const& leaves1 = reconv_cut( reconv_cut_params{4} )( aig, { pivot1 } );
-  window_view<parents_view<aig_network>> win1( parents_ntk, leaves1, { pivot1 }, false );
+  window_view<fanout_view<aig_network>> win1( fanout_ntk, leaves1, { pivot1 }, false );
 
   CHECK( is_network_type_v<decltype( win1 )> );
   CHECK( win1.size() == 5 );
@@ -38,14 +38,14 @@ TEST_CASE( "create window view on AIG", "[window_view]" )
 
   const auto pivot2 = aig.get_node( f2 );
   auto const& leaves2 = reconv_cut( reconv_cut_params{4} )( aig, { pivot2 } );
-  window_view<parents_view<aig_network>> win2( parents_ntk, leaves2, { pivot2 }, false );
+  window_view<fanout_view<aig_network>> win2( fanout_ntk, leaves2, { pivot2 }, false );
   CHECK( win2.size() == 5 );
   CHECK( win2.num_pis() == 2 );
   CHECK( win2.num_pos() == 3 ); // a, f1, f3
 
   const auto pivot3 = aig.get_node( f1 );
   auto const& leaves3 = reconv_cut( reconv_cut_params{4} )( aig, { pivot3 } );
-  window_view<parents_view<aig_network>> win3( parents_ntk, leaves3, { pivot3 }, true );
+  window_view<fanout_view<aig_network>> win3( fanout_ntk, leaves3, { pivot3 }, true );
   CHECK( win3.size() == 7 );
   CHECK( win3.num_pis() == 2 );
   CHECK( win3.num_pos() == 1 ); // f4


### PR DESCRIPTION
This PR renames `parents_view` to `fanout_view`, makes minor changes on `node_map`, and provides a more efficient implementation of `substitute_node` that avoids iterating over all nodes if the parents of the node to be substituted are known (e.g., when `fanout_view` is used).