### PR TITLE
node_map.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -55,6 +55,6 @@ v0.1 (not yet released)
 * Utility data structures: `truth_table_cache`, `cut`, `cut_set`, `node_map`, `progress_bar`, `stopwatch`
     - Truth table cache (`truth_table_cache`) `#1 <https://github.com/lsils/mockturtle/pull/1>`_
     - Cuts (`cut` and `cut_set`) `#2 <https://github.com/lsils/mockturtle/pull/2>`_
-    - Container to associate values to nodes (`node_map`) `#13 <https://github.com/lsils/mockturtle/pull/13>`_
+    - Container to associate values to nodes (`node_map`) `#13 <https://github.com/lsils/mockturtle/pull/13>`_ `#76 <https://github.com/lsils/mockturtle/pull/76>`_
     - Progress bar (`progress_bar`) `#30 <https://github.com/lsils/mockturtle/pull/30>`_
     - Tracking time of computations (`stopwatch`, `call_with_stopwatch`, `make_with_stopwatch`) `#35 <https://github.com/lsils/mockturtle/pull/35>`_

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -33,7 +33,6 @@
 #pragma once
 
 #include <cstdint>
-#include <unordered_map>
 #include <vector>
 
 #include "../traits.hpp"
@@ -225,81 +224,6 @@ node_map<SimulationType, Ntk> simulate_nodes( Ntk const& ntk, Simulator const& s
 
   return node_to_value;
 }
-
-template<class T, class Ntk>
-class unordered_node_map
-{
-public:
-  using node = typename Ntk::node;
-  using signal = typename Ntk::signal;
-  using reference = T&;
-  using const_reference = const T&;
-
-public:
-  explicit unordered_node_map( Ntk const& ntk )
-      : ntk( ntk )
-  {
-  }
-
-  /*! \brief Check if a key is already defined. */
-  bool has( node const& n ) const
-  {
-    return data.find( n ) != data.end();
-  }
-
-  /*! \brief Mutable access to value by node. */
-  reference operator[]( node const& n )
-  {
-    return data[ntk.node_to_index( n )];
-  }
-
-  /*! \brief Constant access to value by node. */
-  const_reference operator[]( node const& n ) const
-  {
-    assert( !has( n ) && "index out of bounds" );
-    return data[ntk.node_to_index( n )];
-  }
-
-  /*! \brief Mutable access to value by signal.
-   *
-   * This method derives the node from the signal.  If the node and signal type
-   * are the same in the network implementation, this method is disabled.
-   */
-  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
-  reference operator[]( signal const& f )
-  {
-    return data[ntk.node_to_index( ntk.get_node( f ) )];
-  }
-
-  /*! \brief Constant access to value by signal.
-   *
-   * This method derives the node from the signal.  If the node and signal type
-   * are the same in the network implementation, this method is disabled.
-   */
-  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
-  const_reference operator[]( signal const& f ) const
-  {
-    assert( !has( ntk.get_node( f ) ) && "index out of bounds" );
-    return data[ntk.node_to_index( ntk.get_node( f ) )];
-  }
-
-  /*! \brief Resets the size of the map.
-   *
-   * This function should be called, if the network changed in size.  Then, the
-   * map is cleared, and resized to the current network's size.  All values are
-   * initialized with `init_value`.
-   *
-   * \param init_value Initialization value after resize
-   */
-  void reset()
-  {
-    data.clear();
-  }
-
-protected:
-  Ntk const& ntk;
-  std::unordered_map<node, T> data;
-};
 
 /*! \brief Simulates a network with a generic simulator.
  *

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -25,9 +25,10 @@
 
 /*!
   \file node_map.hpp
-  \brief A map interface indexed by network nodes
+  \brief Map indexed by network nodes
 
   \author Mathias Soeken
+  \author Heinz Riener
 */
 
 #pragma once
@@ -90,8 +91,8 @@ template<class T, class Ntk>
 class node_map<T, Ntk, std::vector<T>>
 {
 public:
-  using node = node<Ntk>;
-  using signal = signal<Ntk>;
+  using node = typename Ntk::node;
+  using signal = typename Ntk::signal;
 
   using reference = typename std::vector<T>::reference;
   using const_reference = typename std::vector<T>::const_reference;
@@ -139,7 +140,7 @@ public:
    * This method derives the node from the signal.  If the node and signal type
    * are the same in the network implementation, this method is disabled.
    */
-  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<signal<_Ntk>, node<_Ntk>>>>
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   reference operator[]( signal const& f )
   {
     assert( ntk.node_to_index( ntk.get_node( f ) ) < data->size() && "index out of bounds" );
@@ -151,7 +152,7 @@ public:
    * This method derives the node from the signal.  If the node and signal type
    * are the same in the network implementation, this method is disabled.
    */
-  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<signal<_Ntk>, node<_Ntk>>>>
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   const_reference operator[]( signal const& f ) const
   {
     assert( ntk.node_to_index( ntk.get_node( f ) ) < data->size() && "index out of bounds" );

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -90,6 +90,9 @@ template<class T, class Ntk>
 class node_map<T, Ntk, std::vector<T>>
 {
 public:
+  using node = node<Ntk>;
+  using signal = signal<Ntk>;
+
   using reference = typename std::vector<T>::reference;
   using const_reference = typename std::vector<T>::const_reference;
 public:
@@ -119,13 +122,13 @@ public:
   }
 
   /*! \brief Mutable access to value by node. */
-  reference operator[]( node<Ntk> const& n )
+  reference operator[]( node const& n )
   {
     return (*data)[ntk.node_to_index( n )];
   }
 
   /*! \brief Constant access to value by node. */
-  const_reference operator[]( node<Ntk> const& n ) const
+  const_reference operator[]( node const& n ) const
   {
     assert( ntk.node_to_index( n ) < data->size() && "index out of bounds" );
     return (*data)[ntk.node_to_index( n )];
@@ -137,7 +140,7 @@ public:
    * are the same in the network implementation, this method is disabled.
    */
   template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<signal<_Ntk>, node<_Ntk>>>>
-  reference operator[]( signal<Ntk> const& f )
+  reference operator[]( signal const& f )
   {
     assert( ntk.node_to_index( ntk.get_node( f ) ) < data->size() && "index out of bounds" );
     return (*data)[ntk.node_to_index( ntk.get_node( f ) )];
@@ -149,7 +152,7 @@ public:
    * are the same in the network implementation, this method is disabled.
    */
   template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<signal<_Ntk>, node<_Ntk>>>>
-  const_reference operator[]( signal<Ntk> const& f ) const
+  const_reference operator[]( signal const& f ) const
   {
     assert( ntk.node_to_index( ntk.get_node( f ) ) < data->size() && "index out of bounds" );
     return (*data)[ntk.node_to_index( ntk.get_node( f ) )];
@@ -192,7 +195,7 @@ private:
 /*! \brief Unordered node map
  *
  * This implementation of the container is initialized with a network.
- * The map entries are constructed on-the-fly.  The container
+ * The map entries are constructed on the fly.  The container
  * can be accessed via ndoes, or indirectly via signals, from which
  * the corresponding node is derived.
  *

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -25,7 +25,7 @@
 
 /*!
   \file node_map.hpp
-  \brief A vector-based map indexed by network nodes
+  \brief A map interface indexed by network nodes
 
   \author Mathias Soeken
 */
@@ -34,6 +34,7 @@
 
 #include <cassert>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include "../traits.hpp"
@@ -43,13 +44,28 @@ namespace mockturtle
 
 /*! \brief Associative container network nodes
  *
- * This container helps to store values associated to nodes in a network.  The
- * container is initialized with a network to derive the size according to the
- * number of nodes.  The container can be accessed via nodes, or indirectly
- * via signals, from which the corresponding node is derived.
- * 
- * The implementation uses a vector as underlying data structure which is
- * indexed by the node's index.
+ * This container helps to store and access values associated to nodes
+ * in a network.
+ *
+ * Two implementations are provided one using std::vector and another
+ * using std::unordered_map as internal storage.  The former
+ * implementation can be pre-allocated and provides a fast way to
+ * access the data.  The later implementation offers a way to
+ * associate values to a subset of nodes and to check whether a value
+ * is available.
+ */
+template<class T, class Ntk, class Impl = std::vector<T>>
+class node_map;
+
+/*! \brief Specialization using std::vector
+ *
+ * This container is initialized with a network to derive the size
+ * according to the number of nodes.  The container can be accessed
+ * via nodes, or indirectly via signals, from which the corresponding
+ * node is derived.
+ *
+ * The implementation uses a vector as underlying data structure which
+ * is indexed by the node's index.
  * 
  * **Required network functions:**
  * - `size`
@@ -70,7 +86,7 @@ namespace mockturtle
    \endverbatim
  */
 template<class T, class Ntk>
-class node_map
+class node_map<T, Ntk, std::vector<T>>
 {
 public:
   using reference = typename std::vector<T>::reference;
@@ -171,5 +187,84 @@ private:
   Ntk const& ntk;
   std::shared_ptr<std::vector<T>> data;
 };
+
+/*! \brief Specialization using std::unordered_map
+ *
+ */
+template<class T, class Ntk>
+class node_map<T, Ntk, std::unordered_map<typename Ntk::node, T>>
+{
+public:
+  using node = typename Ntk::node;
+  using signal = typename Ntk::signal;
+
+  using reference = T&;
+  using const_reference = const T&;
+
+public:
+  explicit node_map( Ntk const& ntk )
+      : ntk( ntk )
+  {
+  }
+
+  /*! \brief Check if a key is already defined. */
+  bool has( node const& n ) const
+  {
+    return data.find( n ) != data.end();
+  }
+
+  /*! \brief Mutable access to value by node. */
+  reference operator[]( node const& n )
+  {
+    return data[ntk.node_to_index( n )];
+  }
+
+  /*! \brief Constant access to value by node. */
+  const_reference operator[]( node const& n ) const
+  {
+    assert( !has( n ) && "index out of bounds" );
+    return data[ntk.node_to_index( n )];
+  }
+
+  /*! \brief Mutable access to value by signal.
+   *
+   * This method derives the node from the signal.  If the node and signal type
+   * are the same in the network implementation, this method is disabled.
+   */
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
+  reference operator[]( signal const& f )
+  {
+    return data[ntk.node_to_index( ntk.get_node( f ) )];
+  }
+
+  /*! \brief Constant access to value by signal.
+   *
+   * This method derives the node from the signal.  If the node and signal type
+   * are the same in the network implementation, this method is disabled.
+   */
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
+  const_reference operator[]( signal const& f ) const
+  {
+    assert( !has( ntk.get_node( f ) ) && "index out of bounds" );
+    return data[ntk.node_to_index( ntk.get_node( f ) )];
+  }
+
+  /*! \brief Resets the size of the map.
+   *
+   * This function should be called, if the network changed in size.  Then, the
+   * map is cleared, and resized to the current network's size.
+   */
+  void reset()
+  {
+    data.clear();
+  }
+
+protected:
+  Ntk const& ntk;
+  std::unordered_map<node, T> data;
+};
+
+template<class T, class Ntk>
+using unordered_node_map = node_map<T, Ntk, std::unordered_map<typename Ntk::node, T>>;
 
 } /* namespace mockturtle */


### PR DESCRIPTION
This PR integrates `node_map` and `unordered_node_map` in form of a common interface provided with two specializations: one using std::vector and one using std::unordered_map as backend implementation. Moreover, a reasonable default-policy (and an additional template alias `unordered_node_map`) is provided to avoid breaking existing code.