### PR TITLE
Auto examples in mockturtle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Options
+option(MOCKTURTLE_EXAMPLES "Build examples" ON)
 option(MOCKTURTLE_TEST "Build tests" OFF)
 
 if(UNIX)
@@ -21,6 +22,10 @@ endif()
 
 add_subdirectory(include)
 add_subdirectory(lib)
+
+if(MOCKTURTLE_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 if(MOCKTURTLE_TEST)
   add_subdirectory(test)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB FILENAMES *.cpp)
+
+foreach(filename ${FILENAMES})
+  get_filename_component(basename ${filename} NAME_WE)
+  add_executable(${basename} ${filename})
+  target_link_libraries(${basename} PUBLIC mockturtle)
+endforeach()


### PR DESCRIPTION
This PR adds the possibility by auto compiling examples when adding `*.cpp` files into the `examples` folder. At this point, I don't intend to have example files in the repository, but it makes it easy to share examples offline.
