### PR TITLE
Cut rewriting cost function

### DIFF
--- a/docs/algorithms/cut_rewriting.rst
+++ b/docs/algorithms/cut_rewriting.rst
@@ -19,6 +19,24 @@ networks.  In this case the maximum number of variables for a node function is
    cut_rewriting( mig, resyn, ps );
    mig = cleanup_dangling( mig );
 
+It is possible to change the cost function of nodes in cut rewriting.  Here is
+an example, in which the cost function only accounts for AND gates in a network,
+which corresponds to the multiplicative complexity of a function.
+
+.. code-block:: c++
+
+   template<class Ntk>
+   struct mc_cost
+   {
+     uint32_t operator( Ntk const& ntk, node<Ntk> const& n ) const
+     {
+       return ntk.is_and( n ) ? 1 : 0;
+     }
+   };
+
+   SomeResynthesisClass resyn;
+   cut_rewriting<SomeResynthesisClass, mc_cost>( ntk, resyn );
+
 Parameters and statistics
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This adds the possibility to modify the cost function in cut rewriting to compare different replacements. Default is `unit_cost`. An example for cost functions based on the number of AND gates is added to the documentation.
