### PR TITLE
Gates to nodes synthesis and direct resynthesis

### DIFF
--- a/docs/algorithms/gates_to_nodes.rst
+++ b/docs/algorithms/gates_to_nodes.rst
@@ -1,0 +1,9 @@
+Gate-based network to node-based network
+----------------------------------------
+
+**Header:** ``mockturtle/algorithms/gates_to_nodes.hpp``
+
+Algorithm
+~~~~~~~~~
+
+.. doxygenfunction:: mockturtle::gates_to_nodes

--- a/docs/algorithms/node_resynthesis.rst
+++ b/docs/algorithms/node_resynthesis.rst
@@ -51,3 +51,5 @@ Resynthesis functions
 .. doxygenclass:: mockturtle::mig_npn_resynthesis
 
 .. doxygenclass:: mockturtle::xmg_npn_resynthesis
+
+.. doxygenclass:: mockturtle::direct_resynthesis

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,8 @@ v0.1 (not yet released)
     - Compute observability don't cares (`observability_dont_cares`) `#82 <https://github.com/lsils/mockturtle/pull/82>`_
     - Optimum XMG resynthesis for node resynthesis, cut rewriting, and refactoring `#86 <https://github.com/lsils/mockturtle/pull/86>`_
     - XMG algebraic depth rewriting (`xmg_algebraic_depth_rewriting`) `#86 <https://github.com/lsils/mockturtle/pull/86>`_
+    - Convert gate-based networks to node-based networks (`gates_to_nodes`) `#90 <https://github.com/lsils/mockturtle/pull/90>`_
+    - Direct resynthesis of functions into primitives (`direct_resynthesis`) `#90 <https://github.com/lsils/mockturtle/pull/90>`_
 * Views:
     - Visit nodes in topological order (`topo_view`) `#3 <https://github.com/lsils/mockturtle/pull/3>`_
     - Disable structural modifications to network (`immutable_view`) `#3 <https://github.com/lsils/mockturtle/pull/3>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Welcome to mockturtle's documentation!
    algorithms/cleanup
    algorithms/reconv_cut
    algorithms/dont_cares
+   algorithms/gates_to_nodes
 
 .. toctree::
    :maxdepth: 2

--- a/include/mockturtle/algorithms/gates_to_nodes.hpp
+++ b/include/mockturtle/algorithms/gates_to_nodes.hpp
@@ -1,0 +1,131 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file gates_to_nodes.hpp
+  \brief Convert gate-based network into node-based network
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include <fmt/format.h>
+#include <kitty/operations.hpp>
+#include <kitty/print.hpp>
+
+#include "../traits.hpp"
+#include "../utils/node_map.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Translates a gate-based network into a node-based network.
+ *
+ * A node will be created in the node-based network for every gate based on the
+ * gate function.  Possible complemented fanins are merged into the node
+ * function.
+ *
+ * **Required network functions for parameter ntk (type NtkSource):**
+ * - `foreach_pi`
+ * - `foreach_gate`
+ * - `foreach_fanin`
+ * - `get_constant`
+ * - `get_node`
+ * - `is_constant`
+ * - `is_pi`
+ * - `is_complemented`
+ * - `node_function`
+ * 
+ * **Required network functions for return value (type NtkDest):**
+ * - `create_pi`
+ * - `create_po`
+ * - `create_node`
+ * - `create_not`
+ * - `get_constant`
+ *
+ * \param ntk Network
+ */
+template<class NtkDest, class NtkSource>
+NtkDest gates_to_nodes( NtkSource const& ntk )
+{
+  static_assert( is_network_type_v<NtkDest>, "NtkDest is not a network type" );
+  static_assert( has_create_pi_v<NtkDest>, "NtkDest does not implement the create_pi method" );
+  static_assert( has_create_po_v<NtkDest>, "NtkDest does not implement the create_po method" );
+  static_assert( has_create_node_v<NtkDest>, "NtkDest does not implement the create_node method" );
+  static_assert( has_create_not_v<NtkDest>, "NtkDest does not implement the create_not method" );
+  static_assert( has_get_constant_v<NtkDest>, "NtkDest does not implement the get_constant method" );
+
+  static_assert( is_network_type_v<NtkSource>, "NtkSource is not a network type" );
+  static_assert( has_foreach_pi_v<NtkSource>, "NtkSource does not implement the foreach_pi method" );
+  static_assert( has_foreach_gate_v<NtkSource>, "NtkSource does not implement the foreach_gate method" );
+  static_assert( has_foreach_fanin_v<NtkSource>, "NtkSource does not implement the foreach_fanin method" );
+  static_assert( has_get_constant_v<NtkSource>, "NtkSource does not implement the get_constant method" );
+  static_assert( has_get_node_v<NtkSource>, "NtkSource does not implement the get_node method" );
+  static_assert( has_is_constant_v<NtkSource>, "NtkSource does not implement the is_constant method" );
+  static_assert( has_is_pi_v<NtkSource>, "NtkSource does not implement the is_pi method" );
+  static_assert( has_is_complemented_v<NtkSource>, "NtkSource does not implement the is_complemented method" );
+  static_assert( has_node_function_v<NtkSource>, "NtkSource does not implement the node_function method" );
+
+  NtkDest dest;
+  node_map<signal<NtkDest>, NtkSource> node_to_signal( ntk );
+
+  ntk.foreach_pi( [&]( auto const& n ) {
+    node_to_signal[n] = dest.create_pi();
+  } );
+
+  node_to_signal[ntk.get_constant( false )] = dest.get_constant( false );
+  if ( ntk.get_node( ntk.get_constant( false ) ) != ntk.get_node( ntk.get_constant( true ) ) )
+  {
+    node_to_signal[ntk.get_constant( true )] = dest.get_constant( true );
+  }
+
+  ntk.foreach_gate( [&]( auto const& n ) {
+    std::vector<signal<NtkDest>> children;
+    auto func = ntk.node_function( n );
+    ntk.foreach_fanin( n, [&]( auto const& c, auto i ) {
+      if ( ntk.is_complemented( c ) )
+      {
+        kitty::flip_inplace( func, i );
+      }
+      children.push_back( node_to_signal[c] );
+    } );
+
+    node_to_signal[n] = dest.create_node( children, func );
+  } );
+
+  /* outputs */
+  ntk.foreach_po( [&]( auto const& s ) {
+    dest.create_po( ntk.is_complemented( s ) ? dest.create_not( node_to_signal[s] ) : node_to_signal[s] );
+  } );
+
+  return dest;
+}
+
+} /* namespace mockturtle */

--- a/include/mockturtle/algorithms/node_resynthesis/direct.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/direct.hpp
@@ -1,0 +1,260 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file akers.hpp
+  \brief Resynthesis by trying to directly add gates
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+#include <kitty/dynamic_truth_table.hpp>
+#include <kitty/print.hpp>
+
+#include "../../algorithms/akers_synthesis.hpp"
+#include "../../networks/mig.hpp"
+
+namespace mockturtle
+{
+
+struct direct_resynthesis_params
+{
+  bool warn_on_unsupported{false};
+};
+
+/*! \brief Resynthesis function that creates a gate for each node.
+ *
+ * If it detects a function that can be constructed as a gate, it does so.
+ * Otherwise, it does not create a gate.  In that case, a warning can be
+ * printed, if configured in the parameter struct.
+ *
+ * The function works with all 0-, 1-, and 2-input node functions and with
+ * some 3-input node functions, e.g., 3-input majority for MIGs and XMGs, or
+ * 3-input XOR for XMGs.
+ *
+ * This resynthesis function can be passed to ``node_resynthesis``,
+ * ``cut_rewriting``, and ``refactoring``.
+ *
+   \verbatim embed:rst
+  
+   Example
+   
+   .. code-block:: c++
+   
+      const klut_network klut = ...;
+      direct_resynthesis resyn;
+      const auto mig = node_resynthesis<mig_network>( klut, resyn );
+   \endverbatim
+ */
+template<class Ntk>
+class direct_resynthesis
+{
+public:
+  direct_resynthesis( direct_resynthesis_params const& ps = {} )
+      : ps( ps )
+  {
+    static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+    static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
+    static_assert( has_create_not_v<Ntk>, "Ntk does not implement the create_not method" );
+    static_assert( has_create_and_v<Ntk>, "Ntk does not implement the create_and method" );
+    static_assert( has_create_or_v<Ntk>, "Ntk does not implement the create_or method" );
+    static_assert( has_create_xor_v<Ntk>, "Ntk does not implement the create_xor method" );
+  }
+
+  template<typename LeavesIterator, typename Fn>
+  void operator()( Ntk& ntk, kitty::dynamic_truth_table const& function, LeavesIterator begin, LeavesIterator end, Fn&& fn ) const
+  {
+    (void)end;
+    switch ( function.num_vars() )
+    {
+    case 0u:
+      synthesize0( ntk, function, fn );
+      break;
+
+    case 1u:
+      synthesize1( ntk, function, *begin, fn );
+      break;
+
+    case 2u:
+      synthesize2( ntk, function, *begin, *( begin + 1 ), fn );
+      break;
+
+    case 3u:
+      synthesize3( ntk, function, *begin, *( begin + 1 ), *( begin + 2 ), fn );
+      break;
+    }
+  }
+
+private:
+  template<typename Fn>
+  void synthesize0( Ntk& ntk, kitty::dynamic_truth_table const& function, Fn&& fn ) const
+  {
+    fn( ntk.get_constant( kitty::is_const0( function ) ) );
+  }
+
+  template<typename Fn>
+  void synthesize1( Ntk& ntk, kitty::dynamic_truth_table const& function, signal<Ntk> const& f, Fn&& fn ) const
+  {
+    switch ( *function.begin() )
+    {
+    case 0b00:
+      fn( ntk.get_constant( false ) );
+      break;
+    case 0b01:
+      fn( ntk.create_not( f ) );
+      break;
+    case 0b10:
+      fn( f );
+      break;
+    case 0b11:
+      fn( ntk.get_constant( true ) );
+      break;
+    }
+  }
+
+  template<typename Fn>
+  void synthesize2( Ntk& ntk, kitty::dynamic_truth_table const& function, signal<Ntk> const& f, signal<Ntk> const& g, Fn&& fn ) const
+  {
+    switch ( *function.begin() )
+    {
+    case 0b0000:
+      fn( ntk.get_constant( false ) );
+      break;
+    case 0b0001: /* NOR */
+      fn( ntk.create_not( ntk.create_or( f, g ) ) );
+      break;
+    case 0b0010: /* AND(f, !g) */
+      fn( ntk.create_and( f, ntk.create_not( g ) ) );
+      break;
+    case 0b0011: /* !g */
+      fn( ntk.create_not( g ) );
+      break;
+    case 0b0100: /* AND(!f, g) */
+      fn( ntk.create_and( ntk.create_not( f ), g ) );
+      break;
+    case 0b0101: /* !f */
+      fn( ntk.create_not( f ) );
+      break;
+    case 0b0110: /* XOR */
+      fn( ntk.create_xor( f, g ) );
+      break;
+    case 0b0111: /* NAND */
+      fn( ntk.create_not( ntk.create_and( f, g ) ) );
+      break;
+    case 0b1000: /* AND */
+      fn( ntk.create_and( f, g ) );
+      break;
+    case 0b1001: /* XNOR */
+      fn( ntk.create_not( ntk.create_xor( f, g ) ) );
+      break;
+    case 0b1010: /* f */
+      fn( f );
+      break;
+    case 0b1011: /* OR(f, !g) */
+      fn( ntk.create_or( f, ntk.create_not( g ) ) );
+      break;
+    case 0b1100: /* g */
+      fn( g );
+      break;
+    case 0b1101: /* OR(!f, g) */
+      fn( ntk.create_or( ntk.create_not( f ), g ) );
+      break;
+    case 0b1110: /* OR(f, g) */
+      fn( ntk.create_or( f, g ) );
+      break;
+    case 0b1111:
+      fn( ntk.get_constant( true ) );
+      break;
+    }
+  }
+
+  template<typename Fn>
+  void synthesize3( Ntk& ntk, kitty::dynamic_truth_table const& function, signal<Ntk> const& f, signal<Ntk> const& g, signal<Ntk> const& h, Fn&& fn ) const
+  {
+    // TODO? all contained extended 1-input and 2-input functions
+    // TODO create_ite
+
+    const auto word = *function.begin();
+    switch ( word )
+    {
+    case 0x00:
+      fn( ntk.get_constant( false ) );
+      break;
+    case 0xff:
+      fn( ntk.get_constant( true ) );
+      break;
+    case 0xe8: /* <fgh> */
+    case 0xd4: /* <!fgh> */
+    case 0xb2: /* <f!gh> */
+    case 0x8e: /* <fg!h> */
+    case 0x71: /* <!f!gh> */
+    case 0x4d: /* <!fg!h> */
+    case 0x2b: /* <f!g!h> */
+    case 0x17: /* <!f!g!h> */
+      if constexpr ( has_create_maj_v<Ntk> )
+      {
+        const auto _f = ( ( word == 0xd4 ) || ( word == 0x71 ) || ( word == 0x4d ) || ( word == 0x17 ) ) ? ntk.create_not( f ) : f;
+        const auto _g = ( ( word == 0xb2 ) || ( word == 0x71 ) || ( word == 0x2b ) || ( word == 0x17 ) ) ? ntk.create_not( g ) : g;
+        const auto _h = ( ( word == 0x8e ) || ( word == 0x4d ) || ( word == 0x2b ) || ( word == 0x17 ) ) ? ntk.create_not( h ) : h;
+        fn( ntk.create_maj( _f, _g, _h ) );
+      }
+      else
+      {
+        if ( ps.warn_on_unsupported )
+        {
+          std::cout << "[w] function " << kitty::to_hex( function ) << " cannot be synthesized as gate\n";
+        }
+      }
+      break;
+    case 0x96: /* [abc] */
+    case 0x69: /* ![abc] */
+      if constexpr ( has_create_xor3_v<Ntk> )
+      {
+        const auto o = ntk.create_xor3( f, g, h );
+        fn( word == 0x69 ? ntk.create_not( o ) : o );
+      }
+      else
+      {
+        if ( ps.warn_on_unsupported )
+        {
+          std::cout << "[w] function " << kitty::to_hex( function ) << " cannot be synthesized as gate\n";
+        }
+      }
+      break;
+    }
+  }
+
+private:
+  direct_resynthesis_params ps;
+};
+
+} /* namespace mockturtle */

--- a/include/mockturtle/networks/storage.hpp
+++ b/include/mockturtle/networks/storage.hpp
@@ -159,6 +159,9 @@ struct node_hash
 {
   uint64_t operator()( const Node& n ) const
   {
+    if ( n.children.size() == 0 )
+      return 0;
+
     auto it = std::begin( n.children );
     auto seed = hash_block( it->data );
     ++it;

--- a/test/algorithms/gates_to_nodes.cpp
+++ b/test/algorithms/gates_to_nodes.cpp
@@ -1,0 +1,26 @@
+#include <catch.hpp>
+
+#include <mockturtle/algorithms/gates_to_nodes.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/networks/klut.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "Gates to nodes from NAND XOR", "[gates_to_nodes]" )
+{
+  aig_network aig;
+  auto a = aig.create_pi();
+  auto b = aig.create_pi();
+  auto f1 = aig.create_nand( a, b );
+  auto f2 = aig.create_nand( a, f1 );
+  auto f3 = aig.create_nand( b, f1 );
+  auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  const auto klut = gates_to_nodes<klut_network>( aig );
+  CHECK( klut.size() == aig.size() + 2 );
+  CHECK( klut.num_pis() == aig.num_pis() );
+  CHECK( klut.num_pos() == aig.num_pos() );
+  CHECK( klut.num_gates() == aig.num_gates() + 1 );
+}

--- a/test/algorithms/node_resynthesis.cpp
+++ b/test/algorithms/node_resynthesis.cpp
@@ -1,10 +1,17 @@
 #include <catch.hpp>
 
+#include <algorithm>
+
 #include <mockturtle/algorithms/node_resynthesis.hpp>
 #include <mockturtle/algorithms/node_resynthesis/akers.hpp>
+#include <mockturtle/algorithms/node_resynthesis/direct.hpp>
 #include <mockturtle/algorithms/node_resynthesis/mig_npn.hpp>
+#include <mockturtle/algorithms/simulation.hpp>
+#include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/klut.hpp>
 #include <mockturtle/networks/mig.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/networks/xmg.hpp>
 
 #include <kitty/constructors.hpp>
 #include <kitty/dynamic_truth_table.hpp>
@@ -145,4 +152,66 @@ TEST_CASE( "Node resynthesis from negated projection", "[node_resynthesis]" )
     CHECK( mig.is_complemented( f ) );
     CHECK( mig.get_node( f ) == 1 );
   } );
+}
+
+TEST_CASE( "Node resynthesis with direct synthesis", "[selected]" )
+{
+  direct_resynthesis<aig_network> aig_resyn;
+  direct_resynthesis<xag_network> xag_resyn;
+  direct_resynthesis<mig_network> mig_resyn;
+  direct_resynthesis<xmg_network> xmg_resyn;
+
+  for ( auto v = 0u; v <= 2u; ++v )
+  {
+    for ( auto f = 0u; f < ( 1u << v ); ++f )
+    {
+      kitty::dynamic_truth_table tt( v );
+      kitty::create_from_words( tt, &f, &f + 1 );
+
+      klut_network klut;
+      std::vector<klut_network::signal> pis( v );
+      std::generate( pis.begin(), pis.end(), [&]() { return klut.create_pi(); } );
+      klut.create_po( klut.create_node( pis, tt ) );
+
+      CHECK( klut.num_pis() == v );
+      CHECK( klut.num_pos() == 1 );
+      CHECK( klut.num_gates() == 1 );
+
+      const auto aig = node_resynthesis<aig_network>( klut, aig_resyn );
+      CHECK( simulate<kitty::dynamic_truth_table>( aig, {v} )[0] == tt );
+
+      const auto xag = node_resynthesis<xag_network>( klut, xag_resyn );
+      CHECK( simulate<kitty::dynamic_truth_table>( xag, {v} )[0] == tt );
+
+      const auto mig = node_resynthesis<mig_network>( klut, mig_resyn );
+      CHECK( simulate<kitty::dynamic_truth_table>( mig, {v} )[0] == tt );
+
+      const auto xmg = node_resynthesis<xmg_network>( klut, xmg_resyn );
+      CHECK( simulate<kitty::dynamic_truth_table>( xmg, {v} )[0] == tt );
+    }
+  }
+
+  for ( auto f : std::vector<uint64_t>{{0x00, 0xff, 0xe8, 0xd4, 0xb2, 0x8e, 0x71, 0x4d, 0x2b, 0x17, 0x69, 0x96}} )
+  {
+    kitty::dynamic_truth_table tt( 3u );
+    kitty::create_from_words( tt, &f, &f + 1 );
+
+    klut_network klut;
+    std::vector<klut_network::signal> pis( 3u );
+    std::generate( pis.begin(), pis.end(), [&]() { return klut.create_pi(); } );
+    klut.create_po( klut.create_node( pis, tt ) );
+
+    CHECK( klut.num_pis() == 3u );
+    CHECK( klut.num_pos() == 1 );
+    CHECK( klut.num_gates() == 1 );
+
+    if ( f != 0x69 && f != 0x96 )
+    {
+      const auto mig = node_resynthesis<mig_network>( klut, mig_resyn );
+      CHECK( simulate<kitty::dynamic_truth_table>( mig, {3u} )[0] == tt );
+    }
+
+    const auto xmg = node_resynthesis<xmg_network>( klut, xmg_resyn );
+    CHECK( simulate<kitty::dynamic_truth_table>( xmg, {3u} )[0] == tt );
+  }
 }

--- a/test/algorithms/node_resynthesis.cpp
+++ b/test/algorithms/node_resynthesis.cpp
@@ -299,7 +299,7 @@ TEST_CASE( "Node resynthesis from negated projection", "[node_resynthesis]" )
   } );
 }
 
-TEST_CASE( "Node resynthesis with direct synthesis", "[selected]" )
+TEST_CASE( "Node resynthesis with direct synthesis", "[node_resynthesis]" )
 {
   direct_resynthesis<aig_network> aig_resyn;
   direct_resynthesis<xag_network> xag_resyn;


### PR DESCRIPTION
This PR implements two complementary synthesis methods: `gates_to_nodes` and `direct_resynthesis`.

The first one, `gates_to_nodes`, takes any gate-based network and translates it into a node-based network by taking the node function from the gate function and merging complemented fan-ins if necessary,

The second one, `direct_resynthesis`, tries to construct gates for known node functions. These known node functions are all functions with up to 2 inputs, ternary MAJ (with complements), ternary XOR, and ternary XNOR.
