### PR TITLE
depth_view.

### DIFF
--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -125,6 +125,7 @@ public:
   /*! \brief Mutable access to value by node. */
   reference operator[]( node const& n )
   {
+    assert( ntk.node_to_index( n ) < data->size() && "index out of bounds" );
     return (*data)[ntk.node_to_index( n )];
   }
 

--- a/include/mockturtle/views/window_view.hpp
+++ b/include/mockturtle/views/window_view.hpp
@@ -47,9 +47,7 @@
 namespace mockturtle
 {
 
-/*! \brief Implements an isolated view on a window in a network.
- *
- */
+/*! \brief Implements an isolated view on a window in a network. */
 template<typename Ntk>
 class window_view : public immutable_view<Ntk>
 {
@@ -71,24 +69,26 @@ public:
     static_assert( has_make_signal_v<Ntk>, "Ntk does not implement the make_signal method" );
     static_assert( has_foreach_fanout_v<Ntk>, "Ntk does not implement the foreach_fanout method" );
 
+    this->incr_trav_id();
+
     /* constants */
     add_node( this->get_node( this->get_constant( false ) ) );
-    this->set_visited( this->get_node( this->get_constant( false ) ), 1 );
+    this->set_visited( this->get_node( this->get_constant( false ) ), this->trav_id() );
     if ( this->get_node( this->get_constant( true ) ) != this->get_node( this->get_constant( false ) ) )
     {
       add_node( this->get_node( this->get_constant( true ) ) );
-      this->set_visited( this->get_node( this->get_constant( true ) ), 1 );
+      this->set_visited( this->get_node( this->get_constant( true ) ), this->trav_id() );
       ++_num_constants;
     }
 
     /* primary inputs */
     for ( auto const& leaf : leaves )
     {
-      if ( this->visited( leaf ) == 1 )
+      if ( this->visited( leaf ) == this->trav_id() )
         continue;
+      this->set_visited( leaf, this->trav_id() );
 
       add_node( leaf );
-      this->set_visited( leaf, 1 );
       ++_num_leaves;
     }
 
@@ -103,12 +103,6 @@ public:
     }
 
     add_roots( ntk );
-
-    /* restore visited */
-    for ( auto const& n : _nodes )
-    {
-      this->set_visited( n, 0 );
-    }
   }
 
   inline auto size() const { return _nodes.size(); }
@@ -172,15 +166,15 @@ private:
 
   void traverse( node const& n )
   {
-    if ( this->visited( n ) == 1 )
+    if ( this->visited( n ) == this->trav_id() )
       return;
+    this->set_visited( n, this->trav_id() );
 
     this->foreach_fanin( n, [&]( const auto& f ) {
       traverse( this->get_node( f ) );
     } );
 
     add_node( n );
-    this->set_visited( n, 1 );
   }
 
   void extend( Ntk const& ntk )

--- a/test/algorithms/quality.cpp
+++ b/test/algorithms/quality.cpp
@@ -173,8 +173,8 @@ TEST_CASE( "Test quality of MIG algebraic depth rewriting", "[quality]" )
     const auto before = depth_ntk.depth();
     mig_algebraic_depth_rewriting( depth_ntk );
     ntk = cleanup_dangling( ntk );
-    depth_ntk.update_levels();
-    return before - depth_ntk.depth();
+    depth_view depth_ntk2( ntk );
+    return before - depth_ntk2.depth();
   } );
 
   CHECK( v == std::vector<uint32_t>{{0, 4, 1, 8, 2, 4, 3, 11, 6, 35, 7}} );
@@ -190,9 +190,9 @@ TEST_CASE( "Test quality of MIG algebraic depth rewriting without area increase"
     ps.allow_area_increase = false;
     mig_algebraic_depth_rewriting( depth_ntk, ps );
     ntk = cleanup_dangling( ntk );
-    depth_ntk.update_levels();
+    depth_view depth_ntk2( ntk );
     CHECK( ntk.num_gates() <= size_before );
-    return before - depth_ntk.depth();
+    return before - depth_ntk2.depth();
   } );
 
   CHECK( v == std::vector<uint32_t>{{0, 1, 0, 5, 0, 0, 2, 6, 3, 0, 6}} );


### PR DESCRIPTION
This PR implements two new API methods for `depth_view`:
- `set_level` to update the level information of a specific node
- `resize_levels` to resize the data-structure if the network increased in size

Moreover, the update methods in `depth_view` and `window_view` use now traversal IDs. This change sightly improves performance because it is not needed to restoring the values of the visited flags anymore.