### PR TITLE
MIG based cost functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -70,3 +70,4 @@ v0.1 (not yet released)
     - Tracking time of computations (`stopwatch`, `call_with_stopwatch`, `make_with_stopwatch`) `#35 <https://github.com/lsils/mockturtle/pull/35>`_
 * Others:
     - Network events `#107 <https://github.com/lsils/mockturtle/pull/107>`_
+    - MIG cost functions `#115 <https://github.com/lsils/mockturtle/pull/115>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,12 @@ Welcome to mockturtle's documentation!
 
 .. toctree::
    :maxdepth: 2
+   :caption: Properties
+
+   properties
+
+.. toctree::
+   :maxdepth: 2
    :caption: Utilities
 
    utils/util_data_structures

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -1,0 +1,12 @@
+Properties
+==========
+
+MIG-based costs
+---------------
+
+In header ``mockturtle/properties/migcost.hpp`` functions are defined that can
+be used to compute costs relevant in majority-based emerging technologies.
+
+.. doxygenfunction:: mockturtle::num_inverters
+
+.. doxygenfunction:: mockturtle::num_dangling_inputs

--- a/include/mockturtle/properties/migcost.hpp
+++ b/include/mockturtle/properties/migcost.hpp
@@ -1,0 +1,116 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file migcost.hpp
+  \brief Cost functions for majority-based technologies
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_set>
+
+#include "../traits.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Counts number of inverters.
+ *
+ * This number counts all nodes that need to be inverted.  Multiple signals
+ * with complements to the same node are counted once.
+ *
+ * \param ntk Network
+ */
+template<class Ntk>
+uint32_t num_inverters( Ntk const& ntk )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_foreach_gate_v<Ntk>, "Ntk does not implement the foreach_gate method" );
+  static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_is_complemented_v<Ntk>, "Ntk does not implement the is_complemented method" );
+  static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+
+  std::unordered_set<node<Ntk>> inverted_nodes;
+
+  ntk.foreach_gate( [&]( auto const& n ) {
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      if ( ntk.is_complemented( f ) )
+      {
+        inverted_nodes.insert( ntk.get_node( f ) );
+      }
+    } );
+  } );
+
+  ntk.foreach_po( [&]( auto const& f ) {
+    if ( ntk.is_complemented( f ) )
+    {
+      inverted_nodes.insert( ntk.get_node( f ) );
+    }
+  } );
+
+  return inverted_nodes.size();
+}
+
+/*! \brief Counts fanins which are primary inputs.
+ *
+ * \param ntk Network
+ */
+template<class Ntk>
+uint32_t num_dangling_inputs( Ntk const& ntk )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_foreach_gate_v<Ntk>, "Ntk does not implement the foreach_gate method" );
+  static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+
+  uint32_t costs{0u};
+
+  ntk.foreach_gate( [&]( auto const& n ) {
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      if ( ntk.is_pi( ntk.get_node( f ) ) )
+      {
+        costs++;
+      }
+    } );
+  } );
+
+  ntk.foreach_po( [&]( auto const& f ) {
+    if ( ntk.is_pi( ntk.get_node( f ) ) )
+    {
+      costs++;
+    }
+  } );
+
+  return costs;
+}
+
+} // namespace mockturtle

--- a/test/properties/migcost.cpp
+++ b/test/properties/migcost.cpp
@@ -1,0 +1,34 @@
+#include <catch.hpp>
+
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/properties/migcost.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "count inverters in AIG", "[migcost]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( a, f1 );
+  const auto f3 = aig.create_nand( b, f1 );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  CHECK( num_inverters( aig ) == 4u );
+}
+
+TEST_CASE( "count dangling inputs in AIG", "[migcost]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( a, f1 );
+  const auto f3 = aig.create_nand( b, f1 );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  CHECK( num_dangling_inputs( aig ) == 4u );
+}

--- a/test/views/depth_view.cpp
+++ b/test/views/depth_view.cpp
@@ -55,3 +55,24 @@ TEST_CASE( "compute depth and levels for AIG", "[depth_view]" )
   CHECK( depth_aig.level( aig.get_node( f3 ) ) == 2 );
   CHECK( depth_aig.level( aig.get_node( f4 ) ) == 3 );
 }
+
+TEST_CASE( "compute depth and levels for AIG with inverter costs", "[depth_view]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( a, f1 );
+  const auto f3 = aig.create_nand( b, f1 );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  depth_view depth_aig{aig, true};
+  CHECK( depth_aig.depth() == 6 );
+  CHECK( depth_aig.level( aig.get_node( a ) ) == 0 );
+  CHECK( depth_aig.level( aig.get_node( b ) ) == 0 );
+  CHECK( depth_aig.level( aig.get_node( f1 ) ) == 1 );
+  CHECK( depth_aig.level( aig.get_node( f2 ) ) == 3 );
+  CHECK( depth_aig.level( aig.get_node( f3 ) ) == 3 );
+  CHECK( depth_aig.level( aig.get_node( f4 ) ) == 5 );
+}


### PR DESCRIPTION
PR implements three cost functions:

- `num_inverters`
- `num_dangling_inputs`
- Possibility to account for inverters in `depth_view`