### PR TITLE
Minor fixes in resubstitution.

### DIFF
--- a/include/mockturtle/algorithms/aig_resub.hpp
+++ b/include/mockturtle/algorithms/aig_resub.hpp
@@ -543,26 +543,26 @@ public:
           auto const& tt_s1 = sim.get_tt( s1 );
           if ( kitty::implies( tt, tt_s0 & tt_s1 ) )
           {
-            bdivs.positive_divisors0.emplace_back(  s0 );
-            bdivs.positive_divisors1.emplace_back(  s1 );
+            bdivs.negative_divisors0.emplace_back(  s0 );
+            bdivs.negative_divisors1.emplace_back(  s1 );
           }
 
           if ( kitty::implies( tt, ~tt_s0 & tt_s1 ) )
           {
-            bdivs.positive_divisors0.emplace_back( !s0 );
-            bdivs.positive_divisors1.emplace_back(  s1 );
+            bdivs.negative_divisors0.emplace_back( !s0 );
+            bdivs.negative_divisors1.emplace_back(  s1 );
           }
 
           if ( kitty::implies( tt, tt_s0 & ~tt_s1 ) )
           {
-            bdivs.positive_divisors0.emplace_back(  s0 );
-            bdivs.positive_divisors1.emplace_back( !s1 );
+            bdivs.negative_divisors0.emplace_back(  s0 );
+            bdivs.negative_divisors1.emplace_back( !s1 );
           }
 
           if ( kitty::implies( tt, ~tt_s0 & ~tt_s1 ) )
           {
-            bdivs.positive_divisors0.emplace_back( !s0 );
-            bdivs.positive_divisors1.emplace_back( !s1 );
+            bdivs.negative_divisors0.emplace_back( !s0 );
+            bdivs.negative_divisors1.emplace_back( !s1 );
           }
         }
       }

--- a/include/mockturtle/algorithms/mig_resub.hpp
+++ b/include/mockturtle/algorithms/mig_resub.hpp
@@ -355,7 +355,6 @@ public:
       {
         auto const a = sim.get_phase( ntk.get_node( fs[0] ) ) ? !fs[0] : fs[0];
         auto const b = sim.get_phase( ntk.get_node( fs[1] ) ) ? !fs[1] : fs[1];
-        auto const c = sim.get_phase( ntk.get_node( fs[2] ) ) ? !fs[2] : fs[2];
 
         return sim.get_phase( root ) ?
           !ntk.create_maj( sim.get_phase( d0 ) ? !s : s, a, b ) :
@@ -363,7 +362,6 @@ public:
       }
       else if ( ntk.get_node( fs[0] ) != d0 && ntk.fanout_size( ntk.get_node( fs[0] ) ) == 1 && relevance( ~tt0, tt1, tt2, tt ) )
       {
-        auto const a = sim.get_phase( ntk.get_node( fs[0] ) ) ? !fs[0] : fs[0];
         auto const b = sim.get_phase( ntk.get_node( fs[1] ) ) ? !fs[1] : fs[1];
         auto const c = sim.get_phase( ntk.get_node( fs[2] ) ) ? !fs[2] : fs[2];
 
@@ -374,7 +372,6 @@ public:
       else if ( ntk.get_node( fs[1] ) != d0 && ntk.fanout_size( ntk.get_node( fs[1] ) ) == 1 && relevance( ~tt1, tt0, tt2, tt ) )
       {
         auto const a = sim.get_phase( ntk.get_node( fs[0] ) ) ? !fs[0] : fs[0];
-        auto const b = sim.get_phase( ntk.get_node( fs[1] ) ) ? !fs[1] : fs[1];
         auto const c = sim.get_phase( ntk.get_node( fs[2] ) ) ? !fs[2] : fs[2];
 
         return sim.get_phase( root ) ?
@@ -385,7 +382,6 @@ public:
       {
         auto const a = sim.get_phase( ntk.get_node( fs[0] ) ) ? !fs[0] : fs[0];
         auto const b = sim.get_phase( ntk.get_node( fs[1] ) ) ? !fs[1] : fs[1];
-        auto const c = sim.get_phase( ntk.get_node( fs[2] ) ) ? !fs[2] : fs[2];
 
         return sim.get_phase( root ) ?
           !ntk.create_maj( sim.get_phase( d0 ) ? s : !s, a, b ) :
@@ -648,8 +644,8 @@ public:
   std::optional<signal> resub_div2( node const& root, uint32_t required )
   {
     (void)required;
-    auto s = ntk.make_signal( root );
-    auto const& tt = sim.get_tt( ntk.make_signal( root ) );
+    auto const s = ntk.make_signal( root );
+    auto const& tt = sim.get_tt( s );
 
     /* check positive unate divisors */
     for ( auto i = 0u; i < udivs.positive_divisors0.size(); ++i )

--- a/include/mockturtle/algorithms/resubstitution.hpp
+++ b/include/mockturtle/algorithms/resubstitution.hpp
@@ -148,7 +148,7 @@ struct resubstitution_stats
     std::cout << fmt::format( "[i]   substitute                                                ({:>5.2f} secs)\n", to_seconds( time_substitute ) );
     std::cout << fmt::format( "[i] total divisors            = {:8d}\n",         ( num_total_divisors ) );
     std::cout << fmt::format( "[i] total leaves              = {:8d}\n",         ( num_total_leaves ) );
-    std::cout << fmt::format( "[i] estimated gain            = {:8d} ({:>5.2f}\%)\n",
+    std::cout << fmt::format( "[i] estimated gain            = {:8d} ({:>5.2f}%)\n",
                               estimated_gain, ( (100.0 * estimated_gain) / initial_size ) );
   }
 };

--- a/include/mockturtle/algorithms/resubstitution.hpp
+++ b/include/mockturtle/algorithms/resubstitution.hpp
@@ -624,7 +624,7 @@ private:
       }
 
       /* compute truth tables of inner nodes */
-      sim.assign( d, i - leaves.size() + ps.max_pis + 1 );
+      sim.assign( d, i - uint32_t( leaves.size() ) + ps.max_pis + 1 );
       std::vector<typename Simulator::truthtable_t> tts;
       ntk.foreach_fanin( d, [&]( const auto& s, auto i ){
           (void)i;
@@ -632,7 +632,7 @@ private:
         });
 
       auto const tt = ntk.compute( d, tts.begin(), tts.end() );
-      sim.set_tt( i - leaves.size() + ps.max_pis + 1, tt );
+      sim.set_tt( i - uint32_t( leaves.size() ) + ps.max_pis + 1, tt );
     }
 
     /* normalize truth tables */
@@ -719,7 +719,7 @@ private:
       return false;
 
     /* get the number of divisors to collect */
-    int32_t limit = ps.max_divisors - ps.max_pis - ( divs.size() + 1 - leaves.size() + temp.size() );
+    int32_t limit = ps.max_divisors - ps.max_pis - ( uint32_t( divs.size() ) + 1 - uint32_t( leaves.size() ) + uint32_t( temp.size() ) );
 
     /* explore the fanouts, which are not in the MFFC */
     int32_t counter = 0;
@@ -784,7 +784,7 @@ private:
     }
 
     /* get the number of divisors */
-    num_divs = divs.size();
+    num_divs = uint32_t( divs.size() );
 
     /* add the nodes in the MFFC */
     for ( const auto& t : temp )

--- a/test/algorithms/quality.cpp
+++ b/test/algorithms/quality.cpp
@@ -17,6 +17,8 @@
 #include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
 #include <mockturtle/algorithms/refactoring.hpp>
 #include <mockturtle/algorithms/resubstitution.hpp>
+#include <mockturtle/algorithms/aig_resub.hpp>
+#include <mockturtle/algorithms/mig_resub.hpp>
 #include <mockturtle/io/aiger_reader.hpp>
 #include <mockturtle/io/write_bench.hpp>
 #include <mockturtle/networks/aig.hpp>
@@ -163,12 +165,12 @@ TEST_CASE( "Test quality of MIG resubstitution", "[quality]" )
     fanout_view<mig_network> fanout_view{ntk};
     view_t resub_view{fanout_view};
     const auto before = ntk.num_gates();
-    resubstitution( resub_view );
+    mig_resubstitution( resub_view );
     ntk = cleanup_dangling( ntk );
-    return ntk.num_gates();
+    return before - ntk.num_gates();
   } );
 
-  CHECK( v == std::vector<uint32_t>{{6, 198, 393, 317, 497, 330, 693, 996, 1735, 1902, 1444}} );
+  CHECK( v == std::vector<uint32_t>{{0, 39, 6, 16, 6, 15, 57, 53, 105, 17, 40}} );
 }
 
 TEST_CASE( "Test quality of MIG algebraic depth rewriting", "[quality]" )
@@ -276,6 +278,21 @@ TEST_CASE( "Test quality of node resynthesis with 2-LUT exact synthesis (worst-c
   } );
 
   CHECK( v == std::vector<uint32_t>{{6, 172, 182, 296, 182, 189, 484, 841, 1385, 1851, 1292}} );
+}
+
+TEST_CASE( "Test quality of AIG resubstitution", "[quality]" )
+{
+  using view_t = depth_view<fanout_view<aig_network>>;
+  const auto v = foreach_benchmark<aig_network>( []( auto& ntk, auto ) {
+    fanout_view<aig_network> fanout_view{ntk};
+    view_t resub_view{fanout_view};
+    const auto before = ntk.num_gates();
+    aig_resubstitution( resub_view );
+    ntk = cleanup_dangling( ntk );
+    return before - ntk.num_gates();
+  } );
+
+  CHECK( v == std::vector<uint32_t>{{0, 40, 0, 13, 0, 27, 76, 44, 135, 218, 43}} );
 }
 
 TEST_CASE( "Test quality improvement of cut rewriting with AIG NPN4 resynthesis", "[quality]" )


### PR DESCRIPTION
- Fixes a bug `compute_binate_divisors` in AIG resub.
- Removes unused variable-warnings.