### PR TITLE
Sorting network generators

### DIFF
--- a/include/mockturtle/generators/sorting.hpp
+++ b/include/mockturtle/generators/sorting.hpp
@@ -1,0 +1,90 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2019  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file sorting.hpp
+  \brief Generate sorting networks
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace mockturtle
+{
+
+/*! \brief Generates sorting network based on bubble sort.
+ *
+ * The functor is called for every comparator in the network.  The arguments
+ * to the functor are two integers that define on which lines the comparator
+ * acts.
+ *
+ * \param n Number of elements to sort
+ * \param compare_fn Functor
+ */
+template<class Fn>
+void bubble_sorting_network( uint32_t n, Fn&& compare_fn )
+{
+  if ( n <= 1 )
+  {
+    return;
+  }
+  for ( auto c = n - 1; c >= 1; --c )
+  {
+    for ( auto j = 0u; j < c; ++j )
+    {
+      compare_fn( j, j + 1 );
+    }
+  }
+}
+
+/*! \brief Generates sorting network based on insertion sort.
+ *
+ * The functor is called for every comparator in the network.  The arguments
+ * to the functor are two integers that define on which lines the comparator
+ * acts.
+ *
+ * \param n Number of elements to sort
+ * \param compare_fn Functor
+ */
+template<class Fn>
+void insertion_sorting_network( uint32_t n, Fn&& compare_fn )
+{
+  if ( n <= 1 )
+  {
+    return;
+  }
+  for ( auto c = 1u; c < n; ++c )
+  {
+    for ( int j = c - 1; j >= 0; --j )
+    {
+      compare_fn( j, j + 1 );
+    }
+  }
+}
+
+} // namespace mockturtle

--- a/test/generators/sorting.cpp
+++ b/test/generators/sorting.cpp
@@ -1,0 +1,58 @@
+#include <catch.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include <mockturtle/generators/sorting.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "sorting networks based on bubble sort", "[sorting]" )
+{
+  for ( auto n = 0u; n < 17u; ++n )
+  {
+    std::vector<uint32_t> list( n );
+    std::iota( list.begin(), list.end(), 0u );
+
+    for ( auto r = 0u; r < std::max( n, 1u ); ++r )
+    {
+      auto copy = list;
+      std::random_shuffle( copy.begin(), copy.end() );
+
+      bubble_sorting_network( n, [&]( auto a, auto b ) {
+        if ( copy[a] > copy[b] )
+        {
+          std::swap( copy[a], copy[b] );
+        }
+      } );
+
+      CHECK( copy == list );
+    }
+  }
+}
+
+TEST_CASE( "sorting networks based on insertion sort", "[sorting]" )
+{
+  for ( auto n = 0u; n < 17u; ++n )
+  {
+    std::vector<uint32_t> list( n );
+    std::iota( list.begin(), list.end(), 0u );
+
+    for ( auto r = 0u; r < std::max( n, 1u ); ++r )
+    {
+      auto copy = list;
+      std::random_shuffle( copy.begin(), copy.end() );
+
+      insertion_sorting_network( n, [&]( auto a, auto b ) {
+        if ( copy[a] > copy[b] )
+        {
+          std::swap( copy[a], copy[b] );
+        }
+      } );
+
+      CHECK( copy == list );
+    }
+  }
+}

--- a/test/generators/sorting.cpp
+++ b/test/generators/sorting.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <numeric>
+#include <random>
 #include <vector>
 
 #include <mockturtle/generators/sorting.hpp>
@@ -19,7 +20,7 @@ TEST_CASE( "sorting networks based on bubble sort", "[sorting]" )
     for ( auto r = 0u; r < std::max( n, 1u ); ++r )
     {
       auto copy = list;
-      std::random_shuffle( copy.begin(), copy.end() );
+      std::shuffle( copy.begin(), copy.end(), std::default_random_engine( 0 ) );
 
       bubble_sorting_network( n, [&]( auto a, auto b ) {
         if ( copy[a] > copy[b] )
@@ -43,7 +44,7 @@ TEST_CASE( "sorting networks based on insertion sort", "[sorting]" )
     for ( auto r = 0u; r < std::max( n, 1u ); ++r )
     {
       auto copy = list;
-      std::random_shuffle( copy.begin(), copy.end() );
+      std::shuffle( copy.begin(), copy.end(), std::default_random_engine( 0 ) );
 
       insertion_sorting_network( n, [&]( auto a, auto b ) {
         if ( copy[a] > copy[b] )


### PR DESCRIPTION
This PR adds generators for two simple sorting networks. These act as most simple examples for other generators based on more sophisticated sorting networks. The sorting networks can eventually be used to create logic networks based on them or to use them for cardinality constraints in SAT solvers.
