### PR TITLE
Make fanout_view2 work with resubstitution

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+v0.2 (not yet released)
+-----------------------
+
+* Framework for performing quality and performance experiments `#140 <https://github.com/lsils/mockturtle/pull/140>`_
+
 v0.1 (March 31, 2019)
 ---------------------
 

--- a/experiments/aig_resubstitution.cpp
+++ b/experiments/aig_resubstitution.cpp
@@ -1,0 +1,79 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2019  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <lorina/aiger.hpp>
+#include <mockturtle/algorithms/aig_resub.hpp>
+#include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/algorithms/resubstitution.hpp>
+#include <mockturtle/io/aiger_reader.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/views/depth_view.hpp>
+#include <mockturtle/views/fanout_view.hpp>
+#include <mockturtle/views/fanout_view2.hpp>
+
+#include <experiments.hpp>
+
+int main()
+{
+  using namespace experiments;
+  using namespace mockturtle;
+
+  experiment<std::string, uint32_t, uint32_t, float, bool> exp( "aig_resubstitution", "benchmark", "size_before", "size_after", "runtime", "equivalent" );
+
+  for ( auto const& benchmark : epfl_benchmarks() )
+  {
+    fmt::print( "[i] processing {}\n", benchmark );
+    aig_network aig;
+    lorina::read_aiger( benchmark_path( benchmark ), aiger_reader( aig ) );
+
+    resubstitution_params ps;
+    resubstitution_stats st;
+
+    using view_t = fanout_view2<depth_view<aig_network>>;
+    depth_view depth_view{aig};
+    view_t resub_view{depth_view};
+    ps.max_pis = 8u;
+    ps.max_inserts = 1u;
+    ps.progress = false;
+
+    const uint32_t size_before = aig.num_gates();
+    aig_resubstitution( resub_view, ps, &st );
+
+    aig = cleanup_dangling( aig );
+
+    const auto cec = abc_cec( aig, benchmark );
+
+    exp( benchmark, size_before, aig.num_gates(), to_seconds( st.time_total ), cec );
+  }
+
+  exp.save();
+  exp.compare();
+
+  return 0;
+}

--- a/experiments/aig_resubstitution.json
+++ b/experiments/aig_resubstitution.json
@@ -1,0 +1,292 @@
+[
+  {
+    "entries": [
+      {
+        "benchmark": "adder",
+        "equivalent": true,
+        "runtime": 0.0418270006775856,
+        "size_after": 894,
+        "size_before": 1020
+      },
+      {
+        "benchmark": "bar",
+        "equivalent": true,
+        "runtime": 0.10932900011539459,
+        "size_after": 3336,
+        "size_before": 3336
+      },
+      {
+        "benchmark": "div",
+        "equivalent": true,
+        "runtime": 3.411120891571045,
+        "size_after": 52616,
+        "size_before": 57247
+      },
+      {
+        "benchmark": "hyp",
+        "equivalent": true,
+        "runtime": 7.1420512199401855,
+        "size_after": 213692,
+        "size_before": 214335
+      },
+      {
+        "benchmark": "log2",
+        "equivalent": true,
+        "runtime": 1.1120879650115967,
+        "size_after": 32040,
+        "size_before": 32060
+      },
+      {
+        "benchmark": "max",
+        "equivalent": true,
+        "runtime": 0.06496699899435043,
+        "size_after": 2865,
+        "size_before": 2865
+      },
+      {
+        "benchmark": "multiplier",
+        "equivalent": true,
+        "runtime": 0.878387987613678,
+        "size_after": 27017,
+        "size_before": 27062
+      },
+      {
+        "benchmark": "sin",
+        "equivalent": true,
+        "runtime": 0.17823000252246857,
+        "size_after": 5400,
+        "size_before": 5416
+      },
+      {
+        "benchmark": "sqrt",
+        "equivalent": true,
+        "runtime": 1.2999370098114014,
+        "size_after": 20850,
+        "size_before": 24618
+      },
+      {
+        "benchmark": "square",
+        "equivalent": true,
+        "runtime": 0.6096230149269104,
+        "size_after": 18190,
+        "size_before": 18484
+      },
+      {
+        "benchmark": "arbiter",
+        "equivalent": true,
+        "runtime": 0.34188398718833923,
+        "size_after": 11839,
+        "size_before": 11839
+      },
+      {
+        "benchmark": "cavlc",
+        "equivalent": true,
+        "runtime": 0.03624799847602844,
+        "size_after": 680,
+        "size_before": 693
+      },
+      {
+        "benchmark": "ctrl",
+        "equivalent": true,
+        "runtime": 0.008438999764621258,
+        "size_after": 129,
+        "size_before": 174
+      },
+      {
+        "benchmark": "dec",
+        "equivalent": true,
+        "runtime": 0.020881999284029007,
+        "size_after": 304,
+        "size_before": 304
+      },
+      {
+        "benchmark": "i2c",
+        "equivalent": true,
+        "runtime": 0.04168400168418884,
+        "size_after": 1278,
+        "size_before": 1342
+      },
+      {
+        "benchmark": "int2float",
+        "equivalent": true,
+        "runtime": 0.012492000125348568,
+        "size_after": 244,
+        "size_before": 260
+      },
+      {
+        "benchmark": "mem_ctrl",
+        "equivalent": true,
+        "runtime": 1.5072840452194214,
+        "size_after": 46673,
+        "size_before": 46836
+      },
+      {
+        "benchmark": "priority",
+        "equivalent": true,
+        "runtime": 0.025919999927282333,
+        "size_after": 904,
+        "size_before": 978
+      },
+      {
+        "benchmark": "router",
+        "equivalent": true,
+        "runtime": 0.006732000038027763,
+        "size_after": 257,
+        "size_before": 257
+      },
+      {
+        "benchmark": "voter",
+        "equivalent": true,
+        "runtime": 0.5123000144958496,
+        "size_after": 11805,
+        "size_before": 13758
+      }
+    ],
+    "version": "106c4e7"
+  },
+  {
+    "entries": [
+      {
+        "benchmark": "adder",
+        "equivalent": true,
+        "runtime": 0.006180000025779009,
+        "size_after": 894,
+        "size_before": 1020
+      },
+      {
+        "benchmark": "bar",
+        "equivalent": true,
+        "runtime": 0.02387700043618679,
+        "size_after": 3336,
+        "size_before": 3336
+      },
+      {
+        "benchmark": "div",
+        "equivalent": true,
+        "runtime": 0.48394501209259033,
+        "size_after": 52616,
+        "size_before": 57247
+      },
+      {
+        "benchmark": "hyp",
+        "equivalent": true,
+        "runtime": 1.4399160146713257,
+        "size_after": 213692,
+        "size_before": 214335
+      },
+      {
+        "benchmark": "log2",
+        "equivalent": true,
+        "runtime": 0.2875150144100189,
+        "size_after": 32040,
+        "size_before": 32060
+      },
+      {
+        "benchmark": "max",
+        "equivalent": true,
+        "runtime": 0.012713000178337097,
+        "size_after": 2865,
+        "size_before": 2865
+      },
+      {
+        "benchmark": "multiplier",
+        "equivalent": true,
+        "runtime": 0.23626799881458282,
+        "size_after": 27017,
+        "size_before": 27062
+      },
+      {
+        "benchmark": "sin",
+        "equivalent": true,
+        "runtime": 0.05264100059866905,
+        "size_after": 5400,
+        "size_before": 5416
+      },
+      {
+        "benchmark": "sqrt",
+        "equivalent": true,
+        "runtime": 0.23785699903964996,
+        "size_after": 20850,
+        "size_before": 24618
+      },
+      {
+        "benchmark": "square",
+        "equivalent": true,
+        "runtime": 0.15417499840259552,
+        "size_after": 18190,
+        "size_before": 18484
+      },
+      {
+        "benchmark": "arbiter",
+        "equivalent": true,
+        "runtime": 0.07125899940729141,
+        "size_after": 11839,
+        "size_before": 11839
+      },
+      {
+        "benchmark": "cavlc",
+        "equivalent": true,
+        "runtime": 0.013918000273406506,
+        "size_after": 680,
+        "size_before": 693
+      },
+      {
+        "benchmark": "ctrl",
+        "equivalent": true,
+        "runtime": 0.004089999943971634,
+        "size_after": 129,
+        "size_before": 174
+      },
+      {
+        "benchmark": "dec",
+        "equivalent": true,
+        "runtime": 0.01309600006788969,
+        "size_after": 304,
+        "size_before": 304
+      },
+      {
+        "benchmark": "i2c",
+        "equivalent": true,
+        "runtime": 0.008980000391602516,
+        "size_after": 1278,
+        "size_before": 1342
+      },
+      {
+        "benchmark": "int2float",
+        "equivalent": true,
+        "runtime": 0.0028810000512748957,
+        "size_after": 244,
+        "size_before": 260
+      },
+      {
+        "benchmark": "mem_ctrl",
+        "equivalent": true,
+        "runtime": 0.3819870054721832,
+        "size_after": 46673,
+        "size_before": 46836
+      },
+      {
+        "benchmark": "priority",
+        "equivalent": true,
+        "runtime": 0.0074280002154409885,
+        "size_after": 904,
+        "size_before": 978
+      },
+      {
+        "benchmark": "router",
+        "equivalent": true,
+        "runtime": 0.0018210000125691295,
+        "size_after": 257,
+        "size_before": 257
+      },
+      {
+        "benchmark": "voter",
+        "equivalent": true,
+        "runtime": 0.1105789989233017,
+        "size_after": 11805,
+        "size_before": 13758
+      }
+    ],
+    "version": "c858d44"
+  }
+]

--- a/experiments/aig_resubstitution.json
+++ b/experiments/aig_resubstitution.json
@@ -149,140 +149,140 @@
       {
         "benchmark": "adder",
         "equivalent": true,
-        "runtime": 0.006180000025779009,
+        "runtime": 0.009038999676704407,
         "size_after": 894,
         "size_before": 1020
       },
       {
         "benchmark": "bar",
         "equivalent": true,
-        "runtime": 0.02387700043618679,
+        "runtime": 0.026644999161362648,
         "size_after": 3336,
         "size_before": 3336
       },
       {
         "benchmark": "div",
         "equivalent": true,
-        "runtime": 0.48394501209259033,
+        "runtime": 0.5152239799499512,
         "size_after": 52616,
         "size_before": 57247
       },
       {
         "benchmark": "hyp",
         "equivalent": true,
-        "runtime": 1.4399160146713257,
+        "runtime": 1.9649109840393066,
         "size_after": 213692,
         "size_before": 214335
       },
       {
         "benchmark": "log2",
         "equivalent": true,
-        "runtime": 0.2875150144100189,
+        "runtime": 0.2899639904499054,
         "size_after": 32040,
         "size_before": 32060
       },
       {
         "benchmark": "max",
         "equivalent": true,
-        "runtime": 0.012713000178337097,
+        "runtime": 0.013232000172138214,
         "size_after": 2865,
         "size_before": 2865
       },
       {
         "benchmark": "multiplier",
         "equivalent": true,
-        "runtime": 0.23626799881458282,
+        "runtime": 0.23364600539207458,
         "size_after": 27017,
         "size_before": 27062
       },
       {
         "benchmark": "sin",
         "equivalent": true,
-        "runtime": 0.05264100059866905,
+        "runtime": 0.07072100043296814,
         "size_after": 5400,
         "size_before": 5416
       },
       {
         "benchmark": "sqrt",
         "equivalent": true,
-        "runtime": 0.23785699903964996,
+        "runtime": 0.35105499625205994,
         "size_after": 20850,
         "size_before": 24618
       },
       {
         "benchmark": "square",
         "equivalent": true,
-        "runtime": 0.15417499840259552,
+        "runtime": 0.15842799842357635,
         "size_after": 18190,
         "size_before": 18484
       },
       {
         "benchmark": "arbiter",
         "equivalent": true,
-        "runtime": 0.07125899940729141,
+        "runtime": 0.09127900004386902,
         "size_after": 11839,
         "size_before": 11839
       },
       {
         "benchmark": "cavlc",
         "equivalent": true,
-        "runtime": 0.013918000273406506,
+        "runtime": 0.019998999312520027,
         "size_after": 680,
         "size_before": 693
       },
       {
         "benchmark": "ctrl",
         "equivalent": true,
-        "runtime": 0.004089999943971634,
+        "runtime": 0.0042039998807013035,
         "size_after": 129,
         "size_before": 174
       },
       {
         "benchmark": "dec",
         "equivalent": true,
-        "runtime": 0.01309600006788969,
+        "runtime": 0.010598000138998032,
         "size_after": 304,
         "size_before": 304
       },
       {
         "benchmark": "i2c",
         "equivalent": true,
-        "runtime": 0.008980000391602516,
+        "runtime": 0.0087890001013875,
         "size_after": 1278,
         "size_before": 1342
       },
       {
         "benchmark": "int2float",
         "equivalent": true,
-        "runtime": 0.0028810000512748957,
+        "runtime": 0.0028609998989850283,
         "size_after": 244,
         "size_before": 260
       },
       {
         "benchmark": "mem_ctrl",
         "equivalent": true,
-        "runtime": 0.3819870054721832,
+        "runtime": 0.37508100271224976,
         "size_after": 46673,
         "size_before": 46836
       },
       {
         "benchmark": "priority",
         "equivalent": true,
-        "runtime": 0.0074280002154409885,
+        "runtime": 0.007447000127285719,
         "size_after": 904,
         "size_before": 978
       },
       {
         "benchmark": "router",
         "equivalent": true,
-        "runtime": 0.0018210000125691295,
+        "runtime": 0.0017049999441951513,
         "size_after": 257,
         "size_before": 257
       },
       {
         "benchmark": "voter",
         "equivalent": true,
-        "runtime": 0.1105789989233017,
+        "runtime": 0.11269800364971161,
         "size_after": 11805,
         "size_before": 13758
       }

--- a/experiments/cut_rewriting.cpp
+++ b/experiments/cut_rewriting.cpp
@@ -66,7 +66,7 @@ int main()
   }
 
   exp.save();
-  exp.table();
+  exp.compare();
 
   return 0;
 }

--- a/experiments/cut_rewriting.json
+++ b/experiments/cut_rewriting.json
@@ -1,1 +1,292 @@
-[{"entries":[{"benchmark":"adder","equivalent":true,"runtime":0.1783429980278015,"size_after":1020,"size_before":1020},{"benchmark":"bar","equivalent":true,"runtime":0.48257699608802795,"size_after":3141,"size_before":3336},{"benchmark":"div","equivalent":true,"runtime":69.38221740722656,"size_after":41674,"size_before":57247},{"benchmark":"hyp","equivalent":true,"runtime":284.9333190917969,"size_after":213525,"size_before":214335},{"benchmark":"log2","equivalent":true,"runtime":56.37065505981445,"size_after":30242,"size_before":32060},{"benchmark":"max","equivalent":true,"runtime":0.7347429990768433,"size_after":2862,"size_before":2865},{"benchmark":"multiplier","equivalent":true,"runtime":56.119266510009766,"size_after":25086,"size_before":27062},{"benchmark":"sin","equivalent":true,"runtime":1.650305986404419,"size_after":5255,"size_before":5416},{"benchmark":"sqrt","equivalent":true,"runtime":12.261555671691895,"size_after":18647,"size_before":24618},{"benchmark":"square","equivalent":true,"runtime":6.958412170410156,"size_after":18291,"size_before":18484},{"benchmark":"arbiter","equivalent":true,"runtime":5.45804500579834,"size_after":11839,"size_before":11839},{"benchmark":"cavlc","equivalent":true,"runtime":0.10875000059604645,"size_after":687,"size_before":693},{"benchmark":"ctrl","equivalent":true,"runtime":0.040553998202085495,"size_after":137,"size_before":174},{"benchmark":"dec","equivalent":true,"runtime":0.004410000052303076,"size_after":304,"size_before":304},{"benchmark":"i2c","equivalent":true,"runtime":0.25579699873924255,"size_after":1321,"size_before":1342},{"benchmark":"int2float","equivalent":true,"runtime":0.04118499904870987,"size_after":228,"size_before":260},{"benchmark":"mem_ctrl","equivalent":true,"runtime":8.868900299072266,"size_after":46663,"size_before":46836},{"benchmark":"priority","equivalent":true,"runtime":0.16314800083637238,"size_after":893,"size_before":978},{"benchmark":"router","equivalent":true,"runtime":0.06950200349092484,"size_after":252,"size_before":257},{"benchmark":"voter","equivalent":true,"runtime":5.880533218383789,"size_after":11573,"size_before":13758}],"version":"420b67d"}]
+[
+  {
+    "entries": [
+      {
+        "benchmark": "adder",
+        "equivalent": true,
+        "runtime": 0.1783429980278015,
+        "size_after": 1020,
+        "size_before": 1020
+      },
+      {
+        "benchmark": "bar",
+        "equivalent": true,
+        "runtime": 0.48257699608802795,
+        "size_after": 3141,
+        "size_before": 3336
+      },
+      {
+        "benchmark": "div",
+        "equivalent": true,
+        "runtime": 69.38221740722656,
+        "size_after": 41674,
+        "size_before": 57247
+      },
+      {
+        "benchmark": "hyp",
+        "equivalent": true,
+        "runtime": 284.9333190917969,
+        "size_after": 213525,
+        "size_before": 214335
+      },
+      {
+        "benchmark": "log2",
+        "equivalent": true,
+        "runtime": 56.37065505981445,
+        "size_after": 30242,
+        "size_before": 32060
+      },
+      {
+        "benchmark": "max",
+        "equivalent": true,
+        "runtime": 0.7347429990768433,
+        "size_after": 2862,
+        "size_before": 2865
+      },
+      {
+        "benchmark": "multiplier",
+        "equivalent": true,
+        "runtime": 56.119266510009766,
+        "size_after": 25086,
+        "size_before": 27062
+      },
+      {
+        "benchmark": "sin",
+        "equivalent": true,
+        "runtime": 1.650305986404419,
+        "size_after": 5255,
+        "size_before": 5416
+      },
+      {
+        "benchmark": "sqrt",
+        "equivalent": true,
+        "runtime": 12.261555671691895,
+        "size_after": 18647,
+        "size_before": 24618
+      },
+      {
+        "benchmark": "square",
+        "equivalent": true,
+        "runtime": 6.958412170410156,
+        "size_after": 18291,
+        "size_before": 18484
+      },
+      {
+        "benchmark": "arbiter",
+        "equivalent": true,
+        "runtime": 5.45804500579834,
+        "size_after": 11839,
+        "size_before": 11839
+      },
+      {
+        "benchmark": "cavlc",
+        "equivalent": true,
+        "runtime": 0.10875000059604645,
+        "size_after": 687,
+        "size_before": 693
+      },
+      {
+        "benchmark": "ctrl",
+        "equivalent": true,
+        "runtime": 0.040553998202085495,
+        "size_after": 137,
+        "size_before": 174
+      },
+      {
+        "benchmark": "dec",
+        "equivalent": true,
+        "runtime": 0.004410000052303076,
+        "size_after": 304,
+        "size_before": 304
+      },
+      {
+        "benchmark": "i2c",
+        "equivalent": true,
+        "runtime": 0.25579699873924255,
+        "size_after": 1321,
+        "size_before": 1342
+      },
+      {
+        "benchmark": "int2float",
+        "equivalent": true,
+        "runtime": 0.04118499904870987,
+        "size_after": 228,
+        "size_before": 260
+      },
+      {
+        "benchmark": "mem_ctrl",
+        "equivalent": true,
+        "runtime": 8.868900299072266,
+        "size_after": 46663,
+        "size_before": 46836
+      },
+      {
+        "benchmark": "priority",
+        "equivalent": true,
+        "runtime": 0.16314800083637238,
+        "size_after": 893,
+        "size_before": 978
+      },
+      {
+        "benchmark": "router",
+        "equivalent": true,
+        "runtime": 0.06950200349092484,
+        "size_after": 252,
+        "size_before": 257
+      },
+      {
+        "benchmark": "voter",
+        "equivalent": true,
+        "runtime": 5.880533218383789,
+        "size_after": 11573,
+        "size_before": 13758
+      }
+    ],
+    "version": "420b67d"
+  },
+  {
+    "entries": [
+      {
+        "benchmark": "adder",
+        "equivalent": true,
+        "runtime": 0.1090259999036789,
+        "size_after": 1020,
+        "size_before": 1020
+      },
+      {
+        "benchmark": "bar",
+        "equivalent": true,
+        "runtime": 0.443558007478714,
+        "size_after": 3141,
+        "size_before": 3336
+      },
+      {
+        "benchmark": "div",
+        "equivalent": true,
+        "runtime": 11.161718368530273,
+        "size_after": 41674,
+        "size_before": 57247
+      },
+      {
+        "benchmark": "hyp",
+        "equivalent": true,
+        "runtime": 42.172733306884766,
+        "size_after": 213525,
+        "size_before": 214335
+      },
+      {
+        "benchmark": "log2",
+        "equivalent": true,
+        "runtime": 6.692252159118652,
+        "size_after": 30242,
+        "size_before": 32060
+      },
+      {
+        "benchmark": "max",
+        "equivalent": true,
+        "runtime": 0.41910600662231445,
+        "size_after": 2862,
+        "size_before": 2865
+      },
+      {
+        "benchmark": "multiplier",
+        "equivalent": true,
+        "runtime": 4.653367042541504,
+        "size_after": 25086,
+        "size_before": 27062
+      },
+      {
+        "benchmark": "sin",
+        "equivalent": true,
+        "runtime": 1.2638180255889893,
+        "size_after": 5255,
+        "size_before": 5416
+      },
+      {
+        "benchmark": "sqrt",
+        "equivalent": true,
+        "runtime": 4.156030178070068,
+        "size_after": 18647,
+        "size_before": 24618
+      },
+      {
+        "benchmark": "square",
+        "equivalent": true,
+        "runtime": 3.833972930908203,
+        "size_after": 18291,
+        "size_before": 18484
+      },
+      {
+        "benchmark": "arbiter",
+        "equivalent": true,
+        "runtime": 6.577425956726074,
+        "size_after": 11839,
+        "size_before": 11839
+      },
+      {
+        "benchmark": "cavlc",
+        "equivalent": true,
+        "runtime": 0.07806199789047241,
+        "size_after": 687,
+        "size_before": 693
+      },
+      {
+        "benchmark": "ctrl",
+        "equivalent": true,
+        "runtime": 0.025899000465869904,
+        "size_after": 137,
+        "size_before": 174
+      },
+      {
+        "benchmark": "dec",
+        "equivalent": true,
+        "runtime": 0.004449000116437674,
+        "size_after": 304,
+        "size_before": 304
+      },
+      {
+        "benchmark": "i2c",
+        "equivalent": true,
+        "runtime": 0.2142840027809143,
+        "size_after": 1321,
+        "size_before": 1342
+      },
+      {
+        "benchmark": "int2float",
+        "equivalent": true,
+        "runtime": 0.035450998693704605,
+        "size_after": 228,
+        "size_before": 260
+      },
+      {
+        "benchmark": "mem_ctrl",
+        "equivalent": true,
+        "runtime": 7.306457996368408,
+        "size_after": 46663,
+        "size_before": 46836
+      },
+      {
+        "benchmark": "priority",
+        "equivalent": true,
+        "runtime": 0.138264000415802,
+        "size_after": 893,
+        "size_before": 978
+      },
+      {
+        "benchmark": "router",
+        "equivalent": true,
+        "runtime": 0.07094299793243408,
+        "size_after": 252,
+        "size_before": 257
+      },
+      {
+        "benchmark": "voter",
+        "equivalent": true,
+        "runtime": 3.2217791080474854,
+        "size_after": 11573,
+        "size_before": 13758
+      }
+    ],
+    "version": "c858d44"
+  }
+]

--- a/experiments/experiments.hpp
+++ b/experiments/experiments.hpp
@@ -188,7 +188,7 @@ public:
                       {"entries", entries}} );
 
     std::ofstream os( filename_, std::ofstream::out );
-    os << data_.dump() << "\n";
+    os << data_.dump( 2 ) << "\n";
   }
 
   void operator()( ColumnTypes... args )

--- a/include/mockturtle/algorithms/aig_resub.hpp
+++ b/include/mockturtle/algorithms/aig_resub.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <mockturtle/algorithms/resubstitution.hpp>
+#include <mockturtle/networks/aig.hpp>
 
 namespace mockturtle
 {
@@ -379,6 +380,7 @@ public:
 
   std::optional<signal> resub_div12( node const& root, uint32_t required )
   {
+    (void)required;
     auto const s = ntk.make_signal( root );
     auto const& tt = sim.get_tt( s );
 

--- a/include/mockturtle/algorithms/cut_rewriting.hpp
+++ b/include/mockturtle/algorithms/cut_rewriting.hpp
@@ -690,7 +690,9 @@ void cut_rewriting( Ntk& ntk, RewritingFn&& rewriting_fn, cut_rewriting_params c
   }
   else
   {
-    fanout_view2<Ntk> ntk_fo{ntk};
+    fanout_view2_params fvps;
+    fvps.update_on_delete = false;
+    fanout_view2<Ntk> ntk_fo{ntk, fvps};
     detail::cut_rewriting_impl<fanout_view2<Ntk>, RewritingFn, NodeCostFn> p( ntk_fo, rewriting_fn, ps, st, cost_fn );
     p.run();
   }

--- a/include/mockturtle/algorithms/resubstitution.hpp
+++ b/include/mockturtle/algorithms/resubstitution.hpp
@@ -482,49 +482,15 @@ public:
       update_node_level( n );
     };
 
-    auto const update_fanout_of_new_node = [&]( const auto& n ){
-      assert( ntk.fanin_size( n ) > 0 );
-      ntk.resize_fanout();
-
-      /* update fanout */
-      ntk.foreach_fanin( n, [&]( const auto& f ){
-          auto const p = ntk.get_node( f );
-          ntk.add_fanout( p, n );
-        });
-    };
-
-    auto const update_fanout_of_existing_node = [&]( const auto& n, const auto& old_children ){
-      /* update fanout */
-      for ( const auto& c : old_children )
-        ntk.remove_fanout( ntk.get_node( c ), n );
-
-      ntk.foreach_fanin( n, [&]( const auto& f ){
-          auto const p = ntk.get_node( f );
-          ntk.add_fanout( p, n );
-        });
-    };
-
-    auto const update_fanout_of_deleted_node = [&]( const auto& n ){
-      /* update fanout */
-      ntk.set_fanout( n, {} );
-      ntk.foreach_fanin( n, [&]( const auto& f ){
-          auto const p = ntk.get_node( f );
-          ntk.remove_fanout( p, n );
-        });
-    };
-
     auto const update_level_of_deleted_node = [&]( const auto& n ){
       /* update fanout */
       ntk.set_level( n, -1 );
     };
 
-    ntk._events->on_add.emplace_back( update_fanout_of_new_node );
     ntk._events->on_add.emplace_back( update_level_of_new_node );
 
-    ntk._events->on_modified.emplace_back( update_fanout_of_existing_node );
     ntk._events->on_modified.emplace_back( update_level_of_existing_node );
 
-    ntk._events->on_delete.emplace_back( update_fanout_of_deleted_node );
     ntk._events->on_delete.emplace_back( update_level_of_deleted_node );
   }
 

--- a/include/mockturtle/algorithms/resubstitution.hpp
+++ b/include/mockturtle/algorithms/resubstitution.hpp
@@ -183,6 +183,7 @@ public:
 
     /* reference it back */
     auto count2 = node_ref_rec( n );
+    (void)count2;
     assert( count1 == count2 );
 
     for ( const auto& l : leaves )

--- a/include/mockturtle/views/fanout_view2.hpp
+++ b/include/mockturtle/views/fanout_view2.hpp
@@ -140,30 +140,9 @@ public:
     compute_fanout();
   }
 
-  void resize_fanout()
-  {
-    _fanout.resize();
-  }
-
   std::vector<node> fanout( node const& n ) const /* deprecated */
   {
     return _fanout[ n ];
-  }
-
-  void set_fanout( node const& n, std::vector<node> const& fanout )
-  {
-    _fanout[ n ] = fanout;
-  }
-
-  void add_fanout( node const& n, node const& p )
-  {
-    _fanout[ n ].emplace_back( p );
-  }
-
-  void remove_fanout( node const& n, node const& p )
-  {
-    auto &f = _fanout[ n ];
-    f.erase( std::remove( f.begin(), f.end(), p ), f.end() );
   }
 
   void substitute_node( node const& old_node, signal const& new_signal )
@@ -191,26 +170,6 @@ public:
       // reset fan-in of old node
       Ntk::take_out_node( _old );
     }
-  }
-
-  void substitute_node_of_parents( std::vector<node> const& parents, node const& old_node, signal const& new_signal ) /* deprecated */
-  {
-    Ntk::substitute_node_of_parents( parents, old_node, new_signal );
-
-    std::vector<node> old_node_fanout = _fanout[ old_node ];
-    std::sort( old_node_fanout.begin(), old_node_fanout.end() );
-
-    std::vector<node> parents_copy( parents );
-    std::sort( parents_copy.begin(), parents_copy.end() );
-
-    _fanout[ old_node ] = {};
-
-    std::vector<node> intersection;
-    std::set_intersection( parents_copy.begin(), parents_copy.end(), old_node_fanout.begin(), old_node_fanout.end(),
-                           std::back_inserter( intersection ) );
-
-    resize_fanout();
-    set_fanout( this->get_node( new_signal ), intersection );
   }
 
 private:


### PR DESCRIPTION
This PR updates `fanout_view2` to obtain consistent results with resubstitution. Eventually fanout_view2 will replace fanout_view.
