### PR TITLE
Generate CNF from logic network

### DIFF
--- a/docs/algorithms/cnf.rst
+++ b/docs/algorithms/cnf.rst
@@ -1,0 +1,22 @@
+CNF generation
+--------------
+
+**Header:** ``mockturtle/algorithms/cnf.hpp``
+
+The following code shows how to create clauses for a SAT solver based on a
+network.
+
+.. code-block:: c++
+
+   /* derive some XAG (can be any network type) */
+   xag_network xag = ...;
+
+   percy::bsat_wrapper solver;
+   const auto output_lits = generate_cnf( xag, [&]( auto const& clause ) {
+     solver.add_clause( clause );
+   } );
+
+.. doxygenfunction:: mockturtle::node_literals
+.. doxygenfunction:: mockturtle::generate_cnf
+.. doxygentypedef:: mockturtle::clause_callback_t
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ v0.2 (not yet released)
 -----------------------
 
 * Framework for performing quality and performance experiments `#140 <https://github.com/lsils/mockturtle/pull/140>`_
+* Algorithms:
+    - CNF generation (`generate_cnf`) `#145 <https://github.com/lsils/mockturtle/pull/145>`_
 
 v0.1 (March 31, 2019)
 ---------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ Welcome to mockturtle's documentation!
    algorithms/simulation
    algorithms/dsd_decomposition
    algorithms/cleanup
+   algorithms/cnf
    algorithms/reconv_cut
    algorithms/dont_cares
    algorithms/gates_to_nodes

--- a/include/mockturtle/algorithms/cnf.hpp
+++ b/include/mockturtle/algorithms/cnf.hpp
@@ -1,0 +1,243 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2019  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file cnf.hpp
+  \brief CNF generation methods
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include <kitty/constructors.hpp>
+#include <kitty/cnf.hpp>
+
+#include "../traits.hpp"
+#include "../utils/node_map.hpp"
+
+namespace mockturtle
+{
+
+using clause_callback_t = std::function<void( std::vector<uint32_t> const& )>;
+
+namespace detail
+{
+
+template<class Ntk>
+class generate_cnf_impl
+{
+public:
+  generate_cnf_impl( Ntk const& ntk, clause_callback_t const& fn )
+      : ntk_( ntk ),
+        fn_( fn ),
+        node_vars_( ntk )
+  {
+  }
+
+  std::vector<uint32_t> run()
+  {
+    // TODO constants
+
+    /* first indexes are for PIs */
+    ntk_.foreach_pi( [&]( auto const& n, auto i ) {
+      node_vars_[n] = i;
+    } );
+
+    /* compute vars for nodes */
+    uint32_t next_var = ntk_.num_pis();
+    ntk_.foreach_gate( [&]( auto const& n ) {
+      node_vars_[n] = next_var++;
+    } );
+
+    /* compute clauses for nodes */
+    ntk_.foreach_gate( [&]( auto const& n ) {
+      std::vector<uint32_t> child_lits;
+      ntk_.foreach_fanin( n, [&]( auto const& f ) {
+        child_lits.push_back( make_lit( node_vars_[f], ntk_.is_complemented( f ) ) );
+      } );
+      uint32_t node_lit = make_lit( node_vars_[n], false );
+
+      if constexpr ( has_is_and_v<Ntk> )
+      {
+        if ( ntk_.is_and( n ) )
+        {
+          on_and( node_lit, child_lits[0], child_lits[1] );
+          return true;
+        }
+      }
+
+      if constexpr ( has_is_or_v<Ntk> )
+      {
+        if ( ntk_.is_or( n ) )
+        {
+          on_or( node_lit, child_lits[0], child_lits[1] );
+          return true;
+        }
+      }
+
+      if constexpr ( has_is_xor_v<Ntk> )
+      {
+        if ( ntk_.is_xor( n ) )
+        {
+          on_xor( node_lit, child_lits[0], child_lits[1] );
+          return true;
+        }
+      }
+
+      if constexpr ( has_is_maj_v<Ntk> )
+      {
+        if ( ntk_.is_maj( n ) )
+        {
+          on_maj( node_lit, child_lits[0], child_lits[1], child_lits[2] );
+          return true;
+        }
+      }
+
+      if constexpr ( has_is_ite_v<Ntk> )
+      {
+        if ( ntk_.is_ite( n ) )
+        {
+          on_ite( node_lit, child_lits[0], child_lits[1], child_lits[2] );
+          return true;
+        }
+      }
+
+      if constexpr ( has_is_xor3_v<Ntk> )
+      {
+        if ( ntk_.is_xor3( n ) )
+        {
+          on_xor3( node_lit, child_lits[0], child_lits[1], child_lits[2] );
+          return true;
+        }
+      }
+
+      // TODO general case
+      const auto cnf = kitty::cnf_characteristic( ntk_.node_function( n ) );
+
+      assert( false );
+      return true;
+    } );
+
+    std::vector<uint32_t> output_lits;
+    ntk_.foreach_po( [&]( auto const& f ) {
+      output_lits.push_back( make_lit( node_vars_[f], ntk_.is_complemented( f ) ) );
+    } );
+
+    return output_lits;
+  }
+
+private:
+  /* c = a & b */
+  inline void on_and( uint32_t c, uint32_t a, uint32_t b )
+  {
+    fn_( {a, lit_not( c )} );
+    fn_( {b, lit_not( c )} );
+    fn_( {lit_not( a ), lit_not( b ), c} );
+  }
+
+  /* c = a | b */
+  inline void on_or( uint32_t c, uint32_t a, uint32_t b )
+  {
+    fn_( {lit_not( a ), c} );
+    fn_( {lit_not( b ), c} );
+    fn_( {a, b, lit_not( c )} );
+  }
+
+  /* c = a ^ b */
+  inline void on_xor( uint32_t c, uint32_t a, uint32_t b )
+  {
+    fn_( {lit_not( a ), lit_not( b ), lit_not( c )} );
+    fn_( {lit_not( a ), b, c} );
+    fn_( {a, lit_not( b ), c} );
+    fn_( {a, b, lit_not( c )} );
+  }
+
+  /* d = <abc> */
+  inline void on_maj( uint32_t d, uint32_t a, uint32_t b, uint32_t c )
+  {
+    fn_( {lit_not( a ), lit_not( b ), d} );
+    fn_( {lit_not( a ), lit_not( c ), d} );
+    fn_( {lit_not( b ), lit_not( c ), d} );
+    fn_( {a, b, lit_not( d )} );
+    fn_( {a, c, lit_not( d )} );
+    fn_( {b, c, lit_not( d )} );
+  }
+
+  /* d = a ^ b ^ c */
+  inline void on_xor3( uint32_t d, uint32_t a, uint32_t b, uint32_t c )
+  {
+    fn_( {lit_not( a ), b, c, d} );
+    fn_( {a, lit_not( b ), c, d} );
+    fn_( {a, b, lit_not( c ), d} );
+    fn_( {a, b, c, lit_not( d )} );
+    fn_( {a, lit_not( b ), lit_not( c ), lit_not( d )} );
+    fn_( {lit_not( a ), b, lit_not( c ), lit_not( d )} );
+    fn_( {lit_not( a ), lit_not( b ), c, lit_not( d )} );
+    fn_( {lit_not( a ), lit_not( b ), lit_not( c ), d} );
+  }
+
+  /* d = a ? b : c */
+  inline void on_ite( uint32_t d, uint32_t a, uint32_t b, uint32_t c )
+  {
+    fn_( {lit_not( a ), lit_not( b ), d} );
+    fn_( {lit_not( a ), b, lit_not( d )} );
+    fn_( {a, lit_not( c ), d} );
+    fn_( {a, c, lit_not( d )} );
+  }
+
+  constexpr uint32_t make_lit( uint32_t var, bool is_complemented ) const
+  {
+    return ( var << 1 ) | ( is_complemented ? 1 : 0 );
+  }
+
+  constexpr uint32_t lit_not( uint32_t lit ) const
+  {
+    return lit ^ 0x1;
+  }
+
+private:
+  Ntk const& ntk_;
+  clause_callback_t const& fn_;
+
+  node_map<uint32_t, Ntk> node_vars_;
+};
+
+} // namespace detail
+
+template<class Ntk>
+std::vector<uint32_t> generate_cnf( Ntk const& ntk, clause_callback_t const& fn )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+
+  detail::generate_cnf_impl<Ntk> impl( ntk, fn );
+  return impl.run();
+}
+
+} // namespace mockturtle

--- a/lib/abcsat/abc/satSolver.h
+++ b/lib/abcsat/abc/satSolver.h
@@ -355,6 +355,7 @@ static inline int sat_solver_add_const( sat_solver * pSat, int iVar, int fCompl 
     Lits[0] = toLitCond( iVar, fCompl );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 1 );
     assert( Cid );
+    (void)Cid;
     return 1;
 }
 static inline int sat_solver_add_buffer( sat_solver * pSat, int iVarA, int iVarB, int fCompl )
@@ -395,6 +396,7 @@ static inline int sat_solver_add_buffer_enable( sat_solver * pSat, int iVarA, in
     Lits[2] = toLitCond( iVarEn, 1 );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 3 );
     assert( Cid );
+    (void)Cid;
     return 2;
 }
 static inline int sat_solver_add_and( sat_solver * pSat, int iVar, int iVar0, int iVar1, int fCompl0, int fCompl1, int fCompl )
@@ -417,6 +419,7 @@ static inline int sat_solver_add_and( sat_solver * pSat, int iVar, int iVar0, in
     Lits[2] = toLitCond( iVar1, !fCompl1 );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 3 );
     assert( Cid );
+    (void)Cid;
     return 3;
 }
 static inline int sat_solver_add_xor( sat_solver * pSat, int iVarA, int iVarB, int iVarC, int fCompl )
@@ -448,6 +451,7 @@ static inline int sat_solver_add_xor( sat_solver * pSat, int iVarA, int iVarB, i
     Lits[2] = toLitCond( iVarC, 1 );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 3 );
     assert( Cid );
+    (void)Cid;
     return 4;
 }
 static inline int sat_solver_add_mux( sat_solver * pSat, int iVarZ, int iVarC, int iVarT, int iVarE, int iComplC, int iComplT, int iComplE, int iComplZ )
@@ -494,6 +498,7 @@ static inline int sat_solver_add_mux( sat_solver * pSat, int iVarZ, int iVarC, i
     Lits[2] = toLitCond( iVarZ, 0 ^ iComplZ );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 3 );
     assert( Cid );
+    (void)Cid;
     return 6;
 }
 static inline int sat_solver_add_mux41( sat_solver * pSat, int iVarZ, int iVarC0, int iVarC1, int iVarD0, int iVarD1, int iVarD2, int iVarD3 )
@@ -558,6 +563,7 @@ static inline int sat_solver_add_mux41( sat_solver * pSat, int iVarZ, int iVarC0
     Lits[3] = toLitCond( iVarZ,  1 );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 4 );
     assert( Cid );
+    (void)Cid;
     return 8;
 }
 static inline int sat_solver_add_xor_and( sat_solver * pSat, int iVarF, int iVarA, int iVarB, int iVarC )
@@ -597,6 +603,7 @@ static inline int sat_solver_add_xor_and( sat_solver * pSat, int iVarF, int iVar
     Lits[3] = toLitCond( iVarC, 1 );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 4 );
     assert( Cid );
+    (void)Cid;
     return 5;
 }
 static inline int sat_solver_add_constraint( sat_solver * pSat, int iVar, int iVar2, int fCompl )
@@ -614,6 +621,7 @@ static inline int sat_solver_add_constraint( sat_solver * pSat, int iVar, int iV
     Lits[1] = toLitCond( iVar2, 1 );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 2 );
     assert( Cid );
+    (void)Cid;
     return 2;
 }
 
@@ -637,6 +645,7 @@ static inline int sat_solver_add_half_sorter( sat_solver * pSat, int iVarA, int 
     Lits[2] = toLitCond( iVar1, 1 );
     Cid = sat_solver_addclause( pSat, Lits, Lits + 3 );
     assert( Cid );
+    (void)Cid;
     return 3;
 }
 

--- a/lib/abcsat/abc/utilDouble.h
+++ b/lib/abcsat/abc/utilDouble.h
@@ -183,6 +183,8 @@ static inline void Xdbl_Test()
     xdbl ten100_ = ABC_CONST(0x014c924d692ca61b);
 
     assert( ten100 == ten100_ );
+    (void)ten100;
+    (void)ten100_;
 
 //    float f1 = Xdbl_ToDouble(c1);
 //    Extra_PrintBinary( stdout, (int *)&c1, 32 ); printf( "\n" );

--- a/lib/percy/percy/solvers/bsat2.hpp
+++ b/lib/percy/percy/solvers/bsat2.hpp
@@ -2,6 +2,9 @@
 
 #include "solver_wrapper.hpp"
 
+#include <cstdint>
+#include <vector>
+
 namespace percy
 {
     class bsat_wrapper : public solver_wrapper
@@ -49,6 +52,13 @@ namespace percy
         int add_clause(pabc::lit* begin, pabc::lit* end)
         {
             return pabc::sat_solver_addclause(solver, begin, end);
+        }
+
+        /* mockturtle style clause */
+        int add_clause(std::vector<uint32_t> const& clause)
+        {
+            auto lits = (int*)(const_cast<uint32_t*>(clause.data()));
+            return pabc::sat_solver_addclause(solver, lits, lits + clause.size());
         }
 
         void add_var()

--- a/test/algorithms/cnf.cpp
+++ b/test/algorithms/cnf.cpp
@@ -27,9 +27,9 @@ TEST_CASE( "Translate XAG into CNF", "[cnf]" )
     solver.add_clause( clause );
   } )[0];
 
-  CHECK( output == 11 );
+  CHECK( output == 13 );
 
   const auto res = solver.solve( &output, &output + 1, 0 );
   CHECK( res == percy::synth_result::success );
-  CHECK( solver.var_value( 0u ) != solver.var_value( 1u ) ); /* input values are different */
+  CHECK( solver.var_value( 1u ) != solver.var_value( 2u ) ); /* input values are different */
 }

--- a/test/algorithms/cnf.cpp
+++ b/test/algorithms/cnf.cpp
@@ -1,0 +1,37 @@
+#include <catch.hpp>
+
+#include <mockturtle/algorithms/cnf.hpp>
+#include <mockturtle/networks/xag.hpp>
+
+#include <fmt/format.h>
+#include <percy/solvers/bsat2.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "Translate XAG into CNF", "[cnf]" )
+{
+  xag_network xag;
+
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+
+  const auto f1 = xag.create_nand( a, b );
+  const auto f2 = xag.create_nand( a, f1 );
+  const auto f3 = xag.create_nand( b, f1 );
+  const auto f4 = xag.create_nand( f2, f3 );
+
+  xag.create_po( f4 );
+
+  percy::bsat_wrapper solver;
+  int output = generate_cnf( xag, [&]( auto const& clause ) {
+    //auto lits = (int*)( const_cast<uint32_t*>( clause.data() ) );
+    //solver.add_clause( lits, lits + clause.size() );
+    solver.add_clause( clause );
+  } )[0];
+
+  CHECK( output == 11 );
+
+  const auto res = solver.solve( &output, &output + 1, 0 );
+  CHECK( res == percy::synth_result::success );
+  CHECK( solver.var_value( 0u ) != solver.var_value( 1u ) ); /* input values are different */
+}

--- a/test/algorithms/cnf.cpp
+++ b/test/algorithms/cnf.cpp
@@ -24,8 +24,6 @@ TEST_CASE( "Translate XAG into CNF", "[cnf]" )
 
   percy::bsat_wrapper solver;
   int output = generate_cnf( xag, [&]( auto const& clause ) {
-    //auto lits = (int*)( const_cast<uint32_t*>( clause.data() ) );
-    //solver.add_clause( lits, lits + clause.size() );
     solver.add_clause( clause );
   } )[0];
 

--- a/test/algorithms/cnf.cpp
+++ b/test/algorithms/cnf.cpp
@@ -93,10 +93,9 @@ TEST_CASE( "Use CNF generation for CEC on XAG", "[cnf]" )
     solver.add_clause( clause );
   } )[0];
 
-  auto lits = node_literals( xag2, xag1.size() );
   auto output2 = generate_cnf( xag2, [&]( auto const& clause ) {
     solver.add_clause( clause );
-  }, &lits )[0];
+  }, std::make_optional( node_literals( xag2, xag1.size() ) ) )[0];
 
   CHECK( output1 == 13 );
   CHECK( output2 == 14 );


### PR DESCRIPTION
This PR implements a generic function to generate CNF from a logic network. The CNF is passed in terms of a callback back to the user. Therefore, the function can, e.g., be used to initialise a SAT solver or to write a DIMACS file.
