### PR TITLE
Write network's CNF into DIMACS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ v0.2 (not yet released)
 * Algorithms:
     - CNF generation (`generate_cnf`) `#145 <https://github.com/lsils/mockturtle/pull/145>`_
     - SAT-based LUT mapping (`satlut_mapping`) `#122 <https://github.com/lsils/mockturtle/pull/122>`_
+* I/O:
+    - Write networks to DIMACS files for CNF (`write_dimacs`) `#146 <https://github.com/lsils/mockturtle/pull/146>`_
 
 v0.1 (March 31, 2019)
 ---------------------

--- a/docs/io/writers.rst
+++ b/docs/io/writers.rst
@@ -19,6 +19,15 @@ Write into structural Verilog files
 
 .. doxygenfunction:: mockturtle::write_verilog(Ntk const&, std::ostream&)
 
+Write into DIMACS files (CNF)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Header:** ``mockturtle/io/write_cnf.hpp``
+
+.. doxygenfunction:: mockturtle::write_dimacs(Ntk const&, std::string const&)
+
+.. doxygenfunction:: mockturtle::write_dimacs(Ntk const&, std::ostream&)
+
 Write into DOT files (Graphviz)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/mockturtle/io/write_dimacs.hpp
+++ b/include/mockturtle/io/write_dimacs.hpp
@@ -1,0 +1,99 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2019  EPFL EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file write_dimacs.hpp
+  \brief Write networks CNF encoding to DIMACS format
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <fmt/format.h>
+
+#include "../traits.hpp"
+#include "../algorithms/cnf.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Writes network into CNF DIMACS format
+ *
+ * It also adds unit clauses for the outputs.  Therefore a satisfying solution
+ * is one that makes all outputs 1.
+ *
+ * \param ntk Logic network
+ * \param out Output stream
+ */
+template<class Ntk>
+void write_dimacs( Ntk const& ntk, std::ostream& out = std::cout )
+{
+  std::stringstream clauses;
+  uint32_t num_clauses = 0u;
+
+  const auto lits = generate_cnf( ntk, [&]( std::vector<uint32_t> const& clause ) {
+    for ( auto lit : clause ) {
+      const auto var = ( lit / 2 ) + 1;
+      const auto pol = lit % 2;
+      clauses << fmt::format( "{}{} ", pol ? "-" : "", var );
+    }
+    clauses << fmt::format( "0\n" );
+    ++num_clauses;
+  } );
+
+  for ( auto lit : lits ) {
+    const auto var = ( lit / 2 ) + 1;
+    const auto pol = lit % 2;
+    clauses << fmt::format( "{}{} 0\n", pol ? "-" : "", var );
+    ++num_clauses;
+  }
+
+  out << fmt::format( "p cnf {} {}\n{}", ntk.size(), num_clauses, clauses.str() );
+}
+
+/*! \brief Writes network into CNF DIMACS format
+ *
+ * It also adds unit clauses for the outputs.  Therefore a satisfying solution
+ * is one that makes all outputs 1.
+ *
+ * \param ntk Logic network
+ * \param filename Filename
+ */
+template<class Ntk>
+void write_dimacs( Ntk const& ntk, std::string const& filename )
+{
+  std::ofstream os( filename.c_str(), std::ofstream::out );
+  write_dimacs( ntk, os );
+  os.close();
+}
+
+} /* namespace mockturtle */

--- a/test/io/write_dimacs.cpp
+++ b/test/io/write_dimacs.cpp
@@ -1,0 +1,42 @@
+#include <catch.hpp>
+
+#include <sstream>
+
+#include <mockturtle/io/write_dimacs.hpp>
+#include <mockturtle/networks/xag.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "write XAG into DIMACS", "[write_dimacs]" )
+{
+  xag_network xag;
+
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+
+  const auto f1 = xag.create_nand( a, b );
+  const auto f2 = xag.create_nand( a, f1 );
+  const auto f3 = xag.create_nand( b, f1 );
+  const auto f4 = xag.create_nand( f2, f3 );
+
+  xag.create_po( f4 );
+
+  std::ostringstream out;
+  write_dimacs( xag, out );
+
+  CHECK( out.str() == "p cnf 7 14\n"
+                      "-1 0\n"
+                      "2 -4 0\n"
+                      "3 -4 0\n"
+                      "-2 -3 4 0\n"
+                      "2 -5 0\n"
+                      "-4 -5 0\n"
+                      "-2 4 5 0\n"
+                      "3 -6 0\n"
+                      "-4 -6 0\n"
+                      "-3 4 6 0\n"
+                      "-5 -7 0\n"
+                      "-6 -7 0\n"
+                      "5 6 7 0\n"
+                      "-7 0\n" );
+}


### PR DESCRIPTION
This PR uses the recent `generate_cnf` method to create a DIMACS CNF file. The represented SAT formula is satisfiable for all input assignments that lead to all 1s in the primary outputs of the network.