### PR TITLE
Combinational equivalence checking

### DIFF
--- a/docs/algorithms/equivalence_checking.rst
+++ b/docs/algorithms/equivalence_checking.rst
@@ -1,0 +1,41 @@
+Equivalence checking
+--------------------
+
+**Header:** ``mockturtle/algorithms/equivalence_checking.hpp``
+
+
+.. code-block:: c++
+
+   /* derive some AIG and make a copy */
+   aig_network aig = ...;
+   const auto orig = aig;
+
+   /* node resynthesis */
+   xag_npn_resynthesis<aig_network> resyn;
+   cut_rewriting_params ps;
+   ps.cut_enumeration_ps.cut_size = 4;
+   cut_rewriting( aig, resyn, ps );
+   aig = cleanup_dangling( aig );
+
+   const auto miter = *miter<aig_network>( orig, aig );
+   const auto result = equivalence_checking( miter );
+
+   /* result is an optional, which is nullopt if no solution was found */
+   if ( result && *result )
+   {
+     std::cout << "networks are equivalent\n";
+   }
+
+Parameters and statistics
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: mockturtle::equivalence_checking_params
+   :members:
+
+.. doxygenstruct:: mockturtle::equivalence_checking_stats
+   :members:
+
+Algorithm
+~~~~~~~~~
+
+.. doxygenfunction:: mockturtle::equivalence_checking

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ v0.2 (not yet released)
     - CNF generation (`generate_cnf`) `#145 <https://github.com/lsils/mockturtle/pull/145>`_
     - SAT-based LUT mapping (`satlut_mapping`) `#122 <https://github.com/lsils/mockturtle/pull/122>`_
     - Miter generation (`miter`) `#148 <https://github.com/lsils/mockturtle/pull/148>`_
+    - Combinational equivalence checking (`equivalence_checking`) `#149 <https://github.com/lsils/mockturtle/pull/149>`_
 * I/O:
     - Write networks to DIMACS files for CNF (`write_dimacs`) `#146 <https://github.com/lsils/mockturtle/pull/146>`_
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Welcome to mockturtle's documentation!
    algorithms/akers_synthesis
    algorithms/resubstitution
    algorithms/simulation
+   algorithms/equivalence_checking
    algorithms/miter
    algorithms/dsd_decomposition
    algorithms/cleanup

--- a/experiments/equivalence_checking.cpp
+++ b/experiments/equivalence_checking.cpp
@@ -1,0 +1,100 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2019  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <lorina/aiger.hpp>
+#include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/algorithms/cut_rewriting.hpp>
+#include <mockturtle/algorithms/equivalence_checking.hpp>
+#include <mockturtle/algorithms/miter.hpp>
+#include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
+#include <mockturtle/io/aiger_reader.hpp>
+#include <mockturtle/io/write_verilog.hpp>
+#include <mockturtle/networks/aig.hpp>
+
+#include <experiments.hpp>
+
+int main()
+{
+  using namespace experiments;
+  using namespace mockturtle;
+
+  std::unordered_map<std::string, double> baseline = {
+    {"adder", 0.00},
+    {"bar", 0.33},
+    {"div", 9.66},
+    {"hyp", 25.70},
+    {"log2", 9.74},
+    {"max", 0.21},
+    {"multiplier", 6.27},
+    {"sin", 1.97},
+    {"sqrt", 5.28},
+    {"square", 2.90},
+    {"arbiter", 0.01},
+    {"cavlc", 0.01},
+    {"ctrl", 0.01},
+    {"dec", 0.00},
+    {"i2c", 0.02},
+    {"int2float", 0.01},
+    {"mem_ctrl", 4.46},
+    {"priority", 0.06},
+    {"router", 0.01},
+    {"voter", 3.54}
+  };
+
+  experiment<std::string, double, double, bool> exp( "equivalence_checking", "benchmark", "abc cec", "runtime", "equivalent" );
+
+  for ( auto const& benchmark : epfl_benchmarks() )
+  {
+    fmt::print( "[i] processing {}\n", benchmark );
+    aig_network aig;
+    lorina::read_aiger( benchmark_path( benchmark ), aiger_reader( aig ) );
+    const auto orig = aig;
+
+    xag_npn_resynthesis<aig_network> resyn;
+
+    cut_rewriting_params ps;
+    ps.cut_enumeration_ps.cut_size = 4;
+    ps.progress = true;
+
+    cut_rewriting( aig, resyn, ps );
+    aig = cleanup_dangling( aig );
+
+    equivalence_checking_stats st;
+    auto cec = *equivalence_checking( *miter<aig_network>( orig, aig ), {}, &st );
+
+    write_verilog( aig, fmt::format( "/tmp/{}.v", benchmark ) );
+
+    exp( benchmark, baseline[benchmark], to_seconds( st.time_total ), cec );
+  }
+
+  exp.save();
+  exp.table();
+
+  return 0;
+}

--- a/experiments/equivalence_checking.json
+++ b/experiments/equivalence_checking.json
@@ -123,5 +123,130 @@
       }
     ],
     "version": "29b0bce"
+  },
+  {
+    "entries": [
+      {
+        "abc cec": 0.0,
+        "benchmark": "adder",
+        "equivalent": true,
+        "runtime": 0.002185
+      },
+      {
+        "abc cec": 0.33,
+        "benchmark": "bar",
+        "equivalent": true,
+        "runtime": 0.006054
+      },
+      {
+        "abc cec": 9.66,
+        "benchmark": "div",
+        "equivalent": true,
+        "runtime": 0.047581
+      },
+      {
+        "abc cec": 25.7,
+        "benchmark": "hyp",
+        "equivalent": true,
+        "runtime": 0.248725
+      },
+      {
+        "abc cec": 9.74,
+        "benchmark": "log2",
+        "equivalent": true,
+        "runtime": 0.033442
+      },
+      {
+        "abc cec": 0.21,
+        "benchmark": "max",
+        "equivalent": true,
+        "runtime": 0.006885
+      },
+      {
+        "abc cec": 6.27,
+        "benchmark": "multiplier",
+        "equivalent": true,
+        "runtime": 0.03398
+      },
+      {
+        "abc cec": 1.97,
+        "benchmark": "sin",
+        "equivalent": true,
+        "runtime": 0.007005
+      },
+      {
+        "abc cec": 5.28,
+        "benchmark": "sqrt",
+        "equivalent": true,
+        "runtime": 0.022294
+      },
+      {
+        "abc cec": 2.9,
+        "benchmark": "square",
+        "equivalent": true,
+        "runtime": 0.024027
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "arbiter",
+        "equivalent": true,
+        "runtime": 0.016019
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "cavlc",
+        "equivalent": true,
+        "runtime": 0.001599
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "ctrl",
+        "equivalent": true,
+        "runtime": 0.001168
+      },
+      {
+        "abc cec": 0.0,
+        "benchmark": "dec",
+        "equivalent": true,
+        "runtime": 0.001776
+      },
+      {
+        "abc cec": 0.02,
+        "benchmark": "i2c",
+        "equivalent": true,
+        "runtime": 0.004162
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "int2float",
+        "equivalent": true,
+        "runtime": 0.004208
+      },
+      {
+        "abc cec": 4.46,
+        "benchmark": "mem_ctrl",
+        "equivalent": true,
+        "runtime": 0.060122
+      },
+      {
+        "abc cec": 0.06,
+        "benchmark": "priority",
+        "equivalent": true,
+        "runtime": 0.00286
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "router",
+        "equivalent": true,
+        "runtime": 0.001309
+      },
+      {
+        "abc cec": 3.54,
+        "benchmark": "voter",
+        "equivalent": true,
+        "runtime": 0.015054
+      }
+    ],
+    "version": "70ac8c4"
   }
 ]

--- a/experiments/equivalence_checking.json
+++ b/experiments/equivalence_checking.json
@@ -1,0 +1,127 @@
+[
+  {
+    "entries": [
+      {
+        "abc cec": 0.0,
+        "benchmark": "adder",
+        "equivalent": true,
+        "runtime": 0.004775
+      },
+      {
+        "abc cec": 0.33,
+        "benchmark": "bar",
+        "equivalent": true,
+        "runtime": 0.012499
+      },
+      {
+        "abc cec": 9.66,
+        "benchmark": "div",
+        "equivalent": true,
+        "runtime": 0.047315
+      },
+      {
+        "abc cec": 25.7,
+        "benchmark": "hyp",
+        "equivalent": true,
+        "runtime": 0.244476
+      },
+      {
+        "abc cec": 9.74,
+        "benchmark": "log2",
+        "equivalent": true,
+        "runtime": 0.03381
+      },
+      {
+        "abc cec": 0.21,
+        "benchmark": "max",
+        "equivalent": true,
+        "runtime": 0.006366
+      },
+      {
+        "abc cec": 6.27,
+        "benchmark": "multiplier",
+        "equivalent": true,
+        "runtime": 0.03418
+      },
+      {
+        "abc cec": 1.97,
+        "benchmark": "sin",
+        "equivalent": true,
+        "runtime": 0.007252
+      },
+      {
+        "abc cec": 5.28,
+        "benchmark": "sqrt",
+        "equivalent": true,
+        "runtime": 0.022121
+      },
+      {
+        "abc cec": 2.9,
+        "benchmark": "square",
+        "equivalent": true,
+        "runtime": 0.023726
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "arbiter",
+        "equivalent": true,
+        "runtime": 0.016171
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "cavlc",
+        "equivalent": true,
+        "runtime": 0.001653
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "ctrl",
+        "equivalent": true,
+        "runtime": 0.001229
+      },
+      {
+        "abc cec": 0.0,
+        "benchmark": "dec",
+        "equivalent": true,
+        "runtime": 0.001423
+      },
+      {
+        "abc cec": 0.02,
+        "benchmark": "i2c",
+        "equivalent": true,
+        "runtime": 0.002754
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "int2float",
+        "equivalent": true,
+        "runtime": 0.001243
+      },
+      {
+        "abc cec": 4.46,
+        "benchmark": "mem_ctrl",
+        "equivalent": true,
+        "runtime": 0.053334
+      },
+      {
+        "abc cec": 0.06,
+        "benchmark": "priority",
+        "equivalent": true,
+        "runtime": 0.002573
+      },
+      {
+        "abc cec": 0.01,
+        "benchmark": "router",
+        "equivalent": true,
+        "runtime": 0.001317
+      },
+      {
+        "abc cec": 3.54,
+        "benchmark": "voter",
+        "equivalent": true,
+        "runtime": 0.01432
+      }
+    ],
+    "version": "29b0bce"
+  }
+]

--- a/include/mockturtle/algorithms/equivalence_checking.hpp
+++ b/include/mockturtle/algorithms/equivalence_checking.hpp
@@ -1,0 +1,181 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2019  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file equivalence_checking.hpp
+  \brief Combinational equivalence checking
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "../traits.hpp"
+#include "../utils/stopwatch.hpp"
+#include "cnf.hpp"
+
+#include <fmt/format.h>
+#include <percy/solvers/bsat2.hpp>
+
+namespace mockturtle
+{
+
+/*! \brief Parameters for equivalence_checking.
+ *
+ * The data structure `equivalence_checking_params` holds configurable
+ * parameters with default arguments for `equivalence_checking`.
+ */
+struct equivalence_checking_params
+{
+  /*! \brief Conflict limit for SAT solver.
+   *
+   * The default limit is 0, which means the number of conflicts is not used
+   * as a resource limit.
+   */
+  uint32_t conflict_limit{0u};
+
+  /* \brief Be verbose. */
+  bool verbose{false};
+};
+
+/*! \brief Statistics for equivalence_checking.
+ *
+ * The data structure `equivalence_checking_stats` provides data collected by
+ * running `equivalence_checking`.
+ */
+struct equivalence_checking_stats
+{
+  /*! \brief Total runtime. */
+  stopwatch<>::duration time_total{};
+
+  /*! \brief Counter-example, in case miter is not equivalent. */
+  std::vector<bool> counter_example;
+
+  void report() const
+  {
+    std::cout << fmt::format( "[i] total time     = {:>5.2f} secs\n", to_seconds( time_total ) );
+  }
+};
+
+namespace detail
+{
+
+template<class Ntk>
+class equivalence_checking_impl
+{
+public:
+  equivalence_checking_impl( Ntk const& miter, equivalence_checking_params const& ps, equivalence_checking_stats& st )
+      : miter_( miter ),
+        ps_( ps ),
+        st_( st )
+  {
+  }
+
+  std::optional<bool> run()
+  {
+    stopwatch<> t( st_.time_total );
+
+    percy::bsat_wrapper solver;
+    int output = generate_cnf( miter_, [&]( auto const& clause ) {
+      solver.add_clause( clause );
+    } )[0];
+
+    const auto res = solver.solve( &output, &output + 1, 0 );
+
+    switch ( res )
+    {
+    default:
+      return std::nullopt;
+    case percy::synth_result::success:
+    {
+      st_.counter_example.clear();
+      for ( auto i = 1u; i <= miter_.num_pis(); ++i )
+      {
+        st_.counter_example.push_back( solver.var_value( i ) );
+      }
+      return false;
+    }
+    case percy::synth_result::failure:
+      return true;
+    }
+  }
+
+private:
+  Ntk const& miter_;
+  equivalence_checking_params const& ps_; 
+  equivalence_checking_stats& st_;
+};
+
+} // namespace detail
+
+/*! \brief Combinational equivalence checking.
+ *
+ * This function expects as input a miter circuit that can be generated, e.g.,
+ * with the function `miter`.  It returns an optional which is `nullopt`, if no
+ * solution can be found (this happens when a resource limit is set using the
+ * function's parameters).  Otherwise it returns `true`, if the miter is
+ * equivalent or `false`, if the miter is not equivalent.  In the latter case
+ * the counter example is written to the statistics pointer as a
+ * `std::vector<bool>` following the same order as the primary inputs.
+ *
+ * \param miter Miter network
+ * \param ps Parameters
+ * \param st Statistics
+ */
+template<class Ntk>
+std::optional<bool> equivalence_checking( Ntk const& miter, equivalence_checking_params const& ps = {}, equivalence_checking_stats* pst = nullptr )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_num_pis_v<Ntk>, "Ntk does not implement the num_pis method" );
+  static_assert( has_num_pos_v<Ntk>, "Ntk does not implement the num_pos method" );
+
+  if ( miter.num_pos() != 1u )
+  {
+    std::cout << "[e] miter network must have a single output\n";
+    return std::nullopt;
+  }
+
+  equivalence_checking_stats st;
+  detail::equivalence_checking_impl<Ntk> impl( miter, ps, st );
+  const auto result = impl.run();
+
+  if ( ps.verbose )
+  {
+    st.report();
+  }
+
+  if ( pst )
+  {
+    *pst = st;
+  }
+
+  return result;
+}
+
+} /* namespace mockturtle */

--- a/test/algorithms/equivalence_checking.cpp
+++ b/test/algorithms/equivalence_checking.cpp
@@ -1,0 +1,74 @@
+#include <catch.hpp>
+
+#include <vector>
+
+#include <mockturtle/algorithms/equivalence_checking.hpp>
+#include <mockturtle/algorithms/miter.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xag.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "Equivalence check on two XAGs", "[equivalence_checking]" )
+{
+  xag_network xag1, xag2;
+
+  const auto a = xag1.create_pi();
+  const auto b = xag1.create_pi();
+
+  const auto f1 = xag1.create_nand( a, b );
+  const auto f2 = xag1.create_nand( a, f1 );
+  const auto f3 = xag1.create_nand( b, f1 );
+  const auto f4 = xag1.create_nand( f2, f3 );
+
+  xag1.create_po( f4 );
+
+  const auto a_ = xag2.create_pi();
+  const auto b_ = xag2.create_pi();
+
+  const auto f1_ = xag2.create_xor( a_, b_ );
+
+  xag2.create_po( f1_ );
+
+  const auto miter_ntk = *miter<xag_network>( xag1, xag2 );
+
+  CHECK( miter_ntk.num_pos() == 1u );
+
+  const auto result = equivalence_checking( miter_ntk );
+
+  CHECK( result );
+  CHECK( *result );
+}
+
+TEST_CASE( "Equivalence check on two non-equivalent AIGs", "[equivalence_checking]" )
+{
+  aig_network aig1, aig2;
+
+  const auto a = aig1.create_pi();
+  const auto b = aig1.create_pi();
+
+  const auto f1 = aig1.create_nand( a, b );
+  const auto f2 = aig1.create_nand( a, f1 );
+  const auto f3 = aig1.create_nand( b, f1 );
+  const auto f4 = aig1.create_nand( f2, f3 );
+
+  aig1.create_po( f4 );
+
+  const auto a_ = aig2.create_pi();
+  const auto b_ = aig2.create_pi();
+
+  const auto f1_ = aig2.create_or( a_, b_ );
+
+  aig2.create_po( f1_ );
+
+  const auto miter_ntk = *miter<aig_network>( aig1, aig2 );
+
+  CHECK( miter_ntk.num_pos() == 1u );
+
+  equivalence_checking_stats st;
+  const auto result = equivalence_checking( miter_ntk, {}, &st );
+
+  CHECK( result );
+  CHECK( !*result );
+  CHECK( st.counter_example == std::vector<bool>( {true, true} ) );
+}


### PR DESCRIPTION
This PR implements combinational equivalence checking expecting as input a miter circuit. It uses `generate_cnf` to feed the SAT solver with clauses. It can produce a counter example.