### PR TITLE
Show summary of experiments in comparison table (if wanted)

### DIFF
--- a/experiments/cut_rewriting.cpp
+++ b/experiments/cut_rewriting.cpp
@@ -66,7 +66,7 @@ int main()
   }
 
   exp.save();
-  exp.compare();
+  exp.compare( {}, {}, {"size_after"});
 
   return 0;
 }


### PR DESCRIPTION
With this PR, one can specify some columns to track in the comparison table. After the table is printed, a summary informs about how many values change for the specified columns. This is useful when e.g. making sure that values in a column should not change. In the future, more detailed statistics can be given (e.g., how many times a value got smaller or larger).