### PR TITLE
verilog_writer.

### DIFF
--- a/include/mockturtle/io/write_verilog.hpp
+++ b/include/mockturtle/io/write_verilog.hpp
@@ -111,6 +111,8 @@ void write_verilog( Ntk const& ntk, std::ostream& os )
   static_assert( has_is_maj_v<Ntk>, "Ntk does not implement the is_maj method" );
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
 
+  assert( ntk.is_combinational() && "Network has to be combinational" );
+
   std::vector<std::string> xs;
   for ( auto i = 0u; i < ntk.num_pis(); ++i )
     xs.emplace_back( fmt::format( "x{}", i ) );

--- a/include/mockturtle/io/write_verilog.hpp
+++ b/include/mockturtle/io/write_verilog.hpp
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <string>
 
+#include <lorina/verilog.hpp>
 #include <ez/direct_iterator.hpp>
 #include <fmt/format.h>
 
@@ -53,16 +54,15 @@ using namespace std::string_literals;
 namespace detail
 {
 
-template<int Fanin, class Ntk>
-std::pair<std::array<std::string, Fanin>, std::array<std::string, Fanin>>
+template<class Ntk>
+std::vector<std::pair<bool, std::string>>
 format_fanin( Ntk const& ntk, node<Ntk> const& n, node_map<std::string, Ntk>& node_names )
 {
-  std::array<std::string, Fanin> children, inv;
-  ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
-    children[i] = node_names[f];
-    inv[i] = ntk.is_complemented( f ) ? "~" : "";
-  } );
-  return {children, inv};
+  std::vector<std::pair<bool, std::string>> children;
+  ntk.foreach_fanin( n, [&]( auto const& f ) {
+      children.emplace_back( std::make_pair( ntk.is_complemented( f ), node_names[f] ) );
+    });
+  return children;
 }
 
 } // namespace detail
@@ -111,24 +111,26 @@ void write_verilog( Ntk const& ntk, std::ostream& os )
   static_assert( has_is_maj_v<Ntk>, "Ntk does not implement the is_maj method" );
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
 
-  const auto xs = map_and_join( ez::make_direct_iterator<decltype( ntk.num_pis() )>( 0 ),
-                                ez::make_direct_iterator( ntk.num_pis() ),
-                                []( auto i ) { return fmt::format( "x{}", i ); }, ", "s );
-  const auto ys = map_and_join( ez::make_direct_iterator<decltype( ntk.num_pis() )>( 0 ),
-                                ez::make_direct_iterator( ntk.num_pos() ),
-                                []( auto i ) { return fmt::format( "y{}", i ); }, ", "s );
+  std::vector<std::string> xs;
+  for ( auto i = 0u; i < ntk.num_pis(); ++i )
+    xs.emplace_back( fmt::format( "x{}", i ) );
 
-  os << fmt::format( "module top({}, {});\n", xs, ys )
-     << fmt::format( "  input {};\n", xs )
-     << fmt::format( "  output {};\n", ys );
+  std::vector<std::string> ys;
+  for ( auto i = 0u; i < ntk.num_pos(); ++i )
+    ys.emplace_back( fmt::format( "y{}", i ) );
+
+  std::vector<std::string> ws;
+  ntk.foreach_gate( [&]( auto const& n ){
+      ws.emplace_back( fmt::format( "n{}", ntk.node_to_index( n ) ) );
+    });
+
+  lorina::verilog_writer writer( os );
+  writer.on_module_begin( "top", xs, ys, ws );
 
   node_map<std::string, Ntk> node_names( ntk );
-
   node_names[ntk.get_constant( false )] = "1'b0";
   if ( ntk.get_node( ntk.get_constant( false ) ) != ntk.get_node( ntk.get_constant( true ) ) )
-  {
     node_names[ntk.get_constant( true )] = "1'b1";
-  }
 
   ntk.foreach_pi( [&]( auto const& n, auto i ) {
     node_names[n] = fmt::format( "x{}", i );
@@ -136,84 +138,66 @@ void write_verilog( Ntk const& ntk, std::ostream& os )
 
   topo_view ntk_topo{ntk};
 
-  /* declare wires */
-  if ( ntk.num_gates() > 0 )
-  {
-    os << "  wire ";
-    auto first = true;
-    ntk.foreach_gate( [&]( auto const& n ) {
-        if ( first )
-          first = false;
-        else
-          os << ", ";
-        os << fmt::format( "n{}", ntk.node_to_index( n ) );
-      } );
-    os << ";\n";
-  }
-
   ntk_topo.foreach_node( [&]( auto const& n ) {
     if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
       return true;
 
+    /* assign a name */
+    node_names[n] = fmt::format( "n{}", ntk.node_to_index( n ) );
+
     if ( ntk.is_and( n ) )
     {
-      const auto [children, inv] = detail::format_fanin<2, Ntk>( ntk, n, node_names );
-      os << fmt::format( "  assign n{} = {}{} & {}{};\n", ntk.node_to_index( n ),
-                         inv[0], children[0], inv[1], children[1] );
+      writer.on_assign( node_names[n], detail::format_fanin<Ntk>( ntk, n, node_names ), "&" );
     }
     else if ( ntk.is_or( n ) )
     {
-      const auto [children, inv] = detail::format_fanin<2, Ntk>( ntk, n, node_names );
-      os << fmt::format( "  assign n{} = {}{} | {}{};\n", ntk.node_to_index( n ),
-                         inv[0], children[0], inv[1], children[1] );
+      writer.on_assign( node_names[n], detail::format_fanin<Ntk>( ntk, n, node_names ), "|" );
     }
-    else if ( ntk.is_xor( n ) )
+    else if ( ntk.is_xor( n ) || ntk.is_xor3( n ) )
     {
-      const auto [children, inv] = detail::format_fanin<2, Ntk>( ntk, n, node_names );
-      os << fmt::format( "  assign n{} = {}{} ^ {}{};\n", ntk.node_to_index( n ),
-                         inv[0], children[0], inv[1], children[1] );
-    }
-    else if ( ntk.is_xor3( n ) )
-    {
-      const auto [children, inv] = detail::format_fanin<3, Ntk>( ntk, n, node_names );
-      os << fmt::format( "  assign n{} = {}{} ^ {}{} ^ {}{};\n", ntk.node_to_index( n ),
-                         inv[0], children[0], inv[1], children[1], inv[2], children[2] );
+      writer.on_assign( node_names[n], detail::format_fanin<Ntk>( ntk, n, node_names ), "^" );
     }
     else if ( ntk.is_maj( n ) )
     {
-      signal<Ntk> first_child;
-      ntk.foreach_fanin( n, [&]( auto const& f ) { first_child = f; return false; } );
+      std::array<signal<Ntk>, 3> children;
+      ntk.foreach_fanin( n, [&]( auto const& f, auto i ) { children[i] = f; } );
 
-      const auto [children, inv] = detail::format_fanin<3, Ntk>( ntk, n, node_names );
-      if ( ntk.is_constant( ntk.get_node( first_child ) ) )
+      if ( ntk.is_constant( ntk.get_node( children[0u] ) ) )
       {
-        os << fmt::format( "  assign n{0} = {1}{3} {5} {2}{4};\n",
-                           ntk.node_to_index( n ),
-                           inv[1], inv[2], children[1], children[2],
-                           ntk.is_complemented( first_child ) ? "|" : "&" );
+        std::vector<std::pair<bool,std::string>> vs;
+        vs.emplace_back( std::make_pair( ntk.is_complemented( children[1u] ), node_names[ntk.get_node( children[1u] )] ) );
+        vs.emplace_back( std::make_pair( ntk.is_complemented( children[2u] ), node_names[ntk.get_node( children[2u] )] ) );
+
+        if ( ntk.is_complemented( children[0u] ) )
+        {
+          // or
+          writer.on_assign( node_names[n], {vs[0u], vs[1u]}, "|" );
+        }
+        else
+        {
+          // and
+          writer.on_assign( node_names[n], {vs[0u], vs[1u]}, "&" );
+        }
       }
       else
       {
-        os << fmt::format( "  assign n{0} = ({1}{4} & {2}{5}) | ({1}{4} & {3}{6}) | ({2}{5} & {3}{6});\n",
-                           ntk.node_to_index( n ),
-                           inv[0], inv[1], inv[2], children[0], children[1], children[2] );
+        writer.on_assign_maj3( node_names[n], detail::format_fanin<Ntk>( ntk, n, node_names ) );
       }
+
     }
     else
     {
-      os << fmt::format( "  assign n{} = unknown gate;\n", ntk.node_to_index( n ) );
+      writer.on_assign_unknown_gate( node_names[ n ] );
     }
 
-    node_names[n] = fmt::format( "n{}", ntk.node_to_index( n ) );
     return true;
   } );
 
   ntk.foreach_po( [&]( auto const& f, auto i ) {
-    os << fmt::format( "  assign y{} = {}{};\n", i, ntk.is_complemented( f ) ? "~" : "", node_names[f] );
+      writer.on_assign_po( fmt::format( "y{}", i ), std::make_pair( ntk.is_complemented( f ), node_names[f] ) );
   } );
 
-  os << "endmodule\n"
-     << std::flush;
+  writer.on_module_end();
 }
 
 /*! \brief Writes network in structural Verilog format into a file

--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -191,6 +191,11 @@ public:
     _storage->outputs.emplace_back( f );
   }
 
+  bool is_combinational() const
+  {
+    return true;
+  }
+
   bool is_constant( node const& n ) const
   {
     return n <= 1;

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -225,6 +225,12 @@ public:
     return _storage->data.latches[ index ];
   }
 
+  bool is_combinational() const
+  {
+    return ( static_cast<uint32_t>( _storage->inputs.size() ) == _storage->data.num_pis &&
+             static_cast<uint32_t>( _storage->outputs.size() ) == _storage->data.num_pos );
+  }
+
   bool is_constant( node const& n ) const
   {
     return n == 0;

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -189,6 +189,11 @@ public:
     _storage->outputs.emplace_back( f.index, f.complement );
   }
 
+  bool is_combinational() const
+  {
+    return true;
+  }
+
   bool is_constant( node const& n ) const
   {
     return n == 0;


### PR DESCRIPTION
A `lorina`-based writer for Verilog. Network signals (and signal names) are managed by `mockturtle`, strings are assembled via `lorina`.