### PR TITLE
Costs based on multiplicative complexity

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ v0.2 (not yet released)
     - Write networks to BLIF files (`write_blif`) `#169 <https://github.com/lsils/mockturtle/pull/169>`_
 * Generators for arithmetic circuits:
     - Sideways sum generator (`sideways_sum_adder`, contributed by Jovan Blanuša) `#159 <https://github.com/lsils/mockturtle/pull/159>`_
+* Properties:
+    - Costs based on multiplicative complexity (`multiplicative_complexity` and `multiplicative_complexity_depth`) `#170 <https://github.com/lsils/mockturtle/pull/170>`_
 
 v0.1 (March 31, 2019)
 ---------------------

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -10,3 +10,15 @@ be used to compute costs relevant in majority-based emerging technologies.
 .. doxygenfunction:: mockturtle::num_inverters
 
 .. doxygenfunction:: mockturtle::num_dangling_inputs
+
+
+
+Multiplicative complexity costs
+-------------------------------
+
+In header ``mockturtle/properties/mccost.hpp`` functions are defined that can
+be used to compute costs based on the multiplicative complexity of the network.
+
+.. doxygenfunction:: mockturtle::multiplicative_complexity
+
+.. doxygenfunction:: mockturtle::multiplicative_complexity_depth

--- a/include/mockturtle/properties/mccost.hpp
+++ b/include/mockturtle/properties/mccost.hpp
@@ -1,0 +1,244 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2019  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file mccost.hpp
+  \brief Cost functions based on multiplicative-complexity
+
+  \author Mathias Soeken
+*/
+
+#pragma once
+
+#include <cstdint>
+
+#include "../traits.hpp"
+#include "../utils/node_map.hpp"
+#include "../views/topo_view.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Computes the multiplicative complexity
+ *
+ * Computes and sums the multiplicative complexity of each gate in the network.
+ * Returns `std::nullopt`, if multiplicative complexity cannot be determined
+ * for some gate.
+ *
+ * \param ntk Network
+ */
+template<class Ntk>
+std::optional<uint32_t> multiplicative_complexity( Ntk const& ntk )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_foreach_gate_v<Ntk>, "Ntk does not implement the foreach_gate method" );
+
+  uint32_t total{0u};
+  bool valid{true};
+
+  ntk.foreach_gate( [&]( auto const& n ) {
+    if ( has_is_and_v<Ntk> )
+    {
+      if ( ntk.is_and( n ) )
+      {
+        total++;
+        return true;
+      }
+    }
+
+    if ( has_is_or_v<Ntk> )
+    {
+      if ( ntk.is_or( n ) )
+      {
+        total++;
+        return true;
+      }
+    }
+
+    if ( has_is_xor_v<Ntk> )
+    {
+      if ( ntk.is_xor( n ) )
+      {
+        return true;
+      }
+    }
+
+    if ( has_is_maj_v<Ntk> )
+    {
+      if ( ntk.is_maj( n ) )
+      {
+        total++;
+        return true;
+      }
+    }
+
+    if ( has_is_ite_v<Ntk> )
+    {
+      if ( ntk.is_ite( n ) )
+      {
+        total++;
+        return true;
+      }
+    }
+
+    if ( has_is_xor3_v<Ntk> )
+    {
+      if ( ntk.is_xor3( n ) )
+      {
+        return true;
+      }
+    }
+
+    valid = false;
+    return false; /* break */
+  } );
+
+  if ( valid )
+  {
+    return total;
+  }
+  else
+  {
+    return std::nullopt;
+  }
+}
+
+
+
+/*! \brief Computes the multiplicative complexity depth
+ *
+ * Computes multiplicative complexity of each gate and the sum of them on the 
+ * critical path in the network. Returns `std::nullopt`, if multiplicative
+ * complexity cannot be determined for some gate.
+ *
+ * \param ntk Network
+ */
+template<class Ntk>
+std::optional<uint32_t> multiplicative_complexity_depth( Ntk const& ntk )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_foreach_gate_v<Ntk>, "Ntk does not implement the foreach_gate method" );
+  static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
+  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+
+  bool valid{true};
+
+  node_map<uint32_t, Ntk> level( ntk, 0u );
+  topo_view<Ntk> topo{ntk};
+
+  topo.foreach_node( [&]( auto const& n ) {
+    if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+    {
+      return true;
+    }
+
+    /* compute the maximum MC of children */
+    uint32_t max_level{0u};
+    ntk.foreach_fanin( n, [&]( const auto& f ) {
+      if ( level[f] > max_level )
+      {
+        max_level = level[f];
+      }
+    } );
+
+    if ( has_is_and_v<Ntk> )
+    {
+      if ( ntk.is_and( n ) )
+      {
+        level[n] = max_level + 1u;
+        return true;
+      }
+    }
+
+    if ( has_is_or_v<Ntk> )
+    {
+      if ( ntk.is_or( n ) )
+      {
+        level[n] = max_level + 1u;
+        return true;
+      }
+    }
+
+    if ( has_is_xor_v<Ntk> )
+    {
+      if ( ntk.is_xor( n ) )
+      {
+        level[n] = max_level;
+        return true;
+      }
+    }
+
+    if ( has_is_maj_v<Ntk> )
+    {
+      if ( ntk.is_maj( n ) )
+      {
+        level[n] = max_level + 1u;
+        return true;
+      }
+    }
+
+    if ( has_is_ite_v<Ntk> )
+    {
+      if ( ntk.is_ite( n ) )
+      {
+        level[n] = max_level + 1u;
+        return true;
+      }
+    }
+
+    if ( has_is_xor3_v<Ntk> )
+    {
+      if ( ntk.is_xor3( n ) )
+      {
+        level[n] = max_level;
+        return true;
+      }
+    }
+
+    valid = false;
+    return false; /* break */
+  } );
+
+  if ( valid )
+  {
+    uint32_t max_level{0u};
+    ntk.foreach_po( [&]( const auto& f ) {
+      if ( level[f] > max_level )
+      {
+        max_level = level[f];
+      }
+    } );
+    return max_level;
+  }
+  else
+  {
+    return std::nullopt;
+  }
+}
+
+
+} // namespace mockturtle

--- a/test/generators/modular_arithmetic.cpp
+++ b/test/generators/modular_arithmetic.cpp
@@ -11,6 +11,7 @@
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/klut.hpp>
 #include <mockturtle/networks/mig.hpp>
+#include <mockturtle/networks/xag.hpp>
 
 using namespace mockturtle;
 
@@ -64,6 +65,12 @@ TEST_CASE( "build an 8-bit modular adder with different networks", "[modular_ari
   simulate_modular_adder<klut_network>( 0, 255 );
   simulate_modular_adder<klut_network>( 200, 200 );
   simulate_modular_adder<klut_network>( 120, 250 );
+
+  simulate_modular_adder<xag_network>( 37, 73 );
+  simulate_modular_adder<xag_network>( 0, 255 );
+  simulate_modular_adder<xag_network>( 0, 255 );
+  simulate_modular_adder<xag_network>( 200, 200 );
+  simulate_modular_adder<xag_network>( 120, 250 );
 }
 
 template<typename Ntk>
@@ -157,6 +164,12 @@ TEST_CASE( "build an 8-bit modular subtractor with different networks", "[modula
   simulate_modular_subtractor<klut_network>( 0, 255 );
   simulate_modular_subtractor<klut_network>( 200, 200 );
   simulate_modular_subtractor<klut_network>( 120, 250 );
+
+  simulate_modular_subtractor<xag_network>( 37, 73 );
+  simulate_modular_subtractor<xag_network>( 0, 255 );
+  simulate_modular_subtractor<xag_network>( 0, 255 );
+  simulate_modular_subtractor<xag_network>( 200, 200 );
+  simulate_modular_subtractor<xag_network>( 120, 250 );
 }
 
 template<typename Ntk>

--- a/test/properties/mccost.cpp
+++ b/test/properties/mccost.cpp
@@ -1,0 +1,51 @@
+#include <catch.hpp>
+
+#include <algorithm>
+#include <vector>
+
+#include <mockturtle/traits.hpp>
+#include <mockturtle/generators/arithmetic.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/properties/mccost.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "count MC in AIG", "[mccost]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( a, f1 );
+  const auto f3 = aig.create_nand( b, f1 );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  CHECK( multiplicative_complexity( aig ) == 4u );
+  CHECK( multiplicative_complexity_depth( aig ) == 3u );
+}
+
+template<class Ntk>
+inline void test_ripple_carry_adder( uint32_t width, uint32_t expected_count, uint32_t expected_depth )
+{
+  Ntk ntk;
+
+  std::vector<signal<Ntk>> as( width ), bs( width );
+  std::generate( as.begin(), as.end(), [&]() { return ntk.create_pi(); } );
+  std::generate( bs.begin(), bs.end(), [&]() { return ntk.create_pi(); } );
+
+  auto carry = ntk.get_constant( false );
+  carry_ripple_adder_inplace( ntk, as, bs, carry );
+  std::for_each( as.begin(), as.end(), [&]( auto const& f ) { ntk.create_po( f ); } );
+  ntk.create_po( carry );
+
+  CHECK( multiplicative_complexity( ntk ) == expected_count );
+  CHECK( multiplicative_complexity_depth( ntk ) == expected_depth );
+}
+
+TEST_CASE( "count MC in ripple carry adder", "[mccost]" )
+{
+  test_ripple_carry_adder<aig_network>( 16u, 108u, 32u );
+  test_ripple_carry_adder<xag_network>( 16u, 16u, 16u );
+}

--- a/test/properties/mccost.cpp
+++ b/test/properties/mccost.cpp
@@ -31,7 +31,7 @@ inline void test_ripple_carry_adder( uint32_t width, uint32_t expected_count, ui
 {
   Ntk ntk;
 
-  std::vector<signal<Ntk>> as( width ), bs( width );
+  std::vector<typename Ntk::signal> as( width ), bs( width );
   std::generate( as.begin(), as.end(), [&]() { return ntk.create_pi(); } );
   std::generate( bs.begin(), bs.end(), [&]() { return ntk.create_pi(); } );
 


### PR DESCRIPTION
Counts MC for logic networks based on the MC of each gate. Can also count the MC on the critical path.

I also made some changes to how the full-adder is generated. For XAGs this change will prefer low MC based implementations, which propagates to more complex logic such as ripple-carry adders.
