### PR TITLE
Better way to do XOR3 in MIGs

### DIFF
--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -397,7 +397,7 @@ public:
 
   signal create_xor3( signal const& a, signal const& b, signal const& c )
   {
-    return create_xor( create_xor( a, b ), c );
+    return create_maj( !a, create_maj( a, !b, c ), create_maj( a, b, !c ) );
   }
 #pragma endregion
 


### PR DESCRIPTION
Learned this from the Boolean function section in TAOCP.