### PR TITLE
Fix bug in DSD decomposition on non-support vars

### DIFF
--- a/include/mockturtle/algorithms/dsd_decomposition.hpp
+++ b/include/mockturtle/algorithms/dsd_decomposition.hpp
@@ -57,11 +57,16 @@ public:
   dsd_decomposition_impl( Ntk& ntk, kitty::dynamic_truth_table const& func, std::vector<signal<Ntk>> const& children, Fn&& on_prime )
       : _ntk( ntk ),
         remainder( func ),
-        support( children.size() ),
         pis( children ),
         _on_prime( on_prime )
   {
-    std::iota( support.begin(), support.end(), 0u );
+    for ( auto i = 0; i < func.num_vars(); ++i )
+    {
+      if ( kitty::has_var( func, i ) )
+      {
+        support.push_back( i );
+      }
+    }
   }
 
   signal<Ntk> run()

--- a/test/algorithms/dsd_decomposition.cpp
+++ b/test/algorithms/dsd_decomposition.cpp
@@ -3,6 +3,7 @@
 #include <kitty/constructors.hpp>
 #include <kitty/dynamic_truth_table.hpp>
 #include <mockturtle/algorithms/dsd_decomposition.hpp>
+#include <mockturtle/algorithms/shannon_decomposition.hpp>
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/klut.hpp>
@@ -84,4 +85,30 @@ TEST_CASE( "Partial DSD decomposition into k-LUT network", "[dsd_decomposition]"
 
   default_simulator<kitty::dynamic_truth_table> sim( table.num_vars() );
   CHECK( simulate<kitty::dynamic_truth_table>( ntk, sim )[0] == table );
+}
+
+TEST_CASE( "DSD decomposition on random functions of different size", "[dsd_decomposition]" )
+{
+  for ( uint32_t var = 0u; var <= 6u; ++var )
+  {
+    for ( auto i = 0u; i < 100u; ++i )
+    {
+      kitty::dynamic_truth_table func( var );
+      kitty::create_random( func );
+
+      aig_network ntk;
+      std::vector<aig_network::signal> pis( var );
+      std::generate( pis.begin(), pis.end(), [&]() { return ntk.create_pi(); } );
+
+      auto on_prime = [&]( kitty::dynamic_truth_table const& func, std::vector<aig_network::signal> const& pis ) {
+        return shannon_decomposition( ntk, func, pis );
+      };
+
+      ntk.create_po( dsd_decomposition( ntk, func, pis, on_prime ) );
+
+      default_simulator<kitty::dynamic_truth_table> sim( func.num_vars() );
+
+      CHECK( simulate<kitty::dynamic_truth_table>( ntk, sim )[0] == func );
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes a bug preventing DSD decomposition to decompose on variables that are not in the support set.