### PR TITLE
Add custom cmake files to examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,4 +4,8 @@ foreach(filename ${FILENAMES})
   get_filename_component(basename ${filename} NAME_WE)
   add_executable(${basename} ${filename})
   target_link_libraries(${basename} PUBLIC mockturtle)
+
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${basename}.cmake")
+    include(${basename}.cmake)
+  endif()
 endforeach()


### PR DESCRIPTION
Users can write `example-name`.cmake files to add some custom CMake code such as library linkage or include directories.