### PR TITLE
Keep primary input names when copying a names_view

### DIFF
--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -59,8 +59,25 @@ public:
   {
   }
 
-private:
-  names_view<Ntk> operator=( names_view<Ntk> const& named_ntk );
+public:
+  names_view<Ntk>& operator=( names_view<Ntk> const& named_ntk )
+  {
+    std::map<signal, std::string> new_signal_names;
+    std::vector<signal> current_pis;
+    Ntk::foreach_pi( [&]( auto const& n ) {
+      current_pis.emplace_back( Ntk::make_signal( n ) );
+    });
+    named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
+      if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
+      {
+        new_signal_names[named_ntk.make_signal( n )] = it->second;
+      }
+    } );
+
+    Ntk::operator=( named_ntk );
+    _signal_names = new_signal_names;
+    return *this;
+  }
 
 public:
   signal create_pi( std::string const& name = {} )


### PR DESCRIPTION
When assigning a names_view to a new names_view instance, it forgets all internal names, but tries to keep the primary input names.