### PR TITLE
Names view

### DIFF
--- a/include/mockturtle/algorithms/collapse_mapped.hpp
+++ b/include/mockturtle/algorithms/collapse_mapped.hpp
@@ -54,10 +54,8 @@ public:
   {
   }
 
-  NtkDest run()
+  void run( NtkDest& dest )
   {
-    NtkDest dest;
-
     node_map<signal<NtkDest>, NtkSource> node_to_signal( ntk );
 
     /* special map for output drivers to perform some optimizations */
@@ -136,22 +134,32 @@ public:
 
     /* primary inputs */
     ntk.foreach_pi( [&]( auto n ) {
+      signal<NtkDest> dest_signal;
       switch ( node_driver_type[n] )
       {
       default:
       case driver_type::none:
       case driver_type::pos:
-        node_to_signal[n] = dest.create_pi();
+        dest_signal = dest.create_pi();
+        node_to_signal[n] = dest_signal;
         break;
 
       case driver_type::neg:
-        node_to_signal[n] = dest.create_not( dest.create_pi() );
+        dest_signal = dest.create_pi();
+        node_to_signal[n] = dest.create_not( dest_signal );
         break;
 
       case driver_type::mixed:
-        node_to_signal[n] = dest.create_pi();
+        dest_signal = dest.create_pi();
+        node_to_signal[n] = dest_signal;
         opposites[n] = dest.create_not( node_to_signal[n] );
         break;
+      }
+
+      if constexpr ( has_has_name_v<NtkSource> && has_get_name_v<NtkSource> && has_set_name_v<NtkDest> )
+      {
+        if ( ntk.has_name( ntk.make_signal( n ) ) )
+          dest.set_name( dest_signal, ntk.get_name( ntk.make_signal( n ) ) );
       }
     } );
 
@@ -186,7 +194,7 @@ public:
     } );
 
     /* outputs */
-    ntk.foreach_po( [&]( auto const& f ) {
+    ntk.foreach_po( [&]( auto const& f, auto index ) {
       if ( ntk.is_complemented( f ) && node_driver_type[f] == driver_type::mixed )
       {
         dest.create_po( opposites[ntk.get_node( f )] );
@@ -195,9 +203,15 @@ public:
       {
         dest.create_po( node_to_signal[f] );
       }
-    } );
 
-    return dest;
+      if constexpr ( has_has_output_name_v<NtkSource> && has_get_output_name_v<NtkSource> && has_set_output_name_v<NtkDest> )
+      {
+        if ( ntk.has_output_name( index ) )
+        {
+          dest.set_output_name( index, ntk.get_output_name( index ) );
+        }
+      }
+      });
   }
 
 private:
@@ -274,7 +288,8 @@ std::optional<NtkDest> collapse_mapped_network( NtkSource const& ntk )
   else
   {
     detail::collapse_mapped_network_impl<NtkDest, NtkSource> p( ntk );
-    return p.run();
+    NtkDest dest;
+    return p.run( dest );
   }
 }
 
@@ -346,7 +361,7 @@ bool collapse_mapped_network( NtkDest& dest, NtkSource const& ntk )
   else
   {
     detail::collapse_mapped_network_impl<NtkDest, NtkSource> p( ntk );
-    dest = p.run();
+    p.run( dest );
     return true;
   }
 }

--- a/include/mockturtle/algorithms/collapse_mapped.hpp
+++ b/include/mockturtle/algorithms/collapse_mapped.hpp
@@ -289,7 +289,8 @@ std::optional<NtkDest> collapse_mapped_network( NtkSource const& ntk )
   {
     detail::collapse_mapped_network_impl<NtkDest, NtkSource> p( ntk );
     NtkDest dest;
-    return p.run( dest );
+    p.run( dest );
+    return dest;
   }
 }
 

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -59,10 +59,23 @@ public:
   {
   }
 
-private:
-  names_view<Ntk> operator=( names_view<Ntk> const& named_ntk );
+  names_view<Ntk>& operator=( names_view<Ntk> const& named_ntk )
+  {
+    std::map<signal, std::string> new_signal_names;
+    std::vector<signal> current_pis;
+    Ntk::foreach_pi( [&]( auto const& n ) {
+        current_pis.emplace_back( Ntk::make_signal( n ) );
+      });
+    named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
+        if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
+          new_signal_names[named_ntk.make_signal( n )] = it->second;
+      } );
 
-public:
+    Ntk::operator=( named_ntk );
+    _signal_names = new_signal_names;
+    return *this;
+  }
+
   signal create_pi( std::string const& name = {} )
   {
     const auto s = Ntk::create_pi( name );


### PR DESCRIPTION
This PR allows algorithm `collapse_mapped` to preserve names of input and output signals.