### PR TITLE
klut_network: bugfix `create_node` without children.

### DIFF
--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -320,6 +320,11 @@ signal create_maj( signal a, signal b, signal c )
 
   signal create_node( std::vector<signal> const& children, kitty::dynamic_truth_table const& function )
   {
+    if ( children.size() == 0u )
+    {
+      assert( function.num_vars() == 0u );
+      return kitty::is_const0( function ) ? get_constant( false ) : get_constant( true );
+    }
     return _create_node( children, _storage->data.cache.insert( function ) );
   }
 

--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -323,7 +323,7 @@ signal create_maj( signal a, signal b, signal c )
     if ( children.size() == 0u )
     {
       assert( function.num_vars() == 0u );
-      return kitty::is_const0( function ) ? get_constant( false ) : get_constant( true );
+      return get_constant( !kitty::is_const0( function ) );
     }
     return _create_node( children, _storage->data.cache.insert( function ) );
   }

--- a/test/algorithms/node_resynthesis.cpp
+++ b/test/algorithms/node_resynthesis.cpp
@@ -320,7 +320,7 @@ TEST_CASE( "Node resynthesis with direct synthesis", "[node_resynthesis]" )
 
       CHECK( klut.num_pis() == v );
       CHECK( klut.num_pos() == 1 );
-      CHECK( klut.num_gates() == 1 );
+      CHECK( klut.num_gates() == ( pis.size() > 0u ? 1u : 0u ) );
 
       const auto aig = node_resynthesis<aig_network>( klut, aig_resyn );
       CHECK( simulate<kitty::dynamic_truth_table>( aig, {v} )[0] == tt );

--- a/test/networks/klut.cpp
+++ b/test/networks/klut.cpp
@@ -176,11 +176,16 @@ TEST_CASE( "create nodes and compute a function in a k-LUT network", "[klut]" )
   const auto b = klut.create_pi();
   const auto c = klut.create_pi();
 
-  kitty::dynamic_truth_table tt_maj( 3u ), tt_xor( 3u );
+  kitty::dynamic_truth_table tt_maj( 3u ), tt_xor( 3u ), tt_const0( 0u );
   kitty::create_from_hex_string( tt_maj, "e8" );
   kitty::create_from_hex_string( tt_xor, "96" );
 
   CHECK( klut.size() == 5 );
+
+  const auto _const0 = klut.create_node( {}, tt_const0 );
+  const auto _const1 = klut.create_node( {}, ~tt_const0 );
+  CHECK( _const0 == klut.get_constant( false ) );
+  CHECK( _const1 == klut.get_constant( true ) );
 
   const auto _maj = klut.create_node( {a, b, c}, tt_maj );
   const auto _xor = klut.create_node( {a, b, c}, tt_xor );


### PR DESCRIPTION
This PR enables `create_node` to return constant nodes if invoked without children, and fixes a minor issue in the test cases of `node_resynthesis`.