### PR TITLE
SAT-based satisfiability don't cares checker

### DIFF
--- a/docs/algorithms/dont_cares.rst
+++ b/docs/algorithms/dont_cares.rst
@@ -4,3 +4,4 @@ Dont cares
 **Header:** ``mockturtle/algorithms/dont_cares.hpp``
 
 .. doxygenfunction:: mockturtle::satisfiability_dont_cares
+.. doxygenstruct:: mockturtle::satisfiability_dont_cares_checker

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ v0.2 (not yet released)
     - Extract linear subcircuits in XAGs (`extract_linear_circuit` and `merge_linear_circuit`) `#204 <https://github.com/lsils/mockturtle/pull/204>`_
     - Linear resynthesis using Paar algorithm (`linear_resynthesis_paar`) `#211 <https://github.com/lsils/mockturtle/pull/211>`_
     - AND gate optimization by computing transitive linear fanin `#232 <https://github.com/lsils/mockturtle/pull/232>`_
+    - SAT-based satisfiability don't cares checker (`satisfiability_dont_cares_checker`) `236 <https://github.com/lsils/mockturtle/pull/236>`_
 * Views:
     - Assign names to signals and outputs (`names_view`) `#181 <https://github.com/lsils/mockturtle/pull/181>`_ `#184 <https://github.com/lsils/mockturtle/pull/184>`_
 * I/O:

--- a/test/algorithms/dont_cares.cpp
+++ b/test/algorithms/dont_cares.cpp
@@ -40,3 +40,20 @@ TEST_CASE( "ODCs in simple AIG", "[dont_cares]" )
   const auto f2_odc = observability_dont_cares( aig, aig.get_node( f2 ), leaves, { aig.get_node( f3 ) } );
   CHECK( f2_odc._bits[0] == 0x7 );
 }
+
+TEST_CASE( "SDCs in simple AIG using satisfiability checker", "[dont_cares]" )
+{
+  aig_network aig;
+  auto a = aig.create_pi();
+  auto b = aig.create_pi();
+  auto f1 = aig.create_and( a, b );
+  auto f2 = aig.create_and( a, !b );
+  auto f3 = aig.create_and( f1, f2 );
+  aig.create_po( f3 );
+
+  satisfiability_dont_cares_checker<aig_network> checker( aig );
+  CHECK( !checker.is_dont_care( aig.get_node( f3 ), std::vector<bool>{{false, false}} ) );
+  CHECK( !checker.is_dont_care( aig.get_node( f3 ), std::vector<bool>{{false, true}} ) );
+  CHECK( !checker.is_dont_care( aig.get_node( f3 ), std::vector<bool>{{true, false}} ) );
+  CHECK( checker.is_dont_care( aig.get_node( f3 ), std::vector<bool>{{true, true}} ) );
+}


### PR DESCRIPTION
Uses SAT to check explicitly for satisfiability don't cares, i.e., the caller needs to specify which assignment to check for which node.