### PR TITLE
Destructor of cnf_view to clean network events

### DIFF
--- a/include/mockturtle/views/cnf_view.hpp
+++ b/include/mockturtle/views/cnf_view.hpp
@@ -91,6 +91,13 @@ public:
   {
   }
 
+  ~cnf_view_impl()
+  {
+    Ntk::events().on_add.erase( Ntk::events().on_add.begin() + event_ptr_[0] );
+    Ntk::events().on_modified.erase( Ntk::events().on_modified.begin() + event_ptr_[1] );
+    Ntk::events().on_delete.erase( Ntk::events().on_delete.begin() + event_ptr_[2] );
+  }
+
   void init()
   {
     cnf_view_.solver_.add_variables( Ntk::size() );
@@ -113,6 +120,10 @@ public:
       literals_[n] = bill::lit_type( ++v, bill::lit_type::polarities::positive );
       cnf_view_.on_add( n, false );
     } );
+
+    event_ptr_[0] = Ntk::events().on_add.size();
+    event_ptr_[1] = Ntk::events().on_modified.size();
+    event_ptr_[2] = Ntk::events().on_delete.size();
   }
 
   inline bill::var_type add_var()
@@ -171,6 +182,8 @@ private:
 
   node_map<bill::lit_type, Ntk> literals_;
   std::vector<bill::lit_type> switches_;
+
+  int event_ptr_[3];
 };
 
 } /* namespace detail */

--- a/test/views/cnf_view.cpp
+++ b/test/views/cnf_view.cpp
@@ -173,7 +173,6 @@ TEST_CASE( "destructor", "[cnf_view]" )
   const auto c = mig.create_pi();
   mig.create_po( mig.create_maj( a, b, c ) );
 
-  if ( true ) 
   {
     cnf_view view( mig );
     mig.events().on_add.push_back( []( auto const& n ) { (void)n; } );

--- a/test/views/cnf_view.cpp
+++ b/test/views/cnf_view.cpp
@@ -164,3 +164,21 @@ TEST_CASE( "build cnf_view for k-LUT network", "[cnf_view]" )
   CHECK( result );
   CHECK( !*result );
 }
+
+TEST_CASE( "destructor", "[cnf_view]" )
+{
+  mig_network mig;
+  const auto a = mig.create_pi();
+  const auto b = mig.create_pi();
+  const auto c = mig.create_pi();
+  mig.create_po( mig.create_maj( a, b, c ) );
+
+  if ( true ) 
+  {
+    cnf_view view( mig );
+    mig.events().on_add.push_back( []( auto const& n ) { (void)n; } );
+  }
+  
+  CHECK( mig.events().on_add.size() == 1 );
+  CHECK( mig.events().on_delete.size() == 0 );
+}


### PR DESCRIPTION
I noticed that if I create `cnf_view` on top of a circuit to do something, and then after the `cnf_view` object is deleted, even if the original network object is passed by copy, the updating events are still in the network and would cause problem because the solver no longer exists.