### PR TITLE
Exact XMG resynthesis

### DIFF
--- a/include/mockturtle/algorithms/detail/database_generator.hpp
+++ b/include/mockturtle/algorithms/detail/database_generator.hpp
@@ -40,8 +40,8 @@ namespace mockturtle::detail
 
 struct database_generator_params
 {
-  uint32_t num_vars = 4u;
-  bool verbose = false;
+  uint32_t num_vars{4u};
+  bool verbose{false};
 }; /* database_generator_param */
 
 template<typename Ntk, typename ResynFn>

--- a/lib/percy/percy/spec.hpp
+++ b/lib/percy/percy/spec.hpp
@@ -372,7 +372,14 @@ namespace percy
 
             void add_primitive( kitty::dynamic_truth_table const& tt )
             {
-              compiled_primitives.push_back( tt );
+              if ( kitty::is_normal( tt ) )
+              {
+                compiled_primitives.push_back( tt );
+              }
+              else
+              {
+                compiled_primitives.push_back( ~tt ); 
+              }
             }
 
             bool is_primitive_set() const

--- a/test/algorithms/node_resynthesis/exact.cpp
+++ b/test/algorithms/node_resynthesis/exact.cpp
@@ -71,6 +71,7 @@ TEST_CASE( "Exact XMG for MAJ", "[exact]" )
   exact_xmg_resynthesis<xmg_network> resyn;
   resyn( xmg, maj, pis.begin(), pis.end(), [&]( auto const& f ) {
     xmg.create_po( f );
+    return false;
   } );
 
   default_simulator<kitty::dynamic_truth_table> sim( 3u );
@@ -138,6 +139,7 @@ TEST_CASE( "Exact XMG for XOR2", "[exact]" )
   exact_xmg_resynthesis<xmg_network> resyn;
   resyn( xmg, _xor, pis.begin(), pis.end(), [&]( auto const& f ) {
     xmg.create_po( f );
+    return false;
   } );
 
   default_simulator<kitty::dynamic_truth_table> sim( 2u );
@@ -161,6 +163,7 @@ TEST_CASE( "Exact XMG for XOR3", "[exact]" )
   exact_xmg_resynthesis<xmg_network> resyn;
   resyn( xmg, _xor, pis.begin(), pis.end(), [&]( auto const& f ) {
     xmg.create_po( f );
+    return false;
   } );
 
   default_simulator<kitty::dynamic_truth_table> sim( 3u );

--- a/test/algorithms/node_resynthesis/exact.cpp
+++ b/test/algorithms/node_resynthesis/exact.cpp
@@ -123,6 +123,29 @@ TEST_CASE( "Exact XAG for XOR", "[exact]" )
   CHECK( simulate<kitty::dynamic_truth_table>( xag, sim )[0] == _xor );
 }
 
+TEST_CASE( "Exact XMG for XOR2", "[exact]" )
+{
+  kitty::dynamic_truth_table _xor( 2u );
+  kitty::create_from_hex_string( _xor, "6" );
+
+  xmg_network xmg;
+  const auto a = xmg.create_pi();
+  const auto b = xmg.create_pi();
+  const auto c = xmg.create_pi();
+
+  std::vector<xmg_network::signal> pis = {a, b};
+
+  exact_xmg_resynthesis<xmg_network> resyn;
+  resyn( xmg, _xor, pis.begin(), pis.end(), [&]( auto const& f ) {
+    xmg.create_po( f );
+  } );
+
+  default_simulator<kitty::dynamic_truth_table> sim( 2u );
+  CHECK( xmg.num_pos() == 1u );
+  CHECK( xmg.num_gates() == 1u );
+  CHECK( simulate<kitty::dynamic_truth_table>( xmg, sim )[0] == _xor );
+}
+
 TEST_CASE( "Exact XMG for XOR3", "[exact]" )
 {
   kitty::dynamic_truth_table _xor( 3u );


### PR DESCRIPTION
This PR improves the exact XMG resynthesis:
* Support Boolean functions with less than 3 inputs
* Option to turn on/off non-self-dual gate functions
* Check return value of synthesis callback to terminate synthesis of multiple candidates