### PR TITLE
Fix performance bug in aig_resub

### DIFF
--- a/experiments/aig_resubstitution.json
+++ b/experiments/aig_resubstitution.json
@@ -578,5 +578,150 @@
       }
     ],
     "version": "bbd1506"
+  },
+  {
+    "entries": [
+      {
+        "benchmark": "adder",
+        "equivalent": true,
+        "runtime": 0.009396718814969063,
+        "size_after": 893,
+        "size_before": 1020
+      },
+      {
+        "benchmark": "bar",
+        "equivalent": true,
+        "runtime": 0.02560267224907875,
+        "size_after": 3336,
+        "size_before": 3336
+      },
+      {
+        "benchmark": "div",
+        "equivalent": true,
+        "runtime": 0.5105587840080261,
+        "size_after": 52305,
+        "size_before": 57247
+      },
+      {
+        "benchmark": "hyp",
+        "equivalent": true,
+        "runtime": 1.5858064889907837,
+        "size_after": 208375,
+        "size_before": 214335
+      },
+      {
+        "benchmark": "log2",
+        "equivalent": true,
+        "runtime": 0.31664517521858215,
+        "size_after": 32012,
+        "size_before": 32060
+      },
+      {
+        "benchmark": "max",
+        "equivalent": true,
+        "runtime": 0.014417611062526703,
+        "size_after": 2865,
+        "size_before": 2865
+      },
+      {
+        "benchmark": "multiplier",
+        "equivalent": true,
+        "runtime": 0.24908232688903809,
+        "size_after": 26971,
+        "size_before": 27062
+      },
+      {
+        "benchmark": "sin",
+        "equivalent": true,
+        "runtime": 0.057943470776081085,
+        "size_after": 5375,
+        "size_before": 5416
+      },
+      {
+        "benchmark": "sqrt",
+        "equivalent": true,
+        "runtime": 0.286447674036026,
+        "size_after": 20526,
+        "size_before": 24618
+      },
+      {
+        "benchmark": "square",
+        "equivalent": true,
+        "runtime": 0.18075312674045563,
+        "size_after": 18160,
+        "size_before": 18484
+      },
+      {
+        "benchmark": "arbiter",
+        "equivalent": true,
+        "runtime": 0.08873055875301361,
+        "size_after": 11839,
+        "size_before": 11839
+      },
+      {
+        "benchmark": "cavlc",
+        "equivalent": true,
+        "runtime": 0.015460217371582985,
+        "size_after": 674,
+        "size_before": 693
+      },
+      {
+        "benchmark": "ctrl",
+        "equivalent": true,
+        "runtime": 0.003640139941126108,
+        "size_after": 108,
+        "size_before": 174
+      },
+      {
+        "benchmark": "dec",
+        "equivalent": true,
+        "runtime": 0.01071877870708704,
+        "size_after": 304,
+        "size_before": 304
+      },
+      {
+        "benchmark": "i2c",
+        "equivalent": true,
+        "runtime": 0.010299828834831715,
+        "size_after": 1241,
+        "size_before": 1342
+      },
+      {
+        "benchmark": "int2float",
+        "equivalent": true,
+        "runtime": 0.0030428110621869564,
+        "size_after": 236,
+        "size_before": 260
+      },
+      {
+        "benchmark": "mem_ctrl",
+        "equivalent": true,
+        "runtime": 0.413871705532074,
+        "size_after": 46446,
+        "size_before": 46836
+      },
+      {
+        "benchmark": "priority",
+        "equivalent": true,
+        "runtime": 0.008395868353545666,
+        "size_after": 852,
+        "size_before": 978
+      },
+      {
+        "benchmark": "router",
+        "equivalent": true,
+        "runtime": 0.001856424962170422,
+        "size_after": 257,
+        "size_before": 257
+      },
+      {
+        "benchmark": "voter",
+        "equivalent": true,
+        "runtime": 0.1300613284111023,
+        "size_after": 10498,
+        "size_before": 13758
+      }
+    ],
+    "version": "fc251b3"
   }
 ]

--- a/include/mockturtle/algorithms/aig_resub.hpp
+++ b/include/mockturtle/algorithms/aig_resub.hpp
@@ -325,6 +325,20 @@ public:
         continue;
       }
 
+      if ( true ) // ( ps.fix_bug )
+      {
+        if ( kitty::implies( ~tt_d, tt ) )
+        {
+          udivs.positive_divisors.emplace_back( !ntk.make_signal( d ) );
+          continue;
+        }
+        if ( kitty::implies( tt, ~tt_d ) )
+        {
+          udivs.negative_divisors.emplace_back( !ntk.make_signal( d ) );
+          continue;
+        }
+      }
+
       udivs.next_candidates.emplace_back( ntk.make_signal( d ) );
     }
   }


### PR DESCRIPTION
Some input polarities for div1 were not considered with truth table normalization.