### PR TITLE
partial simulator

### DIFF
--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -167,7 +167,7 @@ public:
   partial_simulator() = delete;
   partial_simulator( unsigned num_pis, unsigned num_pattern, std::default_random_engine::result_type seed = 0 )
   {
-    assert( num_pis > 0 );
+    assert( num_pis > 0u );
 
     for ( auto i = 0u; i < num_pis; ++i )
     {

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -187,7 +187,7 @@ public:
     patterns = pats;
   }
 
-  partial_simulator( const std::string& filename, uint32_t length = 0 )
+  partial_simulator( const std::string& filename, uint32_t length = 0u )
   {
     std::ifstream in( filename, std::ifstream::in );
     std::string line;

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -196,8 +196,10 @@ public:
     {
       patterns.emplace_back( line.length() * 4 );
       kitty::create_from_hex_string( patterns.back(), line );
-      if ( length != 0 )
+      if ( length != 0u )
+      {
         patterns.back().resize( length );
+      }
     }
 
     in.close();

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -39,6 +39,7 @@
 #include <string>
 
 #include <kitty/dynamic_truth_table.hpp>
+#include <kitty/partial_truth_table.hpp>
 #include <kitty/operators.hpp>
 
 #include "../traits.hpp"
@@ -1021,6 +1022,33 @@ public:
     auto tt2 = *begin++;
 
     return ( c1.weight ? ~tt1 : tt1 ) & ( c2.weight ? ~tt2 : tt2 );
+  }
+
+  template<typename Iterator>
+  void compute( node const& n, kitty::partial_truth_table& result, Iterator begin, Iterator end ) const
+  {
+    (void)end;
+    /* TODO: assert type of *begin is partial_truth_table */
+
+    assert( n != 0 && !is_ci( n ) );
+
+    auto const& c1 = _storage->nodes[n].children[0];
+    auto const& c2 = _storage->nodes[n].children[1];
+
+    auto tt1 = *begin++;
+    auto tt2 = *begin++;
+
+    assert( tt1.num_bits() == tt2.num_bits() );
+    assert( tt1.num_bits() >= result.num_bits() );
+    if ( result.num_bits() == 0 )
+    {
+      result = ( c1.weight ? ~tt1 : tt1 ) & ( c2.weight ? ~tt2 : tt2 );
+    }
+    else
+    {
+      result.resize( tt1.num_bits() );
+      result._bits.back() = ( c1.weight ? ~(tt1._bits.back()) : tt1._bits.back() ) & ( c2.weight ? ~(tt2._bits.back()) : tt2._bits.back() );
+    }
   }
 #pragma endregion
 

--- a/lib/kitty/kitty/partial_truth_table.hpp
+++ b/lib/kitty/kitty/partial_truth_table.hpp
@@ -155,10 +155,7 @@ struct partial_truth_table
     _num_bits = num_bits;
 
     unsigned needed_blocks = num_bits ? ( ( ( num_bits - 1 ) >> 6 ) + 1 ) : 0;
-    if ( needed_blocks > _bits.size() )
-    {
-      _bits.resize( needed_blocks, 0u );
-    }
+    _bits.resize( needed_blocks, 0u );
 
     mask_bits();
   }
@@ -187,6 +184,10 @@ struct partial_truth_table
 
     if ( ( _num_bits % 64 ) + num_bits <= 64 ) /* no need for a new block */
     {
+      if ( _bits.size() == 0u )
+      {
+        _bits.emplace_back( 0u );
+      }
       _bits.back() |= bits << ( _num_bits % 64 );
     }
     else

--- a/test/algorithms/simulation.cpp
+++ b/test/algorithms/simulation.cpp
@@ -90,3 +90,38 @@ TEST_CASE( "Simulate XOR AIG circuit with pre-defined values", "[simulation]" )
   CHECK( ( aig.is_complemented( f3 ) ? ~node_to_value[f3] : node_to_value[f3] )._bits[0] == 0x3 );
   CHECK( ( aig.is_complemented( f4 ) ? ~node_to_value[f4] : node_to_value[f4] )._bits[0] == 0xe );
 }
+
+TEST_CASE( "Partial simulator", "[simulation]" )
+{
+  aig_network aig;
+
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_nand( a, f1 );
+  const auto f3 = aig.create_nand( b, f1 );
+  const auto f4 = aig.create_nand( f2, f3 );
+  aig.create_po( f4 );
+
+  std::vector<kitty::partial_truth_table> pats( 2 );
+  pats[0].add_bits( 0x0a, 5 ); /* a = 01010 */
+  pats[1].add_bits( 0x13, 5 ); /* b = 10011 */
+  partial_simulator sim( pats );
+
+  unordered_node_map<kitty::partial_truth_table, aig_network> node_to_value( aig );
+  simulate_nodes<kitty::partial_truth_table>( aig, node_to_value, sim );
+
+  CHECK( ( aig.is_complemented( f4 ) ? ~node_to_value[f4] : node_to_value[f4] )._bits[0] == 0x19 ); /* f4 = 11001 */
+
+  node_to_value.reset();
+
+  /* set node f1 to false, such that function f1 becomes true */
+  node_to_value[ aig.get_node( f1 ) ] = kitty::partial_truth_table( 5 );
+
+  /* re-simulated with the fixed value for f1 */
+  simulate_nodes<kitty::partial_truth_table>( aig, node_to_value, sim );
+  CHECK( ( aig.is_complemented( f1 ) ? ~node_to_value[f1] : node_to_value[f1] )._bits[0] == 0x1f ); /* f1 = 11111 */
+  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0x15 ); /* f2 = 10101 */
+  CHECK( ( aig.is_complemented( f3 ) ? ~node_to_value[f3] : node_to_value[f3] )._bits[0] == 0x0c ); /* f3 = 01100 */
+  CHECK( ( aig.is_complemented( f4 ) ? ~node_to_value[f4] : node_to_value[f4] )._bits[0] == 0x1b ); /* f4 = 11011 */
+}


### PR DESCRIPTION
`partial_simulator` implementation based on `partial_truth_table`, with hacks to avoid re-computing all the blocks after `add_bit`. Currently only supports AIGs.