### PR TITLE
docs: circuit_validator

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ Welcome to mockturtle's documentation!
    algorithms/xag_optimization
    algorithms/xmg_optimization
    algorithms/equivalence_classes
+   algorithms/circuit_validator
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR integrates `circuit_validator` into the main index of the documentation.