### PR TITLE
Incremental CNF construction in circuit_validator

### DIFF
--- a/docs/algorithms/circuit_validator.rst
+++ b/docs/algorithms/circuit_validator.rst
@@ -3,6 +3,10 @@ Functional equivalence of circuit nodes
 
 **Header:** ``mockturtle/algorithms/circuit_validator.hpp``
 
+This class can be used to validate potential circuit optimization choices. It checks the functional equivalence of a circuit node with an existing or non-existing signal with SAT, with optional consideration of observability don't-care (ODC).
+
+If more advanced SAT validation is needed, one could consider using ``cnf_view`` instead, which also constructs the CNF clauses of circuit nodes.
+
 **Example**
 
 The following code shows how to check functional equivalence of a root node to signals existing in the network, or created with nodes within the network. If not, get the counter example.
@@ -34,18 +38,20 @@ The following code shows how to check functional equivalence of a root node to s
       }
    }
 
-   circuit_validator<aig_network>::gate::fanin fi1;
-   fi1.idx = 0; fi1.inv = true;
-   circuit_validator<aig_network>::gate::fanin fi2;
-   fi2.idx = 1; fi2.inv = true;
-   circuit_validator<aig_network>::gate g;
-   g.fanins = {fi1, fi2};
+   circuit_validator<aig_network>::gate::fanin gi1; gi1.idx = 0; gi1.inv = true;
+   circuit_validator<aig_network>::gate::fanin gi2; gi2.idx = 1; gi2.inv = true;
+   circuit_validator<aig_network>::gate g; g.fanins = {gi1, gi2};
    g.type = circuit_validator<aig_network>::gate_type::AND;
 
-   result = v.validate( f3, {aig.get_node( f1 ), aig.get_node( f2 )}, {g}, true );
+   circuit_validator<aig_network>::gate::fanin hi1; hi1.idx = 2; hi1.inv = false;
+   circuit_validator<aig_network>::gate::fanin hi2; hi2.idx = 0; hi2.inv = false;
+   circuit_validator<aig_network>::gate h; h.fanins = {hi1, hi2};
+   h.type = circuit_validator<aig_network>::gate_type::AND;
+
+   result = v.validate( f3, {aig.get_node( f1 ), aig.get_node( f2 )}, {g, h}, true );
    if ( result && *result )
    {
-     std::cout << "f3 is equivalent to NOT(NOT f1 AND NOT f2)\n";
+     std::cout << "f3 is equivalent to NOT((NOT f1 AND NOT f2) AND f1)\n";
    }
 
 **Parameters**
@@ -74,5 +80,4 @@ The following code shows how to check functional equivalence of a root node to s
 
 **Updating**
 
-.. doxygenfunction:: mockturtle::circuit_validator::add_node
 .. doxygenfunction:: mockturtle::circuit_validator::update

--- a/docs/algorithms/circuit_validator.rst
+++ b/docs/algorithms/circuit_validator.rst
@@ -38,15 +38,13 @@ The following code shows how to check functional equivalence of a root node to s
       }
    }
 
-   circuit_validator<aig_network>::gate::fanin gi1; gi1.idx = 0; gi1.inv = true;
-   circuit_validator<aig_network>::gate::fanin gi2; gi2.idx = 1; gi2.inv = true;
-   circuit_validator<aig_network>::gate g; g.fanins = {gi1, gi2};
-   g.type = circuit_validator<aig_network>::gate_type::AND;
+   circuit_validator<aig_network>::gate::fanin gi1{0, true};
+   circuit_validator<aig_network>::gate::fanin gi2{1, true};
+   circuit_validator<aig_network>::gate g{{gi1, gi2}, circuit_validator<aig_network>::gate_type::AND};
 
-   circuit_validator<aig_network>::gate::fanin hi1; hi1.idx = 2; hi1.inv = false;
-   circuit_validator<aig_network>::gate::fanin hi2; hi2.idx = 0; hi2.inv = false;
-   circuit_validator<aig_network>::gate h; h.fanins = {hi1, hi2};
-   h.type = circuit_validator<aig_network>::gate_type::AND;
+   circuit_validator<aig_network>::gate::fanin hi1{2, false};
+   circuit_validator<aig_network>::gate::fanin hi2{0, false};
+   circuit_validator<aig_network>::gate h{{hi1, hi2}, circuit_validator<aig_network>::gate_type::AND};
 
    result = v.validate( f3, {aig.get_node( f1 ), aig.get_node( f2 )}, {g, h}, true );
    if ( result && *result )
@@ -76,7 +74,7 @@ The following code shows how to check functional equivalence of a root node to s
 .. doxygenstruct:: mockturtle::circuit_validator::gate
    :members: fanins, type
 .. doxygenstruct:: mockturtle::circuit_validator::gate::fanin
-   :members: idx, inv
+   :members: index, inverted
 
 **Updating**
 

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -144,7 +144,12 @@ public:
     {
       construct( ntk.get_node( d ) );
     }
-    return validate( ntk.get_node( f ), lit_not_cond( literals[d], ntk.is_complemented( f ) ^ ntk.is_complemented( d ) ) );
+    auto const res = validate( ntk.get_node( f ), lit_not_cond( literals[d], ntk.is_complemented( f ) ^ ntk.is_complemented( d ) ) );
+    if ( solver.num_clauses() > ps.max_solver_size )
+    {
+      restart();
+    }
+    return res;
   }
 
   /*! \brief Validate functional equivalence of node `root` and signal `d`. */
@@ -154,7 +159,12 @@ public:
     {
       construct( ntk.get_node( d ) );
     }
-    return validate( root, lit_not_cond( literals[d], ntk.is_complemented( d ) ) );
+    auto const res = validate( root, lit_not_cond( literals[d], ntk.is_complemented( d ) ) );
+    if ( solver.num_clauses() > ps.max_solver_size )
+    {
+      restart();
+    }
+    return res;
   }
 
   /*! \brief Validate functional equivalence of signal `f` with a circuit.
@@ -218,6 +228,11 @@ public:
     if constexpr ( use_pushpop )
     {
       solver.pop();
+    }
+
+    if ( solver.num_clauses() > ps.max_solver_size )
+    {
+      restart();
     }
 
     return res;
@@ -507,10 +522,6 @@ private:
       res = solve( {~nlit} );
     }
 
-    if ( solver.num_clauses() > ps.max_solver_size )
-    {
-      restart();
-    }
     return res;
   }
 

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -44,6 +44,9 @@ namespace mockturtle
 
 struct validator_params
 {
+  /*! \brief Maximum number of clauses of the SAT solver. */
+  uint32_t max_solver_size{10000};
+
   /*! \brief Whether to consider ODC, and how many levels. 0 = No consideration. -1 = Consider TFO until PO. */
   int odc_levels{0};
 
@@ -137,12 +140,20 @@ public:
   /*! \brief Validate functional equivalence of signals `f` and `d`. */
   std::optional<bool> validate( signal const& f, signal const& d )
   {
+    if ( !literals.has( d ) )
+    {
+      construct( ntk.get_node( d ) );
+    }
     return validate( ntk.get_node( f ), lit_not_cond( literals[d], ntk.is_complemented( f ) ^ ntk.is_complemented( d ) ) );
   }
 
   /*! \brief Validate functional equivalence of node `root` and signal `d`. */
   std::optional<bool> validate( node const& root, signal const& d )
   {
+    if ( !literals.has( d ) )
+    {
+      construct( ntk.get_node( d ) );
+    }
     return validate( root, lit_not_cond( literals[d], ntk.is_complemented( d ) ) );
   }
 
@@ -184,6 +195,10 @@ public:
     std::vector<bill::lit_type> lits;
     while ( divs_begin != divs_end )
     {
+      if ( !literals.has( *divs_begin ) )
+      {
+        construct( *divs_begin );
+      }
       lits.emplace_back( literals[*divs_begin] );
       divs_begin++;
     }
@@ -212,6 +227,10 @@ public:
   /*! \brief Validate whether node `root` is a constant of `value`. */
   std::optional<bool> validate( node const& root, bool value )
   {
+    if ( !literals.has( root ) )
+    {
+      construct( root );
+    }
     assert( literals[root].variable() != bill::var_type( 0 ) );
     if constexpr ( use_pushpop )
     {
@@ -250,7 +269,7 @@ public:
    */
   void add_node( node const& n )
   {
-    std::vector<bill::lit_type> lit_fi;
+    /*std::vector<bill::lit_type> lit_fi;
     ntk.foreach_fanin( n, [&]( const auto& f ) {
       lit_fi.emplace_back( lit_not_cond( literals[f], ntk.is_complemented( f ) ) );
     } );
@@ -267,7 +286,7 @@ public:
       assert( lit_fi.size() == 3u );
       assert( ntk.is_maj( n ) || ntk.is_xor3( n ) );
       literals[n] = add_clauses_for_3input_gate( lit_fi[0], lit_fi[1], lit_fi[2], std::nullopt, ntk.is_maj( n ) ? MAJ : XOR );
-    }
+    }*/
   }
 
   /*! \brief Update CNF clauses.
@@ -303,17 +322,59 @@ private:
     } );
 
     /* compute literals for nodes */
-    uint32_t next_var = ntk.num_pis() + 1;
-    ntk.foreach_gate( [&]( auto const& n ) {
-      literals[n] = bill::lit_type( next_var++, bill::lit_type::polarities::positive );
-    } );
+    //uint32_t next_var = ntk.num_pis() + 1;
+    //ntk.foreach_gate( [&]( auto const& n ) {
+    //  literals[n] = bill::lit_type( next_var++, bill::lit_type::polarities::positive );
+    //} );
 
-    solver.add_variables( ntk.size() );
-    generate_cnf<Ntk, bill::lit_type>(
-        ntk, [&]( auto const& clause ) {
-          solver.add_clause( clause );
-        },
-        literals );
+    solver.add_variables( ntk.num_pis() + 1 );
+    solver.add_clause( {~literals[ntk.get_constant( false )]} );
+
+    //generate_cnf<Ntk, bill::lit_type>(
+    //    ntk, [&]( auto const& clause ) {
+    //      solver.add_clause( clause );
+    //    },
+    //    literals );
+  }
+
+  void construct( node const& n )
+  {
+    assert( !literals.has( n ) );
+
+    std::vector<bill::lit_type> child_lits;
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      if ( !literals.has( f ) )
+      {
+        construct( ntk.get_node( f ) );
+      }
+      child_lits.push_back( lit_not_cond( literals[f], ntk.is_complemented( f ) ) );
+    } );
+    bill::lit_type node_lit = literals[n] = bill::lit_type( solver.add_variable(), bill::lit_type::polarities::positive );
+
+    if ( ntk.is_and( n ) )
+    {
+      detail::on_and<add_clause_fn_t>( node_lit, child_lits[0], child_lits[1], [&]( auto const& clause ) {
+        solver.add_clause( clause );
+      } );
+    }
+    else if ( ntk.is_xor( n ) )
+    {
+      detail::on_xor<add_clause_fn_t>( node_lit, child_lits[0], child_lits[1], [&]( auto const& clause ) {
+        solver.add_clause( clause );
+      } );
+    }
+    else if ( ntk.is_xor3( n ) )
+    {
+      detail::on_xor3<add_clause_fn_t>( node_lit, child_lits[0], child_lits[1], child_lits[2], [&]( auto const& clause ) {
+        solver.add_clause( clause );
+      } );
+    }
+    else if ( ntk.is_maj( n ) )
+    {
+      detail::on_maj<add_clause_fn_t>( node_lit, child_lits[0], child_lits[1], child_lits[2], [&]( auto const& clause ) {
+        solver.add_clause( clause );
+      } );
+    }
   }
 
   bill::lit_type add_clauses_for_2input_gate( bill::lit_type a, bill::lit_type b, std::optional<bill::lit_type> c = std::nullopt, gate_type type = AND )
@@ -381,6 +442,11 @@ private:
   std::optional<bool> solve( std::vector<bill::lit_type> assumptions )
   {
     auto const res = solver.solve( assumptions, ps.conflict_limit );
+    if ( solver.num_clauses() > ps.max_solver_size )
+    {
+      restart();
+    }
+
     if ( res == bill::result::states::satisfiable )
     {
       auto model = solver.get_model().model();
@@ -399,6 +465,10 @@ private:
 
   std::optional<bool> validate( node const& root, bill::lit_type const& lit )
   {
+    if ( !literals.has( root ) )
+    {
+      construct( root );
+    }
     assert( literals[root].variable() != bill::var_type( 0 ) );
     if constexpr ( use_pushpop )
     {
@@ -475,6 +545,10 @@ private:
 
       std::vector<bill::lit_type> l_fi;
       ntk.foreach_fanin( fo, [&]( auto const& fi ) {
+        if ( !literals.has( fi ) )
+        {
+          construct( ntk.get_node( fi ) );
+        }
         l_fi.emplace_back( lit_not_cond( lits.has( ntk.get_node( fi ) ) ? lits[fi] : literals[fi], ntk.is_complemented( fi ) ) );
       } );
       if ( l_fi.size() == 2u )
@@ -529,7 +603,7 @@ private:
 
   validator_params const& ps;
 
-  node_map<bill::lit_type, Ntk> literals;
+  unordered_node_map<bill::lit_type, Ntk> literals;
   bill::solver<Solver> solver;
 
 public:

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -76,11 +76,11 @@ public:
   {
     struct fanin
     {
-      /*! \brief Index in the concatenated list of `divs` and `ckt`. */
-      uint32_t idx;
+      /*! \brief Index in the concatenated list of `divs` and `circuit`. */
+      uint32_t index;
 
       /*! \brief Input negation. */
-      bool inv{false};
+      bool inverted{false};
     };
 
     /*! \brief Fanins of the gate. */
@@ -169,33 +169,33 @@ public:
 
   /*! \brief Validate functional equivalence of signal `f` with a circuit.
    * 
-   * The circuit `ckt` uses `divs` as inputs, which are existing nodes in the network.
+   * The circuit `circuit` uses `divs` as inputs, which are existing nodes in the network.
    *
-   * \param divs Existing nodes in the network, serving as PIs of `ckt`.
-   * \param ckt Circuit built with `divs` as inputs. Please see the documentation of `circuit_validator::gate` for its data structure.
+   * \param divs Existing nodes in the network, serving as PIs of `circuit`.
+   * \param circuit Circuit built with `divs` as inputs. Please see the documentation of `circuit_validator::gate` for its data structure.
    * \param output_negation Output negation of the topmost gate of the circuit.
    */
-  std::optional<bool> validate( signal const& f, std::vector<node> const& divs, std::vector<gate> const& ckt, bool output_negation = false )
+  std::optional<bool> validate( signal const& f, std::vector<node> const& divs, std::vector<gate> const& circuit, bool output_negation = false )
   {
-    return validate( ntk.get_node( f ), divs.begin(), divs.end(), ckt, output_negation ^ ntk.is_complemented( f ) );
+    return validate( ntk.get_node( f ), divs.begin(), divs.end(), circuit, output_negation ^ ntk.is_complemented( f ) );
   }
 
   /*! \brief Validate functional equivalence of node `root` with a circuit. */
-  std::optional<bool> validate( node const& root, std::vector<node> const& divs, std::vector<gate> const& ckt, bool output_negation = false )
+  std::optional<bool> validate( node const& root, std::vector<node> const& divs, std::vector<gate> const& circuit, bool output_negation = false )
   {
-    return validate( root, divs.begin(), divs.end(), ckt, output_negation );
+    return validate( root, divs.begin(), divs.end(), circuit, output_negation );
   }
 
   /*! \brief Validate functional equivalence of signal `f` with a circuit. */
   template<class iterator_type>
-  std::optional<bool> validate( signal const& f, iterator_type divs_begin, iterator_type divs_end, std::vector<gate> const& ckt, bool output_negation = false )
+  std::optional<bool> validate( signal const& f, iterator_type divs_begin, iterator_type divs_end, std::vector<gate> const& circuit, bool output_negation = false )
   {
-    return validate( ntk.get_node( f ), divs_begin, divs_end, ckt, output_negation ^ ntk.is_complemented( f ) );
+    return validate( ntk.get_node( f ), divs_begin, divs_end, circuit, output_negation ^ ntk.is_complemented( f ) );
   }
 
   /*! \brief Validate functional equivalence of node `root` with a circuit. */
   template<class iterator_type>
-  std::optional<bool> validate( node const& root, iterator_type divs_begin, iterator_type divs_end, std::vector<gate> const& ckt, bool output_negation = false )
+  std::optional<bool> validate( node const& root, iterator_type divs_begin, iterator_type divs_end, std::vector<gate> const& circuit, bool output_negation = false )
   {
     if ( !literals.has( root ) )
     {
@@ -218,7 +218,7 @@ public:
       solver.push();
     }
 
-    for ( auto g : ckt )
+    for ( auto g : circuit )
     {
       lits.emplace_back( add_tmp_gate( lits, g ) );
     }
@@ -422,16 +422,16 @@ private:
 
     if ( g.fanins.size() == 2u )
     {
-      assert( g.fanins[0].idx < lits.size() );
-      assert( g.fanins[1].idx < lits.size() );
-      return add_clauses_for_2input_gate( lit_not_cond( lits[g.fanins[0].idx], g.fanins[0].inv ), lit_not_cond( lits[g.fanins[1].idx], g.fanins[1].inv ), std::nullopt, g.type );
+      assert( g.fanins[0].index < lits.size() );
+      assert( g.fanins[1].index < lits.size() );
+      return add_clauses_for_2input_gate( lit_not_cond( lits[g.fanins[0].index], g.fanins[0].inverted ), lit_not_cond( lits[g.fanins[1].index], g.fanins[1].inverted ), std::nullopt, g.type );
     }
     else
     {
-      assert( g.fanins[0].idx < lits.size() );
-      assert( g.fanins[1].idx < lits.size() );
-      assert( g.fanins[2].idx < lits.size() );
-      return add_clauses_for_3input_gate( lit_not_cond( lits[g.fanins[0].idx], g.fanins[0].inv ), lit_not_cond( lits[g.fanins[1].idx], g.fanins[1].inv ), lit_not_cond( lits[g.fanins[2].idx], g.fanins[2].inv ), std::nullopt, g.type );
+      assert( g.fanins[0].index < lits.size() );
+      assert( g.fanins[1].index < lits.size() );
+      assert( g.fanins[2].index < lits.size() );
+      return add_clauses_for_3input_gate( lit_not_cond( lits[g.fanins[0].index], g.fanins[0].inverted ), lit_not_cond( lits[g.fanins[1].index], g.fanins[1].inverted ), lit_not_cond( lits[g.fanins[2].index], g.fanins[2].inverted ), std::nullopt, g.type );
     }
   }
 

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -187,6 +187,11 @@ public:
   template<class iterator_type>
   std::optional<bool> validate( node const& root, iterator_type divs_begin, iterator_type divs_end, std::vector<gate> const& ckt, bool output_negation = false )
   {
+    if ( !literals.has( root ) )
+    {
+      construct( root );
+    }
+    
     if constexpr ( use_pushpop )
     {
       solver.push();
@@ -232,17 +237,21 @@ public:
       construct( root );
     }
     assert( literals[root].variable() != bill::var_type( 0 ) );
-    if constexpr ( use_pushpop )
-    {
-      solver.push();
-    }
 
     std::optional<bool> res;
     if constexpr ( use_odc )
     {
       if ( ps.odc_levels != 0 )
       {
+        if constexpr ( use_pushpop )
+        {
+          solver.push();
+        }
         res = solve( {build_odc_window( root, ~literals[root] ), lit_not_cond( literals[root], value )} );
+        if constexpr ( use_pushpop )
+        {
+          solver.pop();
+        }
       }
       else
       {
@@ -254,10 +263,6 @@ public:
       res = solve( {lit_not_cond( literals[root], value )} );
     }
 
-    if constexpr ( use_pushpop )
-    {
-      solver.pop();
-    }
     return res;
   }
 
@@ -470,17 +475,21 @@ private:
       construct( root );
     }
     assert( literals[root].variable() != bill::var_type( 0 ) );
-    if constexpr ( use_pushpop )
-    {
-      solver.push();
-    }
 
     std::optional<bool> res;
     if constexpr ( use_odc )
     {
       if ( ps.odc_levels != 0 )
       {
+        if constexpr ( use_pushpop )
+        {
+          solver.push();
+        }
         res = solve( {build_odc_window( root, lit )} );
+        if constexpr ( use_pushpop )
+        {
+          solver.pop();
+        }
       }
       else
       {
@@ -498,10 +507,6 @@ private:
       res = solve( {~nlit} );
     }
 
-    if constexpr ( use_pushpop )
-    {
-      solver.pop();
-    }
     return res;
   }
 

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -263,6 +263,10 @@ public:
       res = solve( {lit_not_cond( literals[root], value )} );
     }
 
+    if ( solver.num_clauses() > ps.max_solver_size )
+    {
+      restart();
+    }
     return res;
   }
 
@@ -447,10 +451,6 @@ private:
   std::optional<bool> solve( std::vector<bill::lit_type> assumptions )
   {
     auto const res = solver.solve( assumptions, ps.conflict_limit );
-    if ( solver.num_clauses() > ps.max_solver_size )
-    {
-      restart();
-    }
 
     if ( res == bill::result::states::satisfiable )
     {
@@ -507,6 +507,10 @@ private:
       res = solve( {~nlit} );
     }
 
+    if ( solver.num_clauses() > ps.max_solver_size )
+    {
+      restart();
+    }
     return res;
   }
 

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -44,8 +44,8 @@ namespace mockturtle
 
 struct validator_params
 {
-  /*! \brief Maximum number of clauses of the SAT solver. */
-  uint32_t max_solver_size{10000};
+  /*! \brief Maximum number of clauses of the SAT solver. (incremental CNF construction) */
+  uint32_t max_clauses{1000};
 
   /*! \brief Whether to consider ODC, and how many levels. 0 = No consideration. -1 = Consider TFO until PO. */
   int odc_levels{0};
@@ -145,7 +145,7 @@ public:
       construct( ntk.get_node( d ) );
     }
     auto const res = validate( ntk.get_node( f ), lit_not_cond( literals[d], ntk.is_complemented( f ) ^ ntk.is_complemented( d ) ) );
-    if ( solver.num_clauses() > ps.max_solver_size )
+    if ( solver.num_clauses() > ps.max_clauses )
     {
       restart();
     }
@@ -160,7 +160,7 @@ public:
       construct( ntk.get_node( d ) );
     }
     auto const res = validate( root, lit_not_cond( literals[d], ntk.is_complemented( d ) ) );
-    if ( solver.num_clauses() > ps.max_solver_size )
+    if ( solver.num_clauses() > ps.max_clauses )
     {
       restart();
     }
@@ -230,7 +230,7 @@ public:
       solver.pop();
     }
 
-    if ( solver.num_clauses() > ps.max_solver_size )
+    if ( solver.num_clauses() > ps.max_clauses )
     {
       restart();
     }
@@ -278,39 +278,11 @@ public:
       res = solve( {lit_not_cond( literals[root], value )} );
     }
 
-    if ( solver.num_clauses() > ps.max_solver_size )
+    if ( solver.num_clauses() > ps.max_clauses )
     {
       restart();
     }
     return res;
-  }
-
-  /*! \brief Add CNF clauses for a newly created node.
-   *
-   * This function should be called when a new node is created after 
-   * construction of circuit_validator.
-   * It can be called manually every time or be added to `ntk.on_add` events.
-   */
-  void add_node( node const& n )
-  {
-    /*std::vector<bill::lit_type> lit_fi;
-    ntk.foreach_fanin( n, [&]( const auto& f ) {
-      lit_fi.emplace_back( lit_not_cond( literals[f], ntk.is_complemented( f ) ) );
-    } );
-
-    literals.resize();
-    assert( lit_fi.size() == 2u || lit_fi.size() == 3u );
-    if ( lit_fi.size() == 2u )
-    {
-      assert( ntk.is_and( n ) || ntk.is_xor( n ) );
-      literals[n] = add_clauses_for_2input_gate( lit_fi[0], lit_fi[1], std::nullopt, ntk.is_and( n ) ? AND : XOR );
-    }
-    else
-    {
-      assert( lit_fi.size() == 3u );
-      assert( ntk.is_maj( n ) || ntk.is_xor3( n ) );
-      literals[n] = add_clauses_for_3input_gate( lit_fi[0], lit_fi[1], lit_fi[2], std::nullopt, ntk.is_maj( n ) ? MAJ : XOR );
-    }*/
   }
 
   /*! \brief Update CNF clauses.

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -191,11 +191,6 @@ public:
     {
       construct( root );
     }
-    
-    if constexpr ( use_pushpop )
-    {
-      solver.push();
-    }
 
     std::vector<bill::lit_type> lits;
     while ( divs_begin != divs_end )
@@ -206,6 +201,11 @@ public:
       }
       lits.emplace_back( literals[*divs_begin] );
       divs_begin++;
+    }
+
+    if constexpr ( use_pushpop )
+    {
+      solver.push();
     }
 
     for ( auto g : ckt )

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -232,6 +232,12 @@ public:
     return data->find( ntk.node_to_index( n ) ) != data->end();
   }
 
+  /*! \brief Check if a key is already defined. */
+  bool has( signal const& f ) const
+  {
+    return data->find( ntk.node_to_index( ntk.get_node( f ) ) ) != data->end();
+  }
+
   /*! \brief Mutable access to value by node. */
   reference operator[]( node const& n )
   {

--- a/lib/abcsat/abc/satSolver.h
+++ b/lib/abcsat/abc/satSolver.h
@@ -310,6 +310,12 @@ static inline int sat_solver_set_random(sat_solver* s, int fNotUseRandom)
 
 static inline void sat_solver_bookmark(sat_solver* s)
 {
+    if (s->qtail != s->qhead)
+    {
+        int status = sat_solver_simplify(s);
+        assert(status!=0);
+        assert(s->qtail == s->qhead);
+    }
     assert( s->qhead == s->qtail );
     s->iVarPivot    = s->size;
     s->iTrailPivot  = s->qhead;

--- a/lib/bill/bill/sat/solver/abc/satSolver.h
+++ b/lib/bill/bill/sat/solver/abc/satSolver.h
@@ -310,6 +310,12 @@ static inline int sat_solver_set_random(sat_solver* s, int fNotUseRandom)
 
 static inline void sat_solver_bookmark(sat_solver* s)
 {
+    if (s->qtail != s->qhead)
+    {
+        int status = sat_solver_simplify(s);
+        assert(status!=0);
+        assert(s->qtail == s->qhead);
+    }
     assert( s->qhead == s->qtail );
     s->iVarPivot    = s->size;
     s->iTrailPivot  = s->qhead;

--- a/test/algorithms/circuit_validator.cpp
+++ b/test/algorithms/circuit_validator.cpp
@@ -71,12 +71,10 @@ TEST_CASE( "Validating with non-existing circuit", "[validator]" )
 
   circuit_validator v( aig );
 
-  circuit_validator<aig_network>::gate::fanin fi1;
-  fi1.idx = 0; fi1.inv = true;
-  circuit_validator<aig_network>::gate::fanin fi2;
-  fi2.idx = 1; fi2.inv = true;
-  circuit_validator<aig_network>::gate g;
-  g.fanins = {fi1, fi2};
+  circuit_validator<aig_network>::gate::fanin gi1{0, true};
+  circuit_validator<aig_network>::gate::fanin gi2{1, true};
+  circuit_validator<aig_network>::gate g{{gi1, gi2}, circuit_validator<aig_network>::gate_type::AND};
+
   CHECK( *( v.validate( f3, {aig.get_node( f1 ), aig.get_node( f2 )}, {g}, true ) ) == true );
   CHECK( *( v.validate( aig.get_node( f3 ), {aig.get_node( f1 ), aig.get_node( f2 )}, {g}, false ) ) == true );
 }

--- a/test/algorithms/circuit_validator.cpp
+++ b/test/algorithms/circuit_validator.cpp
@@ -93,13 +93,9 @@ TEST_CASE( "Validating after circuit update", "[validator]" )
 
   circuit_validator v( aig );
 
-  /* new nodes created after construction of `circuit_validator` have to be added to it manually with `add_node` */
   auto const g1 = aig.create_and( a, b );
   auto const g2 = aig.create_and( !a, !b );
   auto const g3 = aig.create_or( g1, g2 );
-  v.add_node( aig.get_node( g1 ) );
-  v.add_node( aig.get_node( g2 ) );
-  v.add_node( aig.get_node( g3 ) );
 
   CHECK( *( v.validate( aig.get_node( f3 ), g3 ) ) == true );
 }


### PR DESCRIPTION
Only add the clauses for a node when it is used. 
Invocation of `push`/`pop` is adjusted (only use it for duplicated TFO cone and when validating with non-existing circuit).
Documentation is also updated, referring to `cnf_view`.

I would suggest to wait until this PR is merged and also port it here. [https://github.com/lsils/bill/pull/35](url)