### PR TITLE
cut_rewriting on stacked fanout-depth or depth-fanout view

### DIFF
--- a/test/algorithms/cut_rewriting.cpp
+++ b/test/algorithms/cut_rewriting.cpp
@@ -7,6 +7,7 @@
 #include <mockturtle/algorithms/node_resynthesis/xag_minmc2.hpp>
 #include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
 #include <mockturtle/algorithms/node_resynthesis/xmg3_npn.hpp>
+#include <mockturtle/views/fanout_view.hpp>
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/klut.hpp>
 #include <mockturtle/networks/mig.hpp>
@@ -385,6 +386,76 @@ TEST_CASE( "Cut rewriting should avoid cycles", "[cut_rewriting]" )
   ps.cut_enumeration_ps.cut_size = 4;
   aig = cut_rewriting( aig, resyn, ps );
 
+  CHECK( aig.size() == 12 );
+  CHECK( aig.num_pis() == 3 );
+  CHECK( aig.num_pos() == 2 );
+  CHECK( aig.num_gates() == 8 );
+}
+
+TEST_CASE( "Cut rewriting with stacked fanout-depth views", "[cut_rewriting]" )
+{
+  aig_network aig;
+  const auto x0 = aig.create_pi();
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+
+  const auto n0 = aig.create_and( x1, !x2 );
+  const auto n1 = aig.create_and( !x0, n0 );
+  const auto n2 = aig.create_and( x0, !n0 );
+  const auto n3 = aig.create_and( !n1, !n2 );
+  const auto n4 = aig.create_and( x1, x2 );
+  const auto n5 = aig.create_and( x0, !n4 );
+  const auto n6 = aig.create_and( !x0, n4 );
+  const auto n7 = aig.create_and( !n5, !n6 );
+  aig.create_po( n3 );
+  aig.create_po( n7 );
+
+  /* cut_rewriting of fanout_view of depth_view of aig_network */
+  using cost_fn = unit_cost<aig_network>;
+  using resyn_fn = xag_npn_resynthesis<aig_network>;
+
+  resyn_fn resyn;
+  fanout_view fanout_aig{aig};
+  depth_view<fanout_view<aig_network>, cost_fn> depth_aig{fanout_aig};
+
+  cut_rewriting_params ps;
+  cut_rewriting_stats st;
+  aig = detail::cut_rewriting_impl<aig_network, decltype( depth_aig ), resyn_fn, cost_fn>( depth_aig, resyn, ps, st ).run();
+  CHECK( aig.size() == 12 );
+  CHECK( aig.num_pis() == 3 );
+  CHECK( aig.num_pos() == 2 );
+  CHECK( aig.num_gates() == 8 );
+}
+
+TEST_CASE( "Cut rewriting with stacked depth-fanout views", "[cut_rewriting]" )
+{
+  aig_network aig;
+  const auto x0 = aig.create_pi();
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+
+  const auto n0 = aig.create_and( x1, !x2 );
+  const auto n1 = aig.create_and( !x0, n0 );
+  const auto n2 = aig.create_and( x0, !n0 );
+  const auto n3 = aig.create_and( !n1, !n2 );
+  const auto n4 = aig.create_and( x1, x2 );
+  const auto n5 = aig.create_and( x0, !n4 );
+  const auto n6 = aig.create_and( !x0, n4 );
+  const auto n7 = aig.create_and( !n5, !n6 );
+  aig.create_po( n3 );
+  aig.create_po( n7 );
+
+  /* cut_rewriting of fanout_view of depth_view of aig_network */
+  using cost_fn = unit_cost<aig_network>;
+  using resyn_fn = xag_npn_resynthesis<aig_network>;
+
+  resyn_fn resyn;
+  fanout_view fanout_aig{aig};
+  depth_view<fanout_view<aig_network>, cost_fn> depth_aig{fanout_aig};
+
+  cut_rewriting_params ps;
+  cut_rewriting_stats st;
+  aig = detail::cut_rewriting_impl<aig_network, decltype( depth_aig ), resyn_fn, cost_fn>( depth_aig, resyn, ps, st ).run();
   CHECK( aig.size() == 12 );
   CHECK( aig.num_pis() == 3 );
   CHECK( aig.num_pos() == 2 );


### PR DESCRIPTION
- Allow construction of `fanout_view` without network parameter
- Test `cut_rewriting` on stacked fanout-depth and depth-fanout view