### PR TITLE
Incremental simulation

### DIFF
--- a/docs/algorithms/simulation.rst
+++ b/docs/algorithms/simulation.rst
@@ -72,3 +72,26 @@ The following simulators are implemented:
   simulates truth tables.  Each primary input is assigned the projection
   function according to the index.  The number of variables be passed to the
   constructor of the simulator.
+* ``mockturtle::partial_simulator``: This simulator simulates partial truth tables,
+  whose length is flexible and new simulation patterns can be added.
+
+Partial simulation
+~~~~~~~~~~~~~~~~~~
+
+With `partial_simulator`, adding new simulation patterns and re-simulation can be done.
+Incremental simulation is adopted, which speeds up simulation time by only re-simulating needed nodes and only re-computing the last block of `partial_truth_table`.
+Note that currently only AIG and XAG are supported.
+
+.. doxygenfunction:: mockturtle::partial_simulator::partial_simulator( unsigned, unsigned, std::default_random_engine::result_type )
+
+.. doxygenfunction:: mockturtle::partial_simulator::partial_simulator( std::vector<kitty::partial_truth_table> const& )
+
+.. doxygenfunction:: mockturtle::partial_simulator::partial_simulator( const std::string&, uint32_t )
+
+.. doxygenfunction:: mockturtle::partial_simulator::num_bits()
+
+.. doxygenfunction:: mockturtle::partial_simulator::write_patterns( const std::string& )
+
+.. doxygenfunction:: mockturtle::simulate_nodes( Ntk const&, unordered_node_map<kitty::partial_truth_table, Ntk>&, partial_simulator const&, bool )
+
+.. doxygenfunction:: mockturtle::simulate_node( Ntk const&, typename Ntk::node const&, unordered_node_map<kitty::partial_truth_table, Ntk>&, partial_simulator const& )

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -269,6 +269,7 @@ public:
     ++num_patterns;
   }
 
+  /*! \brief Writes the simulation patterns into a file. */
   void write_patterns( const std::string& filename )
   {
     std::ofstream out( filename, std::ofstream::out );
@@ -487,6 +488,8 @@ void update_const_pi( Ntk const& ntk, unordered_node_map<kitty::partial_truth_ta
  * 
  * It is assumed that `node_to_value.has( n )` is true for every node except `n`,
  * but not necessarily up to date. If not, needed nodes in its transitive fanin cone will be re-simulated.
+ * Note that re-simulation is only done for the last block, no matter how many bits are used in this block.
+ * Hence, it is advised to call `simulate_nodes` with `simulate_whole_tt = false` whenever `sim.num_bits() % 64 == 0`.
  * 
  */
 template<class Ntk>
@@ -527,7 +530,7 @@ void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_
 template<class Ntk>
 void simulate_nodes( Ntk const& ntk, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, partial_simulator const& sim, bool simulate_whole_tt = true )
 {
-  /* TODO: The partial_truth_table specialized ntk.compute is currently only implemented in AIG. */
+  /* TODO: The partial_truth_table specialized ntk.compute is currently only implemented in AIG and XAG. */
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
   static_assert( has_constant_value_v<Ntk>, "Ntk does not implement the constant_value method" );

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -1024,6 +1024,7 @@ public:
     return ( c1.weight ? ~tt1 : tt1 ) & ( c2.weight ? ~tt2 : tt2 );
   }
 
+  /*! \brief Re-compute the last block. */
   template<typename Iterator>
   void compute( node const& n, kitty::partial_truth_table& result, Iterator begin, Iterator end ) const
   {
@@ -1040,15 +1041,11 @@ public:
 
     assert( tt1.num_bits() == tt2.num_bits() );
     assert( tt1.num_bits() >= result.num_bits() );
-    if ( result.num_bits() == 0 )
-    {
-      result = ( c1.weight ? ~tt1 : tt1 ) & ( c2.weight ? ~tt2 : tt2 );
-    }
-    else
-    {
-      result.resize( tt1.num_bits() );
-      result._bits.back() = ( c1.weight ? ~(tt1._bits.back()) : tt1._bits.back() ) & ( c2.weight ? ~(tt2._bits.back()) : tt2._bits.back() );
-    }
+    assert( result.num_blocks() == tt1.num_blocks() || ( result.num_blocks() == tt1.num_blocks() - 1 && result.num_bits() % 64 == 0 ) );
+
+    result.resize( tt1.num_bits() );
+    result._bits.back() = ( c1.weight ? ~(tt1._bits.back()) : tt1._bits.back() ) & ( c2.weight ? ~(tt2._bits.back()) : tt2._bits.back() );
+    result.mask_bits();
   }
 #pragma endregion
 

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -1083,6 +1083,37 @@ public:
       return ( c1.weight ? ~tt1 : tt1 ) ^ ( c2.weight ? ~tt2 : tt2 );
     }
   }
+
+  /*! \brief Re-compute the last block. */
+  template<typename Iterator>
+  void compute( node const& n, kitty::partial_truth_table& result, Iterator begin, Iterator end ) const
+  {
+    (void)end;
+    /* TODO: assert type of *begin is partial_truth_table */
+
+    assert( n != 0 && !is_ci( n ) );
+
+    auto const& c1 = _storage->nodes[n].children[0];
+    auto const& c2 = _storage->nodes[n].children[1];
+
+    auto tt1 = *begin++;
+    auto tt2 = *begin++;
+
+    assert( tt1.num_bits() == tt2.num_bits() );
+    assert( tt1.num_bits() >= result.num_bits() );
+    assert( result.num_blocks() == tt1.num_blocks() || ( result.num_blocks() == tt1.num_blocks() - 1 && result.num_bits() % 64 == 0 ) );
+
+    result.resize( tt1.num_bits() );
+    if ( c1.index < c2.index )
+    {
+      result._bits.back() = ( c1.weight ? ~(tt1._bits.back()) : tt1._bits.back() ) & ( c2.weight ? ~(tt2._bits.back()) : tt2._bits.back() );
+    }
+    else
+    {
+      result._bits.back() = ( c1.weight ? ~(tt1._bits.back()) : tt1._bits.back() ) ^ ( c2.weight ? ~(tt2._bits.back()) : tt2._bits.back() );
+    }
+    result.mask_bits();
+  }
 #pragma endregion
 
 #pragma region Custom node values

--- a/test/algorithms/simulation.cpp
+++ b/test/algorithms/simulation.cpp
@@ -109,19 +109,84 @@ TEST_CASE( "Partial simulator", "[simulation]" )
   partial_simulator sim( pats );
 
   unordered_node_map<kitty::partial_truth_table, aig_network> node_to_value( aig );
-  simulate_nodes<kitty::partial_truth_table>( aig, node_to_value, sim );
+  simulate_nodes( aig, node_to_value, sim );
 
+  CHECK( ( aig.is_complemented( f1 ) ? ~node_to_value[f1] : node_to_value[f1] )._bits[0] == 0x1d ); /* f1 = 11101 */
+  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0x17 ); /* f2 = 10111 */
+  CHECK( ( aig.is_complemented( f3 ) ? ~node_to_value[f3] : node_to_value[f3] )._bits[0] == 0x0e ); /* f3 = 01110 */
   CHECK( ( aig.is_complemented( f4 ) ? ~node_to_value[f4] : node_to_value[f4] )._bits[0] == 0x19 ); /* f4 = 11001 */
+}
 
-  node_to_value.reset();
+TEST_CASE( "Add pattern and re-simulate with partial_simulator", "[simulation]" )
+{
+  aig_network aig;
 
-  /* set node f1 to false, such that function f1 becomes true */
-  node_to_value[ aig.get_node( f1 ) ] = kitty::partial_truth_table( 5 );
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+  const auto f1 = aig.create_xor( a, b );
+  const auto f2 = aig.create_xor( f1, c );
+  aig.create_po( f2 ); /* f2 = a ^ b ^ c */
 
-  /* re-simulated with the fixed value for f1 */
-  simulate_nodes<kitty::partial_truth_table>( aig, node_to_value, sim );
-  CHECK( ( aig.is_complemented( f1 ) ? ~node_to_value[f1] : node_to_value[f1] )._bits[0] == 0x1f ); /* f1 = 11111 */
-  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0x15 ); /* f2 = 10101 */
-  CHECK( ( aig.is_complemented( f3 ) ? ~node_to_value[f3] : node_to_value[f3] )._bits[0] == 0x0c ); /* f3 = 01100 */
-  CHECK( ( aig.is_complemented( f4 ) ? ~node_to_value[f4] : node_to_value[f4] )._bits[0] == 0x1b ); /* f4 = 11011 */
+  std::vector<kitty::partial_truth_table> pats( 3 );
+  pats[0].add_bits( 0x1, 2 ); /* a = 01 */
+  pats[1].add_bits( 0x1, 2 ); /* b = 01 */
+  pats[2].add_bits( 0x1, 2 ); /* c = 01 */
+  partial_simulator sim( pats );
+
+  unordered_node_map<kitty::partial_truth_table, aig_network> node_to_value( aig );
+  simulate_nodes( aig, node_to_value, sim );
+  CHECK( sim.num_bits() == 2u );
+  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0x1 ); /* f2 = 01 */
+
+  std::vector<bool> pattern( 3 );
+  pattern[0] = 0; pattern[1] = 1; pattern[2] = 0;
+  sim.add_pattern( pattern );
+  pattern[0] = 1; pattern[1] = 0; pattern[2] = 0;
+  sim.add_pattern( pattern );
+  /* a = 1001, b = 0101, c = 0001 */
+
+  simulate_nodes( aig, node_to_value, sim, false );
+  CHECK( sim.num_bits() == 4u );
+  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0xd ); /* f2 = 1101 */
+}
+
+TEST_CASE( "Incremental simulation with partial_simulator", "[simulation]" )
+{
+  aig_network aig;
+
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+  const auto f1 = aig.create_xor( a, b );
+  const auto f2 = aig.create_xor( f1, c );
+  aig.create_po( f2 ); /* f2 = a ^ b ^ c */
+  const auto f3 = aig.create_xor( b, !c );
+  const auto f4 = aig.create_xor( f3, a );
+  aig.create_po( f4 ); /* f4 = !(a ^ b ^ c) = !f2 */
+
+  std::vector<kitty::partial_truth_table> pats( 3 );
+  pats[0].add_bits( 0, 64 );
+  pats[1].add_bits( 0, 64 );
+  pats[2].add_bits( 0, 64 );
+  partial_simulator sim( pats );
+
+  unordered_node_map<kitty::partial_truth_table, aig_network> node_to_value( aig );
+  simulate_nodes( aig, node_to_value, sim );
+  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0 );
+  CHECK( ( aig.is_complemented( f4 ) ? ~node_to_value[f4] : node_to_value[f4] )._bits[0] == ~0 );
+
+  std::vector<bool> pattern( 3 );
+  pattern[0] = 0; pattern[1] = 1; pattern[2] = 0;
+  sim.add_pattern( pattern );
+
+  simulate_node( aig, aig.get_node( f2 ), node_to_value, sim );
+  CHECK( node_to_value[f2].num_bits() == 65 );
+  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[1] == 1 );
+  CHECK( node_to_value[f1].num_bits() == 65 ); /* f1 is in f2's fanin cone hence it is re-simulated. */
+  CHECK( node_to_value[f4].num_bits() == 64 ); /* f4 is not in f2's fanin cone hence it is not re-simulated. */
+
+  const auto f5 = aig.create_and( f2, f4 );
+  simulate_node( aig, aig.get_node( f5 ), node_to_value, sim );
+  CHECK( ( aig.is_complemented( f5 ) ? ~node_to_value[f5] : node_to_value[f5] ) == kitty::partial_truth_table( 65 ) );
 }

--- a/test/algorithms/simulation.cpp
+++ b/test/algorithms/simulation.cpp
@@ -2,6 +2,7 @@
 
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xag.hpp>
 
 #include <kitty/static_truth_table.hpp>
 
@@ -119,14 +120,14 @@ TEST_CASE( "Partial simulator", "[simulation]" )
 
 TEST_CASE( "Add pattern and re-simulate with partial_simulator", "[simulation]" )
 {
-  aig_network aig;
+  xag_network xag;
 
-  const auto a = aig.create_pi();
-  const auto b = aig.create_pi();
-  const auto c = aig.create_pi();
-  const auto f1 = aig.create_xor( a, b );
-  const auto f2 = aig.create_xor( f1, c );
-  aig.create_po( f2 ); /* f2 = a ^ b ^ c */
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+  const auto f1 = xag.create_xor( a, b );
+  const auto f2 = xag.create_xor( f1, c );
+  xag.create_po( f2 ); /* f2 = a ^ b ^ c */
 
   std::vector<kitty::partial_truth_table> pats( 3 );
   pats[0].add_bits( 0x1, 2 ); /* a = 01 */
@@ -134,10 +135,10 @@ TEST_CASE( "Add pattern and re-simulate with partial_simulator", "[simulation]" 
   pats[2].add_bits( 0x1, 2 ); /* c = 01 */
   partial_simulator sim( pats );
 
-  unordered_node_map<kitty::partial_truth_table, aig_network> node_to_value( aig );
-  simulate_nodes( aig, node_to_value, sim );
+  unordered_node_map<kitty::partial_truth_table, xag_network> node_to_value( xag );
+  simulate_nodes( xag, node_to_value, sim );
   CHECK( sim.num_bits() == 2u );
-  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0x1 ); /* f2 = 01 */
+  CHECK( ( xag.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0x1 ); /* f2 = 01 */
 
   std::vector<bool> pattern( 3 );
   pattern[0] = 0; pattern[1] = 1; pattern[2] = 0;
@@ -146,9 +147,9 @@ TEST_CASE( "Add pattern and re-simulate with partial_simulator", "[simulation]" 
   sim.add_pattern( pattern );
   /* a = 1001, b = 0101, c = 0001 */
 
-  simulate_nodes( aig, node_to_value, sim, false );
+  simulate_nodes( xag, node_to_value, sim, false );
   CHECK( sim.num_bits() == 4u );
-  CHECK( ( aig.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0xd ); /* f2 = 1101 */
+  CHECK( ( xag.is_complemented( f2 ) ? ~node_to_value[f2] : node_to_value[f2] )._bits[0] == 0xd ); /* f2 = 1101 */
 }
 
 TEST_CASE( "Incremental simulation with partial_simulator", "[simulation]" )


### PR DESCRIPTION
This PR:
* Implements incremental simulation (only needed nodes in the transitive fan-in cone are simulated).
* Supports XAG for fast re-simulation (only re-simulate the last block in `partial_truth_table`).
* Adds documentation for `partial_simulator`-related codes in `simulation.hpp`.
