### PR TITLE
MIG compute value for partial truth tables and test cases

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc/bin/g++-9 -DMOCKTURTLE_TEST=ON ..
+        cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc@9/bin/g++-9 -DMOCKTURTLE_TEST=ON ..
         make run_tests
     - name: Run tests
       run: |

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -38,8 +38,6 @@
 
 #include "../traits.hpp"
 #include "../utils/node_map.hpp"
-#include "../networks/aig.hpp"
-#include "../networks/xag.hpp"
 
 #include <kitty/constructors.hpp>
 #include <kitty/dynamic_truth_table.hpp>
@@ -479,7 +477,7 @@ void update_const_pi( Ntk const& ntk, unordered_node_map<kitty::partial_truth_ta
 
 } // namespace detail
 
-/*! \brief (re-)simulate `n` and its transitive fanin cone.
+/*! \brief (Re-)simulate `n` and its transitive fanin cone.
  * 
  * Note that re-simulation (when `node_to_value.has( n ) == false`) is only done
  * for the last block, no matter how many bits are used in this block.
@@ -496,8 +494,8 @@ void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
   static_assert( has_foreach_pi_v<Ntk>, "Ntk does not implement the foreach_pi method" );
   static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
-  static_assert( has_compute_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the compute method for kitty::partial_truth_table" );
-  static_assert( std::is_same_v<typename Ntk::base_type, aig_network> || std::is_same_v<typename Ntk::base_type, xag_network>, "The partial_truth_table specialized ntk.compute is currently only implemented in AIG and XAG" );
+  static_assert( has_compute_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the compute specialization for kitty::partial_truth_table" );
+  static_assert( has_compute_inplace_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the in-place compute specialization for kitty::partial_truth_table" );
 
   if ( node_to_value[ntk.get_node( ntk.get_constant( false ) )].num_bits() != sim.num_bits() )
   {
@@ -545,8 +543,8 @@ void simulate_nodes( Ntk const& ntk, unordered_node_map<kitty::partial_truth_tab
   static_assert( has_foreach_pi_v<Ntk>, "Ntk does not implement the foreach_pi method" );
   static_assert( has_foreach_gate_v<Ntk>, "Ntk does not implement the foreach_gate method" );
   static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
-  static_assert( has_compute_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the compute method for kitty::partial_truth_table" );
-  static_assert( std::is_same_v<typename Ntk::base_type, aig_network> || std::is_same_v<typename Ntk::base_type, xag_network>, "The partial_truth_table specialized ntk.compute is currently only implemented in AIG and XAG" );
+  static_assert( has_compute_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the compute specialization for kitty::partial_truth_table" );
+  static_assert( has_compute_inplace_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the in-place compute specialization for kitty::partial_truth_table" );
 
   detail::update_const_pi( ntk, node_to_value, sim );
 

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -1028,9 +1028,9 @@ public:
   template<typename Iterator>
   void compute( node const& n, kitty::partial_truth_table& result, Iterator begin, Iterator end ) const
   {
-    (void)end;
-    /* TODO: assert type of *begin is partial_truth_table */
+    static_assert( iterates_over_v<Iterator, kitty::partial_truth_table>, "begin and end have to iterate over partial_truth_tables" );
 
+    (void)end;
     assert( n != 0 && !is_ci( n ) );
 
     auto const& c1 = _storage->nodes[n].children[0];
@@ -1039,6 +1039,7 @@ public:
     auto tt1 = *begin++;
     auto tt2 = *begin++;
 
+    assert( tt1.num_bits() > 0 && "truth tables must not be empty" );
     assert( tt1.num_bits() == tt2.num_bits() );
     assert( tt1.num_bits() >= result.num_bits() );
     assert( result.num_blocks() == tt1.num_blocks() || ( result.num_blocks() == tt1.num_blocks() - 1 && result.num_bits() % 64 == 0 ) );

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -1100,8 +1100,9 @@ public:
   template<typename Iterator>
   void compute( node const& n, kitty::partial_truth_table& result, Iterator begin, Iterator end ) const
   {
-    (void)end;
+    static_assert( iterates_over_v<Iterator, kitty::partial_truth_table>, "begin and end have to iterate over partial_truth_tables" );
 
+    (void)end;
     assert( n != 0 && !is_ci( n ) );
 
     auto const& c1 = _storage->nodes[n].children[0];
@@ -1112,6 +1113,7 @@ public:
     auto tt2 = *begin++;
     auto tt3 = *begin++;
 
+    assert( tt1.num_bits() > 0 && "truth tables must not be empty" );
     assert( tt1.num_bits() == tt2.num_bits() );
     assert( tt1.num_bits() == tt3.num_bits() );
     assert( tt1.num_bits() >= result.num_bits() );

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -1095,6 +1095,35 @@ public:
 
     return kitty::ternary_majority( c1.weight ? ~tt1 : tt1, c2.weight ? ~tt2 : tt2, c3.weight ? ~tt3 : tt3 );
   }
+
+  /*! \brief Re-compute the last block. */
+  template<typename Iterator>
+  void compute( node const& n, kitty::partial_truth_table& result, Iterator begin, Iterator end ) const
+  {
+    (void)end;
+
+    assert( n != 0 && !is_ci( n ) );
+
+    auto const& c1 = _storage->nodes[n].children[0];
+    auto const& c2 = _storage->nodes[n].children[1];
+    auto const& c3 = _storage->nodes[n].children[2];
+
+    auto tt1 = *begin++;
+    auto tt2 = *begin++;
+    auto tt3 = *begin++;
+
+    assert( tt1.num_bits() == tt2.num_bits() );
+    assert( tt1.num_bits() == tt3.num_bits() );
+    assert( tt1.num_bits() >= result.num_bits() );
+    assert( result.num_blocks() == tt1.num_blocks() || ( result.num_blocks() == tt1.num_blocks() - 1 && result.num_bits() % 64 == 0 ) );
+
+    result.resize( tt1.num_bits() );
+    result._bits.back() =
+      ( ( c1.weight ? ~tt1._bits.back() : tt1._bits.back() ) & ( c2.weight ? ~tt2._bits.back() : tt2._bits.back() ) ) |
+      ( ( c1.weight ? ~tt1._bits.back() : tt1._bits.back() ) & ( c3.weight ? ~tt3._bits.back() : tt3._bits.back() ) ) |
+      ( ( c2.weight ? ~tt2._bits.back() : tt2._bits.back() ) & ( c3.weight ? ~tt3._bits.back() : tt3._bits.back() ) );
+    result.mask_bits();
+  }
 #pragma endregion
 
 #pragma region Custom node values

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -1088,9 +1088,9 @@ public:
   template<typename Iterator>
   void compute( node const& n, kitty::partial_truth_table& result, Iterator begin, Iterator end ) const
   {
-    (void)end;
-    /* TODO: assert type of *begin is partial_truth_table */
+    static_assert( iterates_over_v<Iterator, kitty::partial_truth_table>, "begin and end have to iterate over partial_truth_tables" );
 
+    (void)end;
     assert( n != 0 && !is_ci( n ) );
 
     auto const& c1 = _storage->nodes[n].children[0];
@@ -1099,6 +1099,7 @@ public:
     auto tt1 = *begin++;
     auto tt2 = *begin++;
 
+    assert( tt1.num_bits() > 0 && "truth tables must not be empty" );
     assert( tt1.num_bits() == tt2.num_bits() );
     assert( tt1.num_bits() >= result.num_bits() );
     assert( result.num_blocks() == tt1.num_blocks() || ( result.num_blocks() == tt1.num_blocks() - 1 && result.num_bits() % 64 == 0 ) );

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -1553,6 +1553,21 @@ template<class Ntk, typename T>
 inline constexpr bool has_compute_v = has_compute<Ntk, T>::value;
 #pragma endregion
 
+#pragma region has_compute_inplace
+template<class Ntk, typename T, class = void>
+struct has_compute_inplace : std::false_type
+{
+};
+
+template<class Ntk, typename T>
+struct has_compute_inplace<Ntk, T, std::void_t<decltype( std::declval<Ntk>().compute( std::declval<node<Ntk>>(), std::declval<T&>(), std::begin( std::vector<T>() ), std::end( std::vector<T>() ) ) )>> : std::true_type
+{
+};
+
+template<class Ntk, typename T>
+inline constexpr bool has_compute_inplace_v = has_compute_inplace<Ntk, T>::value;
+#pragma endregion
+
 #pragma region has_has_mapping
 template<class Ntk, class = void>
 struct has_has_mapping : std::false_type

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -1953,4 +1953,7 @@ using iterates_over_t = std::enable_if_t<std::is_same_v<typename Iterator::value
 template<typename Iterator>
 using iterates_over_truth_table_t = std::enable_if_t<kitty::is_truth_table<typename Iterator::value_type>::value, typename Iterator::value_type>;
 
+template<class Iterator, typename T>
+inline constexpr bool iterates_over_v = std::is_same_v<typename Iterator::value_type, T>;
+
 } /* namespace mockturtle */

--- a/test/algorithms/pattern_generation.cpp
+++ b/test/algorithms/pattern_generation.cpp
@@ -4,7 +4,7 @@
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/algorithms/pattern_generation.hpp>
 #include <mockturtle/networks/aig.hpp>
-#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xag.hpp>
 
 #include <kitty/bit_operations.hpp>
 

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -437,6 +437,7 @@ TEST_CASE( "compute values in AIGs", "[aig]" )
 
   CHECK( has_compute_v<aig_network, bool> );
   CHECK( has_compute_v<aig_network, kitty::dynamic_truth_table> );
+  CHECK( has_compute_v<aig_network, kitty::partial_truth_table> );
 
   const auto x1 = aig.create_pi();
   const auto x2 = aig.create_pi();
@@ -445,17 +446,48 @@ TEST_CASE( "compute values in AIGs", "[aig]" )
   aig.create_po( f1 );
   aig.create_po( f2 );
 
-  std::vector<bool> values{{true, false}};
+  {
+    std::vector<bool> values{{true, false}};
 
-  CHECK( aig.compute( aig.get_node( f1 ), values.begin(), values.end() ) == false );
-  CHECK( aig.compute( aig.get_node( f2 ), values.begin(), values.end() ) == true );
+    CHECK( aig.compute( aig.get_node( f1 ), values.begin(), values.end() ) == false );
+    CHECK( aig.compute( aig.get_node( f2 ), values.begin(), values.end() ) == true );
+  }
 
-  std::vector<kitty::dynamic_truth_table> xs{2, kitty::dynamic_truth_table( 2 )};
-  kitty::create_nth_var( xs[0], 0 );
-  kitty::create_nth_var( xs[1], 1 );
+  {
+    std::vector<kitty::dynamic_truth_table> xs{2, kitty::dynamic_truth_table( 2 )};
+    kitty::create_nth_var( xs[0], 0 );
+    kitty::create_nth_var( xs[1], 1 );
 
-  CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
-  CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+    CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+  }
+
+  {
+    std::vector<kitty::partial_truth_table> xs{2, kitty::partial_truth_table( 4 )};
+
+    CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 );
+
+    CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 );
+
+    CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 );
+
+    CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 );
+
+    CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+  }
 }
 
 TEST_CASE( "custom node values in AIGs", "[aig]" )

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -438,6 +438,7 @@ TEST_CASE( "compute values in AIGs", "[aig]" )
   CHECK( has_compute_v<aig_network, bool> );
   CHECK( has_compute_v<aig_network, kitty::dynamic_truth_table> );
   CHECK( has_compute_v<aig_network, kitty::partial_truth_table> );
+  CHECK( has_compute_inplace_v<aig_network, kitty::partial_truth_table> );
 
   const auto x1 = aig.create_pi();
   const auto x2 = aig.create_pi();

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -464,7 +464,7 @@ TEST_CASE( "compute values in AIGs", "[aig]" )
   }
 
   {
-    std::vector<kitty::partial_truth_table> xs{2, kitty::partial_truth_table( 4 )};
+    std::vector<kitty::partial_truth_table> xs{2};
 
     CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
     CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -7,6 +7,7 @@
 #include <mockturtle/algorithms/cleanup.hpp>
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xmg.hpp>
 #include <mockturtle/traits.hpp>
 
 using namespace mockturtle;
@@ -488,6 +489,31 @@ TEST_CASE( "compute values in AIGs", "[aig]" )
 
     CHECK( aig.compute( aig.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
     CHECK( aig.compute( aig.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+  }
+
+  {
+    std::vector<kitty::partial_truth_table> xs{2};
+    kitty::partial_truth_table result;
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 );
+
+    aig.compute( aig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    aig.compute( aig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 );
+
+    aig.compute( aig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    aig.compute( aig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 );
+
+    aig.compute( aig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    aig.compute( aig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 );
+
+    aig.compute( aig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    aig.compute( aig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );
   }
 }
 

--- a/test/networks/mig.cpp
+++ b/test/networks/mig.cpp
@@ -468,6 +468,7 @@ TEST_CASE( "compute values in MIGs", "[mig]" )
 
   CHECK( has_compute_v<mig_network, bool> );
   CHECK( has_compute_v<mig_network, kitty::dynamic_truth_table> );
+  CHECK( has_compute_v<mig_network, kitty::partial_truth_table> );
 
   const auto x1 = mig.create_pi();
   const auto x2 = mig.create_pi();
@@ -477,18 +478,69 @@ TEST_CASE( "compute values in MIGs", "[mig]" )
   mig.create_po( f1 );
   mig.create_po( f2 );
 
-  std::vector<bool> values{{true, false, true}};
+  {
+    std::vector<bool> values{{true, false, true}};
 
-  CHECK( mig.compute( mig.get_node( f1 ), values.begin(), values.end() ) == false );
-  CHECK( mig.compute( mig.get_node( f2 ), values.begin(), values.end() ) == true );
+    CHECK( mig.compute( mig.get_node( f1 ), values.begin(), values.end() ) == false );
+    CHECK( mig.compute( mig.get_node( f2 ), values.begin(), values.end() ) == true );
+  }
 
-  std::vector<kitty::dynamic_truth_table> xs{3, kitty::dynamic_truth_table( 3 )};
-  kitty::create_nth_var( xs[0], 0 );
-  kitty::create_nth_var( xs[1], 1 );
-  kitty::create_nth_var( xs[2], 2 );
+  {
+    std::vector<kitty::dynamic_truth_table> xs{3, kitty::dynamic_truth_table( 3 )};
+    kitty::create_nth_var( xs[0], 0 );
+    kitty::create_nth_var( xs[1], 1 );
+    kitty::create_nth_var( xs[2], 2 );
 
-  CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
-  CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+  }
+
+  {
+    std::vector<kitty::partial_truth_table> xs{3, kitty::partial_truth_table( 8 )};
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 ); xs[2].add_bit( 0 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 ); xs[2].add_bit( 1 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 ); xs[2].add_bit( 0 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 ); xs[2].add_bit( 1 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 ); xs[2].add_bit( 0 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 ); xs[2].add_bit( 1 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 ); xs[2].add_bit( 0 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 ); xs[2].add_bit( 1 );
+
+    CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+  }
 }
 
 TEST_CASE( "custom node values in MIGs", "[mig]" )

--- a/test/networks/mig.cpp
+++ b/test/networks/mig.cpp
@@ -497,7 +497,7 @@ TEST_CASE( "compute values in MIGs", "[mig]" )
   }
 
   {
-    std::vector<kitty::partial_truth_table> xs{3, kitty::partial_truth_table( 8 )};
+    std::vector<kitty::partial_truth_table> xs{3};
 
     CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
     CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );

--- a/test/networks/mig.cpp
+++ b/test/networks/mig.cpp
@@ -542,6 +542,54 @@ TEST_CASE( "compute values in MIGs", "[mig]" )
     CHECK( mig.compute( mig.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
     CHECK( mig.compute( mig.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
   }
+
+  {
+    std::vector<kitty::partial_truth_table> xs{3};
+    kitty::partial_truth_table result;
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 ); xs[2].add_bit( 0 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 ); xs[2].add_bit( 1 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 ); xs[2].add_bit( 0 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 ); xs[2].add_bit( 1 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 ); xs[2].add_bit( 0 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 ); xs[2].add_bit( 1 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 ); xs[2].add_bit( 0 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 ); xs[2].add_bit( 1 );
+
+    mig.compute( mig.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    mig.compute( mig.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+  }
 }
 
 TEST_CASE( "custom node values in MIGs", "[mig]" )

--- a/test/networks/mig.cpp
+++ b/test/networks/mig.cpp
@@ -469,6 +469,7 @@ TEST_CASE( "compute values in MIGs", "[mig]" )
   CHECK( has_compute_v<mig_network, bool> );
   CHECK( has_compute_v<mig_network, kitty::dynamic_truth_table> );
   CHECK( has_compute_v<mig_network, kitty::partial_truth_table> );
+  CHECK( has_compute_inplace_v<mig_network, kitty::partial_truth_table> );
 
   const auto x1 = mig.create_pi();
   const auto x2 = mig.create_pi();

--- a/test/networks/xag.cpp
+++ b/test/networks/xag.cpp
@@ -536,7 +536,7 @@ TEST_CASE( "node and signal iteration in an xag", "[xag]" )
   CHECK( mask == 2 );
 }
 
-TEST_CASE( "compute values in xags", "[xag]" )
+TEST_CASE( "compute values in XAGs", "[xag]" )
 {
   xag_network xag;
 
@@ -569,7 +569,7 @@ TEST_CASE( "compute values in xags", "[xag]" )
   }
 
   {
-    std::vector<kitty::partial_truth_table> xs{2, kitty::partial_truth_table( 4 )};
+    std::vector<kitty::partial_truth_table> xs{2};
 
     CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
     CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );

--- a/test/networks/xag.cpp
+++ b/test/networks/xag.cpp
@@ -542,6 +542,7 @@ TEST_CASE( "compute values in xags", "[xag]" )
 
   CHECK( has_compute_v<xag_network, bool> );
   CHECK( has_compute_v<xag_network, kitty::dynamic_truth_table> );
+  CHECK( has_compute_v<xag_network, kitty::partial_truth_table> );
 
   const auto x1 = xag.create_pi();
   const auto x2 = xag.create_pi();
@@ -550,17 +551,48 @@ TEST_CASE( "compute values in xags", "[xag]" )
   xag.create_po( f1 );
   xag.create_po( f2 );
 
-  std::vector<bool> values{{true, false}};
+  {
+    std::vector<bool> values{{true, false}};
 
-  CHECK( xag.compute( xag.get_node( f1 ), values.begin(), values.end() ) == false );
-  CHECK( xag.compute( xag.get_node( f2 ), values.begin(), values.end() ) == true );
+    CHECK( xag.compute( xag.get_node( f1 ), values.begin(), values.end() ) == false );
+    CHECK( xag.compute( xag.get_node( f2 ), values.begin(), values.end() ) == true );
+  }
 
-  std::vector<kitty::dynamic_truth_table> xs{2, kitty::dynamic_truth_table( 2 )};
-  kitty::create_nth_var( xs[0], 0 );
-  kitty::create_nth_var( xs[1], 1 );
+  {
+    std::vector<kitty::dynamic_truth_table> xs{2, kitty::dynamic_truth_table( 2 )};
+    kitty::create_nth_var( xs[0], 0 );
+    kitty::create_nth_var( xs[1], 1 );
 
-  CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
-  CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+    CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+  }
+
+  {
+    std::vector<kitty::partial_truth_table> xs{2, kitty::partial_truth_table( 4 )};
+
+    CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 );
+
+    CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 );
+
+    CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 );
+
+    CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 );
+
+    CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
+    CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
+  }
 }
 
 TEST_CASE( "custom node values in xags", "[xag]" )

--- a/test/networks/xag.cpp
+++ b/test/networks/xag.cpp
@@ -594,6 +594,31 @@ TEST_CASE( "compute values in XAGs", "[xag]" )
     CHECK( xag.compute( xag.get_node( f1 ), xs.begin(), xs.end() ) == ( ~xs[0] & xs[1] ) );
     CHECK( xag.compute( xag.get_node( f2 ), xs.begin(), xs.end() ) == ( xs[0] & ~xs[1] ) );
   }
+
+  {
+    std::vector<kitty::partial_truth_table> xs{2};
+    kitty::partial_truth_table result;
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 );
+
+    xag.compute( xag.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    xag.compute( xag.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 );
+
+    xag.compute( xag.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    xag.compute( xag.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 );
+
+    xag.compute( xag.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    xag.compute( xag.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 );
+
+    xag.compute( xag.get_node( f1 ), result, xs.begin(), xs.end() ); CHECK( result == ( ~xs[0] & xs[1] ) );
+    xag.compute( xag.get_node( f2 ), result, xs.begin(), xs.end() ); CHECK( result == ( xs[0] & ~xs[1] ) );    
+  }
 }
 
 TEST_CASE( "custom node values in xags", "[xag]" )

--- a/test/networks/xag.cpp
+++ b/test/networks/xag.cpp
@@ -543,6 +543,7 @@ TEST_CASE( "compute values in xags", "[xag]" )
   CHECK( has_compute_v<xag_network, bool> );
   CHECK( has_compute_v<xag_network, kitty::dynamic_truth_table> );
   CHECK( has_compute_v<xag_network, kitty::partial_truth_table> );
+  CHECK( has_compute_inplace_v<xag_network, kitty::partial_truth_table> );
 
   const auto x1 = xag.create_pi();
   const auto x2 = xag.create_pi();

--- a/test/networks/xmg.cpp
+++ b/test/networks/xmg.cpp
@@ -545,12 +545,14 @@ TEST_CASE( "node and signal iteration in an xmg", "[xmg]" )
   CHECK( mask == 2 );
 }
 
-TEST_CASE( "compute values in xmgs", "[xmg]" )
+TEST_CASE( "compute values in XMGs", "[xmg]" )
 {
   xmg_network xmg;
 
   CHECK( has_compute_v<xmg_network, bool> );
   CHECK( has_compute_v<xmg_network, kitty::dynamic_truth_table> );
+  CHECK( has_compute_v<xmg_network, kitty::partial_truth_table> );
+  CHECK( !has_compute_inplace_v<xmg_network, kitty::partial_truth_table> );
 
   const auto x1 = xmg.create_pi();
   const auto x2 = xmg.create_pi();
@@ -560,18 +562,69 @@ TEST_CASE( "compute values in xmgs", "[xmg]" )
   xmg.create_po( f1 );
   xmg.create_po( f2 );
 
-  std::vector<bool> values{{true, false, true}};
+  {
+    std::vector<bool> values{{true, false, true}};
 
-  CHECK( xmg.compute( xmg.get_node( f1 ), values.begin(), values.end() ) == false );
-  CHECK( xmg.compute( xmg.get_node( f2 ), values.begin(), values.end() ) == true );
+    CHECK( xmg.compute( xmg.get_node( f1 ), values.begin(), values.end() ) == false );
+    CHECK( xmg.compute( xmg.get_node( f2 ), values.begin(), values.end() ) == true );
+  }
 
-  std::vector<kitty::dynamic_truth_table> xs{3, kitty::dynamic_truth_table( 3 )};
-  kitty::create_nth_var( xs[0], 0 );
-  kitty::create_nth_var( xs[1], 1 );
-  kitty::create_nth_var( xs[2], 2 );
+  {
+    std::vector<kitty::dynamic_truth_table> xs{3, kitty::dynamic_truth_table( 3 )};
+    kitty::create_nth_var( xs[0], 0 );
+    kitty::create_nth_var( xs[1], 1 );
+    kitty::create_nth_var( xs[2], 2 );
 
-  CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
-  CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+  }
+
+  {
+    std::vector<kitty::partial_truth_table> xs{3};
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 ); xs[2].add_bit( 0 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 0 ); xs[2].add_bit( 1 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 ); xs[2].add_bit( 0 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 0 ); xs[1].add_bit( 1 ); xs[2].add_bit( 1 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 ); xs[2].add_bit( 0 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 0 ); xs[2].add_bit( 1 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 ); xs[2].add_bit( 0 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+
+    xs[0].add_bit( 1 ); xs[1].add_bit( 1 ); xs[2].add_bit( 1 );
+
+    CHECK( xmg.compute( xmg.get_node( f1 ), xs.begin(), xs.end() ) == ( ( ~xs[0] & xs[1] ) | ( ~xs[0] & xs[2] ) | ( xs[2] & xs[1] ) ) );
+    CHECK( xmg.compute( xmg.get_node( f2 ), xs.begin(), xs.end() ) == ( ( xs[0] & ~xs[1] ) | ( xs[0] & xs[2] ) | ( xs[2] & ~xs[1] ) ) );
+  }
 }
 
 TEST_CASE( "custom node values in xmgs", "[xmg]" )


### PR DESCRIPTION
This PR adds a specialization of `compute` for partial_truth_tables to `mig_network` and implements test cases for this specialization for all supported network types. This PR allows provides a new trait `has_compute_inplace` and resolves the network dependencies in simulation.