### PR TITLE
Bit packing

### DIFF
--- a/docs/algorithms/simulation.rst
+++ b/docs/algorithms/simulation.rst
@@ -82,16 +82,34 @@ With ``partial_simulator``, adding new simulation patterns and re-simulation can
 Incremental simulation is adopted, which speeds up simulation time by only re-simulating needed nodes and only re-computing the last block of ``partial_truth_table``.
 Note that currently only AIG and XAG are supported.
 
+**Constructors**
+
 .. doxygenfunction:: mockturtle::partial_simulator::partial_simulator( unsigned, unsigned, std::default_random_engine::result_type )
 
 .. doxygenfunction:: mockturtle::partial_simulator::partial_simulator( std::vector<kitty::partial_truth_table> const& )
 
 .. doxygenfunction:: mockturtle::partial_simulator::partial_simulator( const std::string&, uint32_t )
 
+**Interfaces**
+
+.. doxygenfunction:: mockturtle::partial_simulator::add_pattern( std::vector<bool> const& )
+
 .. doxygenfunction:: mockturtle::partial_simulator::num_bits()
 
 .. doxygenfunction:: mockturtle::partial_simulator::get_patterns()
 
-.. doxygenfunction:: mockturtle::simulate_nodes( Ntk const&, unordered_node_map<kitty::partial_truth_table, Ntk>&, partial_simulator const&, bool )
+**Simulation**
 
-.. doxygenfunction:: mockturtle::simulate_node( Ntk const&, typename Ntk::node const&, unordered_node_map<kitty::partial_truth_table, Ntk>&, partial_simulator const& )
+.. doxygenfunction:: mockturtle::simulate_nodes( Ntk const&, unordered_node_map<kitty::partial_truth_table, Ntk>&, Simulator const&, bool )
+
+.. doxygenfunction:: mockturtle::simulate_node( Ntk const&, typename Ntk::node const&, unordered_node_map<kitty::partial_truth_table, Ntk>&, Simulator const& )
+
+**Bit Packing**
+
+To reduce the size of simulation pattern set during pattern generation, ``bit_packed_simulator`` can be used instead of ``partial_simulator``, which has additional interfaces to specify care bits in patterns and to perform bit packing.
+
+.. doxygenclass:: mockturtle::bit_packed_simulator
+
+.. doxygenfunction:: mockturtle::bit_packed_simulator::add_pattern( std::vector<bool> const&, std::vector<bool> const& )
+
+.. doxygenfunction:: mockturtle::bit_packed_simulator::pack_bits()

--- a/experiments/pattern_generation.cpp
+++ b/experiments/pattern_generation.cpp
@@ -54,7 +54,7 @@ int main()
     pattern_generation_stats st;
 
     uint32_t num_random_pattern = 1000;
-    partial_simulator sim( aig.num_pis(), num_random_pattern );
+    bit_packed_simulator sim( aig.num_pis(), num_random_pattern );
     pattern_generation( aig, sim, ps, &st );
 
     exp( benchmark, aig.num_pis(), size_before, sim.num_bits(), st.num_generated_patterns, st.num_constant, to_seconds( st.time_total ), to_seconds( st.time_sim ), to_seconds( st.time_sat ) );

--- a/include/mockturtle/algorithms/pattern_generation.hpp
+++ b/include/mockturtle/algorithms/pattern_generation.hpp
@@ -130,7 +130,7 @@ public:
     stopwatch t( st.time_total );
 
     call_with_stopwatch( st.time_sim, [&]() {
-      simulate_nodes<Ntk>( ntk, tts, sim );
+      simulate_nodes<Ntk>( ntk, tts, sim, true );
     } );
 
     if ( ps.num_stuck_at > 0 )

--- a/include/mockturtle/algorithms/pattern_generation.hpp
+++ b/include/mockturtle/algorithms/pattern_generation.hpp
@@ -443,12 +443,12 @@ private:
 
   std::vector<bool> compute_support( node const& n )
   {
+    ntk.incr_trav_id();
     if constexpr ( use_odc )
     {
       if ( ps.odc_levels != 0 )
       {
         std::vector<node> leaves;
-        ntk.incr_trav_id();
         mark_fanout_leaves_rec( n, 1, leaves );
         ntk.foreach_po( [&]( auto const& f ) {
           if ( ntk.visited( ntk.get_node( f ) ) == ntk.trav_id() )
@@ -457,14 +457,13 @@ private:
           }
         });
 
+        ntk.incr_trav_id();
         for ( auto& l : leaves )
         {
-          ntk.incr_trav_id();
           mark_support_rec( l );
         }
       }
     }
-    ntk.incr_trav_id();
     mark_support_rec( n );
 
     std::vector<bool> care( ntk.num_pis(), false );
@@ -486,7 +485,6 @@ private:
     ntk.foreach_fanin( n, [&]( auto const& f ) {
       if ( ntk.visited( ntk.get_node( f ) ) == ntk.trav_id() )
         { return true; }
-      ntk.set_visited( ntk.get_node( f ), ntk.trav_id() );
       mark_support_rec( ntk.get_node( f ) );
       return true;
     });

--- a/include/mockturtle/algorithms/sim_resub.hpp
+++ b/include/mockturtle/algorithms/sim_resub.hpp
@@ -566,7 +566,7 @@ struct abc_resub_functor_stats
     std::cout << fmt::format( "[i]         #solution = {:6d}\n", num_success );
     std::cout << fmt::format( "[i]         #invoke   = {:6d}\n", num_success + num_fail );
     std::cout << fmt::format( "[i]         ABC time:   {:>5.2f} secs\n", to_seconds( time_compute_function ) );
-    std::cout << fmt::format( "[i]         interface:  {:>5.2f} secs\n", to_seconds( time_compute_function ) );
+    std::cout << fmt::format( "[i]         interface:  {:>5.2f} secs\n", to_seconds( time_interface ) );
     // clang-format on
   }
 };

--- a/include/mockturtle/algorithms/sim_resub.hpp
+++ b/include/mockturtle/algorithms/sim_resub.hpp
@@ -815,7 +815,7 @@ public:
 
     /* first simulation: the whole circuit; from 0 bits. */
     call_with_stopwatch( st.time_sim, [&]() {
-      simulate_nodes<Ntk>( ntk, tts, sim );
+      simulate_nodes<Ntk>( ntk, tts, sim, true );
     });
   }
 

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -1,5 +1,5 @@
 /* mockturtle: C++ logic network library
- * Copyright (C) 2018-2019  EPFL
+ * Copyright (C) 2018-2020  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -28,6 +28,7 @@
   \brief Simulate networks
 
   \author Mathias Soeken
+  \author Siang-Yun Lee (partial simulation)
 */
 
 #pragma once
@@ -35,6 +36,7 @@
 #include <cstdint>
 #include <vector>
 #include <fstream>
+#include <random>
 
 #include "../traits.hpp"
 #include "../utils/node_map.hpp"
@@ -42,6 +44,7 @@
 #include <kitty/constructors.hpp>
 #include <kitty/dynamic_truth_table.hpp>
 #include <kitty/operators.hpp>
+#include <kitty/bit_operations.hpp>
 #include <kitty/partial_truth_table.hpp>
 #include <kitty/static_truth_table.hpp>
 
@@ -167,6 +170,8 @@ public:
  */
 class partial_simulator
 {
+  friend class bit_packed_simulator;
+
 public:
   partial_simulator() {}
 
@@ -276,6 +281,135 @@ public:
 private:
   std::vector<kitty::partial_truth_table> patterns;
   uint32_t num_patterns;
+};
+
+class bit_packed_simulator : public partial_simulator
+{
+public:
+  using partial_simulator::compute_constant;
+  using partial_simulator::compute_pi;
+  using partial_simulator::compute_not;
+  using partial_simulator::num_bits;
+  using partial_simulator::get_patterns;
+
+  bit_packed_simulator() {}
+
+  bit_packed_simulator( unsigned num_pis, unsigned num_patterns, std::default_random_engine::result_type seed = 0 )
+    : partial_simulator( num_pis, num_patterns, seed ), packed_patterns( num_patterns )
+  {
+    for ( auto i = 0u; i < num_pis; ++i )
+    {
+      care.emplace_back( num_patterns );
+      care.back() = ~care.back();
+    }
+  }
+
+  bit_packed_simulator( std::vector<kitty::partial_truth_table> const& initial_patterns )
+    : partial_simulator( initial_patterns ), packed_patterns( num_patterns )
+  {
+    for ( auto i = 0u; i < patterns.size(); ++i )
+    {
+      care.emplace_back( num_patterns );
+      care.back() = ~care.back();
+    }
+  }
+
+  void add_pattern( std::vector<bool> const& pattern, std::vector<bool> const& care_bits )
+  {
+    assert( pattern.size() == care_bits.size() );
+    assert( pattern.size() == patterns.size() );
+
+    for ( auto i = 0u; i < pattern.size(); ++i )
+    {
+      patterns.at( i ).add_bit( pattern.at( i ) );
+      care.at( i ).add_bit( care_bits.at( i ) );
+    }
+    ++num_patterns;
+  }
+
+  /* return true when some patterns are packed (so that update of truth tables is needed) */
+  bool pack_bits()
+  {
+    if ( num_patterns == 0u ) { return false; }
+    if ( num_patterns == packed_patterns ) { return false; }
+    assert( num_patterns > packed_patterns );
+
+    std::vector<uint32_t> empty_slots;
+    /* for each unpacked pattern (at `p`), try to pack it into one of the patterns before it (at `pos` in block `block`). */
+    for ( int p = num_patterns - 1; p >= (int)packed_patterns; --p )
+    {
+      for ( auto block = p < 1024 ? 0 : std::rand() % ( p >> 6 ); block <= ( p >> 6 ); ++block )
+      {
+        uint64_t unavailable = 0u;
+        /* check each PI */
+        for ( auto i = 0u; i < patterns.size(); ++i )
+        {
+          if ( !kitty::get_bit( care[i], p ) ) { continue; } /* only check for the cared PIs of p */
+          unavailable |= care[i]._bits[block];
+        }
+        auto pos = kitty::find_first_bit_in_word( ~unavailable );
+        if ( pos != -1 && ( block < ( p >> 6 ) || pos < ( p % 64 ) ) )
+        {
+          move_pattern( p, pos + ( block << 6 ) );
+          empty_slots.emplace_back( p );
+        }
+      }
+    }
+
+    if ( empty_slots.size() > 0u )
+    {
+      /* fill the empty slots (from smaller values; `empty_slots` should be reversely sorted) */
+      /* `empty_slots[j]` is the smallest position where larger positions are all empty */
+      int j = 0;
+      for ( int i = empty_slots.size() - 1; i >= 0; --i )
+      {
+        while ( empty_slots[j] >= num_patterns - 1 && j <= i )
+        {
+          if ( empty_slots[j] == num_patterns - 1 ) { --num_patterns; }
+          ++j;
+        }
+        if ( j > i ) { break; }
+        move_pattern( num_patterns - 1, empty_slots[i] );
+        --num_patterns;
+      }
+    
+      assert( patterns[0].num_bits() - num_patterns == empty_slots.size() );
+      for ( auto i = 0u; i < patterns.size(); ++i )
+      {
+        patterns[i].resize( num_patterns );
+        care[i].resize( num_patterns );
+      }
+      packed_patterns = num_patterns;
+      return true;
+    }
+    packed_patterns = num_patterns;
+    return false;
+  }
+
+private:
+  /* move the pattern at position `from` to position `to`. */
+  void move_pattern( uint32_t const from, uint32_t const to )
+  {
+    for ( auto i = 0u; i < patterns.size(); ++i )
+    {
+      if ( !kitty::get_bit( care[i], from ) ) { continue; }
+      assert( !kitty::get_bit( care[i], to ) );
+      if ( kitty::get_bit( patterns[i], from ) )
+      {
+        kitty::set_bit( patterns[i], to );
+      }
+      else
+      {
+        kitty::clear_bit( patterns[i], to );
+      }
+      kitty::set_bit( care[i], to );
+      kitty::clear_bit( care[i], from );
+    }
+  }
+
+private:
+  std::vector<kitty::partial_truth_table> care;
+  uint32_t packed_patterns;
 };
 
 /*! \brief Simulates a network with a generic simulator.
@@ -429,8 +563,8 @@ void simulate_nodes( Ntk const& ntk, unordered_node_map<SimulationType, Ntk>& no
 namespace detail
 {
 
-template<class Ntk>
-void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, partial_simulator const& sim )
+template<class Ntk, class Simulator>
+void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
   ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
@@ -444,8 +578,8 @@ void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered
   node_to_value[n] = ntk.compute( n, fanin_values.begin(), fanin_values.end() );
 }
 
-template<class Ntk>
-void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, partial_simulator const& sim )
+template<class Ntk, class Simulator>
+void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
   ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
@@ -459,8 +593,8 @@ void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unorde
   ntk.compute( n, node_to_value[n], fanin_values.begin(), fanin_values.end() );
 }
 
-template<class Ntk>
-void update_const_pi( Ntk const& ntk, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, partial_simulator const& sim )
+template<class Ntk, class Simulator>
+void update_const_pi( Ntk const& ntk, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
 {
   /* constants */
   node_to_value[ntk.get_node( ntk.get_constant( false ) )] = sim.compute_constant( ntk.constant_value( ntk.get_node( ntk.get_constant( false ) ) ) );
@@ -485,8 +619,8 @@ void update_const_pi( Ntk const& ntk, unordered_node_map<kitty::partial_truth_ta
  * whenever `sim.num_bits() % 64 == 0`.
  * 
  */
-template<class Ntk>
-void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, partial_simulator const& sim )
+template<class Ntk, class Simulator = partial_simulator>
+void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
@@ -496,6 +630,7 @@ void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_
   static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
   static_assert( has_compute_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the compute specialization for kitty::partial_truth_table" );
   static_assert( has_compute_inplace_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the in-place compute specialization for kitty::partial_truth_table" );
+  static_assert( std::is_same_v<Simulator, partial_simulator> || std::is_same_v<Simulator, bit_packed_simulator>, "This function is specialized for partial_simulator or bit_packed_simulator" );
 
   if ( node_to_value[ntk.get_node( ntk.get_constant( false ) )].num_bits() != sim.num_bits() )
   {
@@ -533,8 +668,8 @@ void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_
  * In contrast, when this parameter is false, only the last block of `partial_truth_table` will be re-computed,
  * and it is assumed that `node_to_value.has( n )` is true for every node.
  */
-template<class Ntk>
-void simulate_nodes( Ntk const& ntk, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, partial_simulator const& sim, bool simulate_whole_tt = true )
+template<class Ntk, class Simulator = partial_simulator>
+void simulate_nodes( Ntk const& ntk, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim, bool simulate_whole_tt )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
@@ -545,6 +680,7 @@ void simulate_nodes( Ntk const& ntk, unordered_node_map<kitty::partial_truth_tab
   static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
   static_assert( has_compute_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the compute specialization for kitty::partial_truth_table" );
   static_assert( has_compute_inplace_v<Ntk, kitty::partial_truth_table>, "Ntk does not implement the in-place compute specialization for kitty::partial_truth_table" );
+  static_assert( std::is_same_v<Simulator, partial_simulator> || std::is_same_v<Simulator, bit_packed_simulator>, "This function is specialized for partial_simulator or bit_packed_simulator" );
 
   detail::update_const_pi( ntk, node_to_value, sim );
 

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -399,14 +399,14 @@ public:
         {
           if ( empty_slots[j] == num_patterns - 1 ) { --num_patterns; }
           ++j;
-          std::cout<<"    [i] ... j = "<<j<<"\n";
+          std::cout<<"    [i] ... j = "<<j<<". condition: "<<(empty_slots[j] >= num_patterns - 1 && j <= i)<< "\n";
         }
         if ( j > i ) { break; }
         std::cout<<"    [i] move from "<<num_patterns-1<<" to "<<empty_slots[i]<<"\n";
         move_pattern( num_patterns - 1, empty_slots[i] );
         --num_patterns;
       }
-    
+      std::cout<<"[i] exit while loop\n";
       assert( patterns[0].num_bits() - num_patterns == empty_slots.size() );
       for ( auto i = 0u; i < patterns.size(); ++i )
       {

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -340,7 +340,6 @@ public:
    */
   void add_pattern( std::vector<bool> const& pattern, std::vector<bool> const& care_bits )
   {
-    std::cout<<"[i] add pattern...\n";
     assert( pattern.size() == care_bits.size() );
     assert( pattern.size() == patterns.size() );
 
@@ -358,7 +357,6 @@ public:
    */
   bool pack_bits()
   {
-    std::cout<<"[i] bit packing...\n";
     if ( num_patterns == 0u ) { return false; }
     if ( num_patterns == packed_patterns ) { return false; }
     assert( num_patterns > packed_patterns );
@@ -386,7 +384,6 @@ public:
       }
     }
 
-    std::cout<<"[i] removing "<<empty_slots.size()<<" empty_slots\n";
     if ( empty_slots.size() > 0u )
     {
       /* fill the empty slots (from smaller values; `empty_slots` should be reversely sorted) */
@@ -394,30 +391,25 @@ public:
       int j = 0;
       for ( int i = empty_slots.size() - 1; i >= 0; --i )
       {
-        std::cout<<"    [i] i = "<<i<<"\n";
         while ( empty_slots[j] >= num_patterns - 1 && j <= i )
         {
           if ( empty_slots[j] == num_patterns - 1 ) { --num_patterns; }
           ++j;
-          std::cout<<"    [i] ... j = "<<j<<". condition: "<<(empty_slots[j] >= num_patterns - 1 && j <= i)<< "\n";
+          if ( j == empty_slots.size() ) { break; }
         }
         if ( j > i ) { break; }
-        std::cout<<"    [i] move from "<<num_patterns-1<<" to "<<empty_slots[i]<<"\n";
         move_pattern( num_patterns - 1, empty_slots[i] );
         --num_patterns;
       }
-      std::cout<<"[i] exit while loop\n";
       assert( patterns[0].num_bits() - num_patterns == empty_slots.size() );
       for ( auto i = 0u; i < patterns.size(); ++i )
       {
         patterns[i].resize( num_patterns );
         care[i].resize( num_patterns );
       }
-      std::cout<<"[i] bit packing finished...\n";
       packed_patterns = num_patterns;
       return true;
     }
-    std::cout<<"[i] bit packing finished...\n";
     packed_patterns = num_patterns;
     return false;
   }

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -395,7 +395,7 @@ public:
         {
           if ( empty_slots[j] == num_patterns - 1 ) { --num_patterns; }
           ++j;
-          if ( j == empty_slots.size() ) { break; }
+          if ( j == (int)empty_slots.size() ) { break; }
         }
         if ( j > i ) { break; }
         move_pattern( num_patterns - 1, empty_slots[i] );

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -379,6 +379,7 @@ public:
         {
           move_pattern( p, pos + ( block << 6 ) );
           empty_slots.emplace_back( p );
+          break;
         }
       }
     }

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -340,6 +340,7 @@ public:
    */
   void add_pattern( std::vector<bool> const& pattern, std::vector<bool> const& care_bits )
   {
+    std::cout<<"[i] add pattern...\n";
     assert( pattern.size() == care_bits.size() );
     assert( pattern.size() == patterns.size() );
 
@@ -412,9 +413,11 @@ public:
         patterns[i].resize( num_patterns );
         care[i].resize( num_patterns );
       }
+      std::cout<<"[i] bit packing finished...\n";
       packed_patterns = num_patterns;
       return true;
     }
+    std::cout<<"[i] bit packing finished...\n";
     packed_patterns = num_patterns;
     return false;
   }

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -357,6 +357,7 @@ public:
    */
   bool pack_bits()
   {
+    std::cout<<"[i] bit packing...\n";
     if ( num_patterns == 0u ) { return false; }
     if ( num_patterns == packed_patterns ) { return false; }
     assert( num_patterns > packed_patterns );
@@ -384,6 +385,7 @@ public:
       }
     }
 
+    std::cout<<"[i] removing "<<empty_slots.size()<<" empty_slots\n";
     if ( empty_slots.size() > 0u )
     {
       /* fill the empty slots (from smaller values; `empty_slots` should be reversely sorted) */
@@ -391,12 +393,15 @@ public:
       int j = 0;
       for ( int i = empty_slots.size() - 1; i >= 0; --i )
       {
+        std::cout<<"    [i] i = "<<i<<"\n";
         while ( empty_slots[j] >= num_patterns - 1 && j <= i )
         {
           if ( empty_slots[j] == num_patterns - 1 ) { --num_patterns; }
           ++j;
+          std::cout<<"    [i] ... j = "<<j<<"\n";
         }
         if ( j > i ) { break; }
+        std::cout<<"    [i] move from "<<num_patterns-1<<" to "<<empty_slots[i]<<"\n";
         move_pattern( num_patterns - 1, empty_slots[i] );
         --num_patterns;
       }

--- a/include/mockturtle/io/write_patterns.hpp
+++ b/include/mockturtle/io/write_patterns.hpp
@@ -50,11 +50,14 @@ namespace mockturtle
  * The output contains `num_pis()` lines, each line contains a stream of
  * simulation values of a primary input, represented in hexadecimal.
  *
- * \param sim The `partial_simulator` object containing simulation patterns
+ * \param sim The `partial_simulator` or `bit_packed_simulator` object containing simulation patterns
  * \param out Output stream
  */
-inline void write_patterns( partial_simulator const& sim, std::ostream& out = std::cout )
+template<class Simulator>
+void write_patterns( Simulator const& sim, std::ostream& out = std::cout )
 {
+  static_assert( std::is_same_v<Simulator, partial_simulator> || std::is_same_v<Simulator, bit_packed_simulator>, "This function is specialized for partial_simulator or bit_packed_simulator" );
+
   auto const& patterns = sim.get_patterns();
   for ( auto i = 0u; i < patterns.size(); ++i )
   {
@@ -67,11 +70,14 @@ inline void write_patterns( partial_simulator const& sim, std::ostream& out = st
  * The output contains `num_pis()` lines, each line contains a stream of
  * simulation values of a primary input, represented in hexadecimal.
  *
- * \param sim The `partial_simulator` object containing simulation patterns
+ * \param sim The `partial_simulator` or `bit_packed_simulator` object containing simulation patterns
  * \param filename Filename
  */
-inline void write_patterns( partial_simulator const& sim, std::string const& filename )
+template<class Simulator>
+void write_patterns( Simulator const& sim, std::string const& filename )
 {
+  static_assert( std::is_same_v<Simulator, partial_simulator> || std::is_same_v<Simulator, bit_packed_simulator>, "This function is specialized for partial_simulator or bit_packed_simulator" );
+
   std::ofstream os( filename.c_str(), std::ofstream::out );
   write_patterns( sim, os );
   os.close();

--- a/test/algorithms/simulation.cpp
+++ b/test/algorithms/simulation.cpp
@@ -194,8 +194,6 @@ TEST_CASE( "Incremental simulation with partial_simulator", "[simulation]" )
 
 TEST_CASE( "Bit packing", "[simulation]" )
 {
-#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) || defined(__MINGW32__)
-#else
   std::vector<kitty::partial_truth_table> pats( 5 );
   pats[0].add_bits( 0x1, 2 ); /* x0 = 01 */
   pats[1].add_bits( 0x1, 2 ); /* x1 = 01 */
@@ -255,5 +253,4 @@ TEST_CASE( "Bit packing", "[simulation]" )
   CHECK( ( sim.compute_pi( 2 )._bits[0] & 0x0f ) == 0x0d ); /* x2 = xxx1101 -> x1101 */
   CHECK( ( sim.compute_pi( 3 )._bits[0] & 0x0f ) == 0x0d ); /* x3 = xx1x101 -> x1101 */
   CHECK( ( sim.compute_pi( 4 )._bits[0] & 0x1f ) == 0x1d ); /* x4 = x1x1101 -> 11101 */
-#endif
 }

--- a/test/algorithms/simulation.cpp
+++ b/test/algorithms/simulation.cpp
@@ -194,6 +194,8 @@ TEST_CASE( "Incremental simulation with partial_simulator", "[simulation]" )
 
 TEST_CASE( "Bit packing", "[simulation]" )
 {
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) || defined(__MINGW32__)
+#else
   std::vector<kitty::partial_truth_table> pats( 5 );
   pats[0].add_bits( 0x1, 2 ); /* x0 = 01 */
   pats[1].add_bits( 0x1, 2 ); /* x1 = 01 */
@@ -253,4 +255,5 @@ TEST_CASE( "Bit packing", "[simulation]" )
   CHECK( ( sim.compute_pi( 2 )._bits[0] & 0x0f ) == 0x0d ); /* x2 = xxx1101 -> x1101 */
   CHECK( ( sim.compute_pi( 3 )._bits[0] & 0x0f ) == 0x0d ); /* x3 = xx1x101 -> x1101 */
   CHECK( ( sim.compute_pi( 4 )._bits[0] & 0x1f ) == 0x1d ); /* x4 = x1x1101 -> 11101 */
+#endif
 }


### PR DESCRIPTION
Added a new `bit_packed_simulator` wrapping on top of `partial_simulator`, which records care bits when new patterns are added, and does a batch bit-packing when `pack_bits` is called.

Structural support computation when ODC is considered is still missing.