### PR TITLE
Avoid erroneous fanout-size and primary output updates

### DIFF
--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -312,6 +312,7 @@ public:
     const auto it = _storage->hash.find( node );
     if ( it != _storage->hash.end() )
     {
+      assert( !is_dead( it->second ) );
       return {it->second, 0};
     }
 

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -572,7 +572,7 @@ public:
 
       for ( auto idx = 1u; idx < _storage->nodes.size(); ++idx )
       {
-        if ( is_ci( idx ) )
+        if ( is_ci( idx ) || is_dead( idx ) )
           continue; /* ignore CIs */
 
         if ( const auto repl = replace_in_node( idx, _old, _new ); repl )

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -511,6 +511,9 @@ public:
 
   void replace_in_outputs( node const& old_node, signal const& new_signal )
   {
+    if ( is_dead( old_node ) )
+      return;
+
     for ( auto& output : _storage->outputs )
     {
       if ( output.index == old_node )

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -530,7 +530,7 @@ public:
   void take_out_node( node const& n )
   {
     /* we cannot delete CIs, constants, or already dead nodes */
-    if ( n == 0 || is_ci( n ) || is_dead( n ))
+    if ( n == 0 || is_ci( n ) || is_dead( n ) )
       return;
 
     auto& nobj = _storage->nodes[n];

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -525,8 +525,8 @@ public:
 
   void take_out_node( node const& n )
   {
-    /* we cannot delete CIs or constants */
-    if ( n == 0 || is_ci( n ) )
+    /* we cannot delete CIs, constants, or already dead nodes */
+    if ( n == 0 || is_ci( n ) || is_dead( n ))
       return;
 
     auto& nobj = _storage->nodes[n];

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -784,7 +784,7 @@ TEST_CASE( "substitute node by constant in NAND-based XOR circuit (test case 2)"
   CHECK( aig.fanout_size( aig.get_node( f4 ) ) == 1u );
 }
 
-TEST_CASE( "remove node from AIG", "[aig]" )
+TEST_CASE( "invoke take_out_node two times on the same node", "[aig]" )
 {
   aig_network aig;
   const auto x1 = aig.create_pi();
@@ -800,15 +800,13 @@ TEST_CASE( "remove node from AIG", "[aig]" )
   /* delete node */
   CHECK( !aig.is_dead( aig.get_node( f1 ) ) );
   aig.take_out_node( aig.get_node( f1 ) );
-
   CHECK( aig.is_dead( aig.get_node( f1 ) ) );
   CHECK( aig.fanout_size( aig.get_node( x1 ) ) == 1u );
   CHECK( aig.fanout_size( aig.get_node( x2 ) ) == 1u );
 
-  /* ensure that double deletion has no affect on x1 and x2 */
+  /* ensure that double-deletion has no effect on the fanout-size of x1 and x2 */
   CHECK( aig.is_dead( aig.get_node( f1 ) ) );
   aig.take_out_node( aig.get_node( f1 ) );
-
   CHECK( aig.is_dead( aig.get_node( f1 ) ) );
   CHECK( aig.fanout_size( aig.get_node( x1 ) ) == 1u );
   CHECK( aig.fanout_size( aig.get_node( x2 ) ) == 1u );

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -783,3 +783,33 @@ TEST_CASE( "substitute node by constant in NAND-based XOR circuit (test case 2)"
   CHECK( aig.fanout_size( aig.get_node( f3 ) ) == 0u );
   CHECK( aig.fanout_size( aig.get_node( f4 ) ) == 1u );
 }
+
+TEST_CASE( "remove node from AIG", "[aig]" )
+{
+  aig_network aig;
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+
+  const auto f1 = aig.create_and( x1, x2 );
+  const auto f2 = aig.create_or( x1, x2 );
+  (void)f2;
+
+  CHECK( aig.fanout_size( aig.get_node( x1 ) ) == 2u );
+  CHECK( aig.fanout_size( aig.get_node( x2 ) ) == 2u );
+
+  /* delete node */
+  CHECK( !aig.is_dead( aig.get_node( f1 ) ) );
+  aig.take_out_node( aig.get_node( f1 ) );
+
+  CHECK( aig.is_dead( aig.get_node( f1 ) ) );
+  CHECK( aig.fanout_size( aig.get_node( x1 ) ) == 1u );
+  CHECK( aig.fanout_size( aig.get_node( x2 ) ) == 1u );
+
+  /* ensure that double deletion has no affect on x1 and x2 */
+  CHECK( aig.is_dead( aig.get_node( f1 ) ) );
+  aig.take_out_node( aig.get_node( f1 ) );
+
+  CHECK( aig.is_dead( aig.get_node( f1 ) ) );
+  CHECK( aig.fanout_size( aig.get_node( x1 ) ) == 1u );
+  CHECK( aig.fanout_size( aig.get_node( x2 ) ) == 1u );
+}


### PR DESCRIPTION
This PR makes minor changes to the logic of `take_out_node`, `replace_in_outputs`, and `substitute_node`:
- Avoid fanout-size updates when deleting a node, which has already been deleted before.
- Avoid updating primary outputs if the update propagates from a dead node.
- Avoid update propagation from dead nodes in the hash.

A new test case ensures that `take_out_node` can be invoked twice on the same node without recursively affecting its fanins.
