### PR TITLE
Resolve ambiguity in ABC's index-list encoding

### DIFF
--- a/include/mockturtle/utils/index_list.hpp
+++ b/include/mockturtle/utils/index_list.hpp
@@ -72,25 +72,23 @@ public:
     }
   }
 
-  explicit abc_index_list( std::vector<element_type> const& values )
+  explicit abc_index_list( std::vector<element_type> const& values, uint32_t num_pis )
     : values( std::begin( values ), std::end( values ) )
   {
-    /* parse the values to determine the number of inputs and outputs */
-    auto i = 2u;
-    for ( ; ( i+1 ) < values.size(); i+=2 )
+    /* The number of primary inputs has to be passed as a parameter
+       because constant outputs cannot be distinguished from primary
+       inputs, e.g.,
+
+         0 0 | 0 0 0 0 0 0 | 0 0 77
+
+       could be either read as 3 PIs and 2 POs (the first is a
+       constant 0) or 4 PIs and 1 POs.
+    */
+    _num_pis = num_pis;
+
+    /* parse the values to determine the number of outputs */
+    for ( auto i = ( num_pis + 1 ) << 1; ( i+1 ) < values.size(); i += 2 )
     {
-      if ( values.at( i ) == 0 && values.at( i + 1 ) == 0 )
-      {
-        ++_num_pis;
-      }
-      else
-      {
-        break;
-      }
-    }
-    for ( ; ( i+1 ) < values.size(); i+=2 )
-    {
-      // assert( !( values.at( i ) == 0 && values.at( i + 1 ) == 0 ) );
       if ( values.at( i ) == values.at( i+1 ) )
       {
         ++_num_pos;

--- a/test/utils/index_list.cpp
+++ b/test/utils/index_list.cpp
@@ -49,7 +49,7 @@ TEST_CASE( "encode mig_network into mig_index_list", "[index_list]" )
 TEST_CASE( "decode abc_index_list into xag_network", "[index_list]" )
 {
   std::vector<uint32_t> const raw_list{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 6, 8, 12, 10, 14, 14};
-  abc_index_list xag_il{raw_list};
+  abc_index_list xag_il( raw_list, 4u );
 
   xag_network xag;
   decode( xag, xag_il );


### PR DESCRIPTION
This PR resolves an ambiguity in the encoding of ABC's index-list by requiring the user to pass the number of PIs as an additional parameter when constructing the index-list.

This is necessary because ABC's encoding uses 0 0 for primary inputs and 0 0 for constants outputs, such that these entries cannot be distinguished in an index-list with no gates.