### PR TITLE
Bugfix for special case in `substitute_node`

### DIFF
--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -481,7 +481,7 @@ public:
     storage::element_type::node_type _hash_obj;
     _hash_obj.children[0] = child0;
     _hash_obj.children[1] = child1;
-    if ( const auto it = _storage->hash.find( _hash_obj ); it != _storage->hash.end() )
+    if ( const auto it = _storage->hash.find( _hash_obj ); it != _storage->hash.end() && it->second != old_node )
     {
       return std::make_pair( n, signal( it->second, 0 ) );
     }


### PR DESCRIPTION
This PR provides a quick-fix for an issue triggered by a special case in the implementation of `substitute_node`:
- A failing test case documents the issue.
- `replace_in_node` is modified to avoid returning a node equal to the `old_node` that will be deleted later.