### PR TITLE
Cut_enumeration: cut_limit must not exceed maximum number of cuts.

### DIFF
--- a/include/mockturtle/algorithms/cut_enumeration.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration.hpp
@@ -296,6 +296,7 @@ public:
         st( st ),
         cuts( cuts )
   {
+    assert( ps.cut_limit < cuts.max_cut_num && "cut_limit exceeds the compile-time limit for the maximum number of cuts" );
   }
 
 public:


### PR DESCRIPTION
Addresses issue #371.