### PR TITLE
updated bill to improve compatibility with Alpine Linux

### DIFF
--- a/lib/bill/bill/sat/solver/ghack.hpp
+++ b/lib/bill/bill/sat/solver/ghack.hpp
@@ -1472,10 +1472,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Ghack_System_h
 #define Ghack_System_h
 
-#if defined(__linux__)
-#include <fpu_control.h>
-#endif
-
 
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR integrates the [latest changes to bill](https://github.com/lsils/bill/pull/42) into mockturtle to improve compatibility with Alpine Linux, which is used for many Docker images.