### PR TITLE
Rewrite the event mechanism using CRTP

### DIFF
--- a/include/mockturtle/algorithms/sim_resub.hpp
+++ b/include/mockturtle/algorithms/sim_resub.hpp
@@ -336,12 +336,15 @@ struct sim_resub_stats
  * \param MffcRes Typename of `potential_gain` needed by the resubstitution functor.
  */
 template<class Ntk, typename validator_t = circuit_validator<Ntk, bill::solvers::bsat2, false, true, false>, class ResubFn = resyn_functor<Ntk, xag_resyn_engine<kitty::partial_truth_table, Ntk>>, typename MffcRes = uint32_t>
-class simulation_based_resub_engine
+class simulation_based_resub_engine :
+  public event_add_crtp<Ntk, simulation_based_resub_engine<Ntk, validator_t, ResubFn, MffcRes>>
 {
 public:
   static constexpr bool require_leaves_and_mffc = false;
   using stats = sim_resub_stats<typename ResubFn::stats>;
   using mffc_result_t = MffcRes;
+
+  friend class network_events<Ntk>::add_accessor;
 
   using node = typename Ntk::node;
   using signal = typename Ntk::signal;
@@ -362,9 +365,10 @@ public:
     vps.conflict_limit = ps.conflict_limit;
     vps.random_seed = ps.random_seed;
 
-    ntk._events->on_add.emplace_back( [&]( const auto& n ) {
-      call_with_stopwatch( st.time_sim, [&]() {
-        simulate_node<Ntk>( ntk, n, tts, sim );
+    ntk._events->on_add.emplace_back( event_add_crtp<Ntk, simulation_based_resub_engine>::wp(), []( void *wp, const auto& n ) {
+      auto self = reinterpret_cast<simulation_based_resub_engine *>(wp);
+      call_with_stopwatch( self->st.time_sim, [&]() {
+        simulate_node<Ntk>( self->ntk, n, self->tts, self->sim );
       });
     } );
   }

--- a/include/mockturtle/networks/aqfp.hpp
+++ b/include/mockturtle/networks/aqfp.hpp
@@ -337,10 +337,7 @@ public:
     _storage->nodes[b.index].data[0].h1++;
     _storage->nodes[c.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_add )
-    {
-      fn( index );
-    }
+    _events->on_add( index );
 
     return { index, node_complement };
   }
@@ -415,10 +412,7 @@ public:
       _storage->nodes[c.index].data[0].h1++;
     }
 
-    for ( auto const& fn : _events->on_add )
-    {
-      fn( index );
-    }
+    _events->on_add( index );
 
     return { index, node_complement };
   }
@@ -539,10 +533,7 @@ public:
 
     /* TODO: Do the simplifications if possible */
 
-    for ( auto const& fn : _events->on_modified )
-    {
-      fn( n, old_children );
-    }
+    _events->on_modified( n, old_children );
 
     return std::nullopt;
   }
@@ -571,10 +562,7 @@ public:
     auto& nobj = _storage->nodes[n];
     nobj.data[0].h1 = UINT32_C( 0x80000000 ); /* fanout size 0, but dead */
 
-    for ( auto const& fn : _events->on_delete )
-    {
-      fn( n );
-    }
+    _events->on_delete( n );
 
     for ( auto i = 0u; i < nobj.children.size(); ++i )
     {

--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -384,10 +384,7 @@ signal create_maj( signal a, signal b, signal c )
 
     set_value( index, 0 );
 
-    for ( auto const& fn : _events->on_add )
-    {
-      fn( index );
-    }
+    _events->on_add( index );
 
     return index;
   }
@@ -428,10 +425,7 @@ signal create_maj( signal a, signal b, signal c )
           // increment fan-out of new node
           _storage->nodes[new_signal].data[0].h1++;
 
-          for ( auto const& fn : _events->on_modified )
-          {
-            fn( i, old_children );
-          }
+          _events->on_modified( i, old_children );
         }
       }
     }

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -352,10 +352,7 @@ public:
     _storage->nodes[b.index].data[0].h1++;
     _storage->nodes[c.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_add )
-    {
-      fn( index );
-    }
+    _events->on_add( index );
 
     return {index, node_complement};
   }
@@ -532,10 +529,7 @@ public:
     // update the reference counter of the new signal
     _storage->nodes[new_signal.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_modified )
-    {
-      fn( n, {old_child0, old_child1, old_child2} );
-    }
+    _events->on_modified( n, {old_child0, old_child1, old_child2} );
 
     return std::nullopt;
   }
@@ -565,10 +559,7 @@ public:
     nobj.data[0].h1 = UINT32_C( 0x80000000 ); /* fanout size 0, but dead */
     _storage->hash.erase( nobj );
 
-    for ( auto const& fn : _events->on_delete )
-    {
-      fn( n );
-    }
+    _events->on_delete( n );
 
     for ( auto i = 0u; i < 3u; ++i )
     {

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -326,10 +326,7 @@ public:
     _storage->nodes[a.index].data[0].h1++;
     _storage->nodes[b.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_add )
-    {
-      fn( index );
-    }
+    _events->on_add( index );
 
     return {index, 0};
   }
@@ -553,10 +550,7 @@ public:
     // update the reference counter of the new signal
     _storage->nodes[new_signal.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_modified )
-    {
-      fn( n, {old_child0, old_child1} );
-    }
+    _events->on_modified( n, {old_child0, old_child1} );
 
     return std::nullopt;
   }
@@ -586,10 +580,7 @@ public:
     nobj.data[0].h1 = UINT32_C( 0x80000000 ); /* fanout size 0, but dead */
     _storage->hash.erase( nobj );
 
-    for ( auto const& fn : _events->on_delete )
-    {
-      fn( n );
-    }
+    _events->on_delete( n );
 
     for ( auto i = 0u; i < 2u; ++i )
     {

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -350,10 +350,7 @@ public:
     _storage->nodes[b.index].data[0].h1++;
     _storage->nodes[c.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_add )
-    {
-      fn( index );
-    }
+    _events->on_add( index );
 
     return {index, node_complement};
   }
@@ -417,10 +414,7 @@ public:
     _storage->nodes[b.index].data[0].h1++;
     _storage->nodes[c.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_add )
-    {
-      fn( index );
-    }
+    _events->on_add( index );
 
     return {index, fcompl};
   }
@@ -656,10 +650,7 @@ public:
     // update the reference counter of the new signal
     _storage->nodes[new_signal.index].data[0].h1++;
 
-    for ( auto const& fn : _events->on_modified )
-    {
-      fn( n, {old_child0, old_child1, old_child2} );
-    }
+    _events->on_modified( n, {old_child0, old_child1, old_child2} );
 
     return std::nullopt;
   }
@@ -689,10 +680,7 @@ public:
     nobj.data[0].h1 = UINT32_C( 0x80000000 ); /* fanout size 0, but dead */
     _storage->hash.erase( nobj );
 
-    for ( auto const& fn : _events->on_delete )
-    {
-      fn( n );
-    }
+    _events->on_delete( n );
 
     for ( auto i = 0u; i < 3u; ++i )
     {

--- a/include/mockturtle/utils/event_crtp.hpp
+++ b/include/mockturtle/utils/event_crtp.hpp
@@ -1,0 +1,167 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2021  Princeton University
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file event_crtp.hpp
+  \brief Safe event API using CRTP
+
+  \author Jinzheng Tu <jinzheng@princeton.edu>
+*/
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace mockturtle
+{
+
+/*! \brief Event handler.
+ *
+ * This data structure holds a weak pointer to the owner of the handler and a
+ * function containing the code to be executed.  Note that we are using void *
+ * to store arbitrary owner object, so the handler function is responsible for
+ * necessary type pointer conversion (mostly reinterpret_cast).
+ */
+template<typename ... TArgs>
+struct event_handler_t
+{
+  std::weak_ptr<void> ptr;
+  std::function<void( void *self, TArgs && ... args )> handler;
+
+  template<typename Func>
+    event_handler_t( std::weak_ptr<void> ptr, Func &&handler )
+    : ptr{ std::move(ptr) }, handler{ std::forward<Func>(handler) } { }
+
+  bool operator()(TArgs && ... args)
+  {
+    if ( auto self = ptr.lock(); self )
+    {
+      handler( self.get(), std::forward<TArgs>(args) ... );
+      return true;
+    }
+    return false;
+  }
+};
+
+/*! \brief Event handler list.
+ *
+ * A vector of event handlers. When the owner of any handler is missing, it
+ * will be kick out automatically upon a operator() call.
+ */
+template<typename ... TArgs>
+struct event_handlers_t : public std::vector<event_handler_t<TArgs ...>>
+{
+  void operator()(TArgs && ... args) {
+    std::remove_if(
+        std::vector<event_handler_t<TArgs ...>>::begin(),
+        std::vector<event_handler_t<TArgs ...>>::end(),
+        [&]( auto &eh ) {
+          return !eh( std::forward<TArgs>(args) ... );
+        } );
+  }
+};
+
+/*! \brief Base CRTP class for all willing to register their event handlers.
+ *
+ * This CRTP class takes care of generating self pointers soly and it is the
+ * derived class's responsibility to enable its copy/move ctor/assignment to
+ * default value, i.e.
+ *
+ *      class T : public Ntk, public event_crtp<T, Accessor> {
+ *        public:
+ *          T(const T &) = default;
+ *          T(T &&) = default;
+ *          T &(const T &) = default;
+ *          T &(T &&) = default;
+ *      }
+ *
+ * where Accessor should be one of the event_(add|modified|delete)_crtp in
+ * the file mockturtle/networks/events.hpp.
+ *
+ * Note that event_crtp must be initialized AFTER whatever Accessor is going to
+ * access. In mostly of the cases, it means that T must inherit Ntk first
+ * before inheriting event_crtp.
+ *
+ * \tparam Derived The owner class
+ * \tparam Accessor Callable of event_handlers_t<...>(Derived &owner)
+ */
+template <typename Derived, typename Accessor>
+class event_crtp
+{
+  [[nodiscard]] decltype(auto) underlying()
+  {
+    return static_cast<Derived &>(*this);
+  }
+
+  /*! \brief Smart pointer to the Derived class.  Deletion is disabled. */
+  std::shared_ptr<Derived> _self;
+
+protected:
+
+  event_crtp() : _self{ &underlying(), [](auto){} } { }
+
+  event_crtp( const event_crtp &other ) : _self{ &underlying(), [](auto){} }
+  {
+    operator=(other);
+  }
+
+  event_crtp( event_crtp &&other ) noexcept : _self{ &underlying(), [](auto){} }
+  {
+    operator=(std::move(other));
+  }
+
+  event_crtp &operator=( const event_crtp &other )
+  {
+    if ( this != &other ) {
+      auto &ehs = Accessor{}( underlying() );
+      typename std::remove_reference<decltype(ehs)>::type tmp;
+      for (auto &h : ehs)
+        if (auto lp = h.ptr.lock(); lp == other._self)
+          tmp.emplace_back(_self, h.handler);
+      for (auto &h : tmp)
+        ehs.push_back(h);
+    }
+    return *this;
+  }
+
+  event_crtp &operator=( event_crtp &&other ) noexcept
+  {
+    if (this != &other) {
+      auto &ehs = Accessor{}( underlying() );
+      for (auto &h : ehs)
+        if (auto lp = h.ptr.lock(); lp == other._self)
+          h.ptr = _self;
+    }
+    return *this;
+  }
+
+  /*! \brief Get a weak pointer to self for adding to event handler list. */
+  std::weak_ptr<Derived> wp() const { return _self; }
+};
+
+} // namespace mockturtle

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -100,7 +100,7 @@ public:
 public:
   /*! \brief Default constructor. */
   explicit node_map( Ntk const& ntk )
-      : ntk( ntk ),
+      : ntk( &ntk ),
         data( std::make_shared<std::vector<T>>( ntk.size() ) )
   {
     static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
@@ -114,7 +114,7 @@ public:
    * Initializes all values in the container to `init_value`.
    */
   node_map( Ntk const& ntk, T const& init_value )
-      : ntk( ntk ),
+      : ntk( &ntk ),
         data( std::make_shared<std::vector<T>>( ntk.size(), init_value ) )
   {
     static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
@@ -126,15 +126,15 @@ public:
   /*! \brief Mutable access to value by node. */
   reference operator[]( node const& n )
   {
-    assert( ntk.node_to_index( n ) < data->size() && "index out of bounds" );
-    return (*data)[ntk.node_to_index( n )];
+    assert( ntk->node_to_index( n ) < data->size() && "index out of bounds" );
+    return (*data)[ntk->node_to_index( n )];
   }
 
   /*! \brief Constant access to value by node. */
   const_reference operator[]( node const& n ) const
   {
-    assert( ntk.node_to_index( n ) < data->size() && "index out of bounds" );
-    return (*data)[ntk.node_to_index( n )];
+    assert( ntk->node_to_index( n ) < data->size() && "index out of bounds" );
+    return (*data)[ntk->node_to_index( n )];
   }
 
   /*! \brief Mutable access to value by signal.
@@ -145,8 +145,8 @@ public:
   template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   reference operator[]( signal const& f )
   {
-    assert( ntk.node_to_index( ntk.get_node( f ) ) < data->size() && "index out of bounds" );
-    return (*data)[ntk.node_to_index( ntk.get_node( f ) )];
+    assert( ntk->node_to_index( ntk->get_node( f ) ) < data->size() && "index out of bounds" );
+    return (*data)[ntk->node_to_index( ntk->get_node( f ) )];
   }
 
   /*! \brief Constant access to value by signal.
@@ -157,8 +157,8 @@ public:
   template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   const_reference operator[]( signal const& f ) const
   {
-    assert( ntk.node_to_index( ntk.get_node( f ) ) < data->size() && "index out of bounds" );
-    return (*data)[ntk.node_to_index( ntk.get_node( f ) )];
+    assert( ntk->node_to_index( ntk->get_node( f ) ) < data->size() && "index out of bounds" );
+    return (*data)[ntk->node_to_index( ntk->get_node( f ) )];
   }
 
   /*! \brief Resets the size of the map.
@@ -172,7 +172,7 @@ public:
   void reset( T const& init_value = {} )
   {
     data->clear();
-    data->resize( ntk.size(), init_value );
+    data->resize( ntk->size(), init_value );
   }
 
   /*! \brief Resizes the map.
@@ -184,14 +184,14 @@ public:
    */
   void resize( T const& init_value = {} )
   {
-    if ( ntk.size() > data->size() )
+    if ( ntk->size() > data->size() )
     {
-      data->resize( ntk.size(), init_value );
+      data->resize( ntk->size(), init_value );
     }
   }
 
 private:
-  Ntk const& ntk;
+  Ntk const* ntk;
   std::shared_ptr<std::vector<T>> data;
 };
 
@@ -222,7 +222,7 @@ public:
 
 public:
   explicit node_map( Ntk const& ntk )
-    : ntk( ntk ),
+    : ntk( &ntk ),
       data( std::make_shared<std::unordered_map<typename Ntk::node, T>>() )
   {
   }
@@ -230,20 +230,20 @@ public:
   /*! \brief Check if a key is already defined. */
   bool has( node const& n ) const
   {
-    return data->find( ntk.node_to_index( n ) ) != data->end();
+    return data->find( ntk->node_to_index( n ) ) != data->end();
   }
 
   /*! \brief Check if a key is already defined. */
   bool has( signal const& f ) const
   {
-    return data->find( ntk.node_to_index( ntk.get_node( f ) ) ) != data->end();
+    return data->find( ntk->node_to_index( ntk->get_node( f ) ) ) != data->end();
   }
 
   void erase( node const& n )
   {
     if ( has( n ) )
     {
-      data->erase( ntk.node_to_index( n ) );
+      data->erase( ntk->node_to_index( n ) );
     }
   }
 
@@ -258,14 +258,14 @@ public:
   /*! \brief Mutable access to value by node. */
   reference operator[]( node const& n )
   {
-    return (*data)[ntk.node_to_index( n )];
+    return (*data)[ntk->node_to_index( n )];
   }
 
   /*! \brief Constant access to value by node. */
   const_reference operator[]( node const& n ) const
   {
     assert( has( n ) && "index out of bounds" );
-    return (*data)[ntk.node_to_index( n )];
+    return (*data)[ntk->node_to_index( n )];
   }
 
   /*! \brief Mutable access to value by signal.
@@ -276,7 +276,7 @@ public:
   template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   reference operator[]( signal const& f )
   {
-    return (*data)[ntk.node_to_index( ntk.get_node( f ) )];
+    return (*data)[ntk->node_to_index( ntk->get_node( f ) )];
   }
 
   /*! \brief Constant access to value by signal.
@@ -287,8 +287,8 @@ public:
   template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   const_reference operator[]( signal const& f ) const
   {
-    assert( has( ntk.get_node( f ) ) && "index out of bounds" );
-    return (*data)[ntk.node_to_index( ntk.get_node( f ) )];
+    assert( has( ntk->get_node( f ) ) && "index out of bounds" );
+    return (*data)[ntk->node_to_index( ntk->get_node( f ) )];
   }
 
   /*! \brief Clear all entries of the map.
@@ -301,7 +301,7 @@ public:
   }
 
 protected:
-  Ntk const& ntk;
+  Ntk const* ntk;
   std::shared_ptr<std::unordered_map<node, T>> data;
 };
 

--- a/include/mockturtle/views/fanout_limit_view.hpp
+++ b/include/mockturtle/views/fanout_limit_view.hpp
@@ -276,10 +276,7 @@ protected:
     Ntk::_storage->nodes[b.index].data[0].h1++;
     Ntk::_storage->nodes[c.index].data[0].h1++;
 
-    for ( auto const& fn : Ntk::_events->on_add )
-    {
-      fn( index );
-    }
+    Ntk::_events->on_add( index );
 
     return {index, node_complement};
   }

--- a/include/mockturtle/views/fanout_view.hpp
+++ b/include/mockturtle/views/fanout_view.hpp
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "../traits.hpp"
+#include "../networks/events.hpp"
 #include "../networks/detail/foreach.hpp"
 #include "../utils/node_map.hpp"
 #include "immutable_view.hpp"
@@ -80,7 +81,10 @@ public:
 };
 
 template<typename Ntk>
-class fanout_view<Ntk, false> : public Ntk
+class fanout_view<Ntk, false> : public Ntk,
+      public event_add_crtp<Ntk, fanout_view<Ntk>>,
+      public event_modified_crtp<Ntk, fanout_view<Ntk>>,
+      public event_delete_crtp<Ntk, fanout_view<Ntk>>
 {
 public:
   using storage = typename Ntk::storage;
@@ -100,33 +104,36 @@ public:
 
     if ( _ps.update_on_add )
     {
-      Ntk::events().on_add.push_back( [this]( auto const& n ) {
-        _fanout.resize();
-        Ntk::foreach_fanin( n, [&, this]( auto const& f ) {
-          _fanout[f].push_back( n );
+      Ntk::events().on_add.emplace_back( event_add_crtp<Ntk, fanout_view>::wp(), []( void *wp, auto const& n ) {
+        auto self = reinterpret_cast<fanout_view *>(wp);
+        self->_fanout.resize();
+        self->Ntk::foreach_fanin( n, [&, self]( auto const& f ) {
+          self->_fanout[f].push_back( n );
         } );
       } );
     }
 
     if ( _ps.update_on_modified )
     {
-      Ntk::events().on_modified.push_back( [this]( auto const& n, auto const& previous ) {
+      Ntk::events().on_modified.emplace_back( event_modified_crtp<Ntk, fanout_view>::wp(), []( void *wp, auto const& n, auto const& previous ) {
         (void)previous;
+        auto self = reinterpret_cast<fanout_view *>(wp);
         for ( auto const& f : previous ) {
-          _fanout[f].erase( std::remove( _fanout[f].begin(), _fanout[f].end(), n ), _fanout[f].end() );
+          self->_fanout[f].erase( std::remove( self->_fanout[f].begin(), self->_fanout[f].end(), n ), self->_fanout[f].end() );
         }
-        Ntk::foreach_fanin( n, [&, this]( auto const& f ) {
-          _fanout[f].push_back( n );
+        self->Ntk::foreach_fanin( n, [&, self]( auto const& f ) {
+          self->_fanout[f].push_back( n );
         } );
       } );
     }
 
     if ( _ps.update_on_delete )
     {
-      Ntk::events().on_delete.push_back( [this]( auto const& n ) {
-        _fanout[n].clear();
-        Ntk::foreach_fanin( n, [&, this]( auto const& f ) {
-          _fanout[f].erase( std::remove( _fanout[f].begin(), _fanout[f].end(), n ), _fanout[f].end() );
+      Ntk::events().on_delete.emplace_back( event_delete_crtp<Ntk, fanout_view>::wp(), []( void *wp, auto const& n ) {
+        auto self = reinterpret_cast<fanout_view *>(wp);
+        self->_fanout[n].clear();
+        self->Ntk::foreach_fanin( n, [&, self]( auto const& f ) {
+          self->_fanout[f].erase( std::remove( self->_fanout[f].begin(), self->_fanout[f].end(), n ), self->_fanout[f].end() );
         } );
       } );
     }
@@ -145,33 +152,36 @@ public:
 
     if ( _ps.update_on_add )
     {
-      Ntk::events().on_add.push_back( [this]( auto const& n ) {
-        _fanout.resize();
-        Ntk::foreach_fanin( n, [&, this]( auto const& f ) {
-          _fanout[f].push_back( n );
+      Ntk::events().on_add.emplace_back( event_add_crtp<Ntk, fanout_view>::wp(), []( void *wp, auto const& n ) {
+        auto self = reinterpret_cast<fanout_view *>(wp);
+        self->_fanout.resize();
+        self->Ntk::foreach_fanin( n, [&, self]( auto const& f ) {
+          self->_fanout[f].push_back( n );
         } );
       } );
     }
 
     if ( _ps.update_on_modified )
     {
-      Ntk::events().on_modified.push_back( [this]( auto const& n, auto const& previous ) {
+      Ntk::events().on_modified.emplace_back( event_modified_crtp<Ntk, fanout_view>::wp(), []( void *wp, auto const& n, auto const& previous ) {
         (void)previous;
+        auto self = reinterpret_cast<fanout_view *>(wp);
         for ( auto const& f : previous ) {
-          _fanout[f].erase( std::remove( _fanout[f].begin(), _fanout[f].end(), n ), _fanout[f].end() );
+          self->_fanout[f].erase( std::remove( self->_fanout[f].begin(), self->_fanout[f].end(), n ), self->_fanout[f].end() );
         }
-        Ntk::foreach_fanin( n, [&, this]( auto const& f ) {
-          _fanout[f].push_back( n );
+        self->Ntk::foreach_fanin( n, [&, self]( auto const& f ) {
+          self->_fanout[f].push_back( n );
         } );
       } );
     }
 
     if ( _ps.update_on_delete )
     {
-      Ntk::events().on_delete.push_back( [this]( auto const& n ) {
-        _fanout[n].clear();
-        Ntk::foreach_fanin( n, [&, this]( auto const& f ) {
-          _fanout[f].erase( std::remove( _fanout[f].begin(), _fanout[f].end(), n ), _fanout[f].end() );
+      Ntk::events().on_delete.emplace_back( event_delete_crtp<Ntk, fanout_view>::wp(), []( void *wp, auto const& n ) {
+        auto self = reinterpret_cast<fanout_view *>(wp);
+        self->_fanout[n].clear();
+        self->Ntk::foreach_fanin( n, [&, self]( auto const& f ) {
+          self->_fanout[f].erase( std::remove( self->_fanout[f].begin(), self->_fanout[f].end(), n ), self->_fanout[f].end() );
         } );
       } );
     }

--- a/test/views/cnf_view.cpp
+++ b/test/views/cnf_view.cpp
@@ -164,20 +164,3 @@ TEST_CASE( "build cnf_view for k-LUT network", "[cnf_view]" )
   CHECK( result );
   CHECK( !*result );
 }
-
-TEST_CASE( "destructor", "[cnf_view]" )
-{
-  mig_network mig;
-  const auto a = mig.create_pi();
-  const auto b = mig.create_pi();
-  const auto c = mig.create_pi();
-  mig.create_po( mig.create_maj( a, b, c ) );
-
-  {
-    cnf_view view( mig );
-    mig.events().on_add.push_back( []( auto const& n ) { (void)n; } );
-  }
-  
-  CHECK( mig.events().on_add.size() == 1 );
-  CHECK( mig.events().on_delete.size() == 0 );
-}

--- a/test/views/depth_view.cpp
+++ b/test/views/depth_view.cpp
@@ -136,3 +136,74 @@ TEST_CASE( "compute levels during node construction with cost function", "[depth
   CHECK( dxag.depth() == 1u );
 }
 
+TEST_CASE( "compute levels during node construction after copy ctor", "[depth_view]" )
+{
+  xag_network xag{};
+  auto tmp = new depth_view<xag_network>{xag};
+  depth_view<xag_network> dxag{ *tmp }; // copy ctor
+  delete tmp;
+
+  const auto a = dxag.create_pi();
+  const auto b = dxag.create_pi();
+  const auto c = dxag.create_pi();
+
+  dxag.create_po( dxag.create_xor( b, dxag.create_and( dxag.create_xor( a, b ), dxag.create_xor( b, c ) ) ) );
+
+  CHECK( dxag.depth() == 3u );
+}
+
+TEST_CASE( "compute levels during node construction after move ctor", "[depth_view]" )
+{
+  xag_network xag{};
+  auto tmp = new depth_view<xag_network>{xag};
+  depth_view<xag_network> dxag{ std::move(*tmp) }; // move ctor
+  delete tmp;
+
+  const auto a = dxag.create_pi();
+  const auto b = dxag.create_pi();
+  const auto c = dxag.create_pi();
+
+  dxag.create_po( dxag.create_xor( b, dxag.create_and( dxag.create_xor( a, b ), dxag.create_xor( b, c ) ) ) );
+
+  CHECK( dxag.depth() == 3u );
+}
+
+
+TEST_CASE( "compute levels during node construction after copy assignment", "[depth_view]" )
+{
+  xag_network xag{};
+  depth_view<xag_network> dxag;
+  {
+    auto tmp = new depth_view<xag_network>{xag};
+    dxag = *tmp; // copy assignment
+    delete tmp;
+  }
+
+  const auto a = dxag.create_pi();
+  const auto b = dxag.create_pi();
+  const auto c = dxag.create_pi();
+
+  dxag.create_po( dxag.create_xor( b, dxag.create_and( dxag.create_xor( a, b ), dxag.create_xor( b, c ) ) ) );
+
+  CHECK( dxag.depth() == 3u );
+}
+
+TEST_CASE( "compute levels during node construction after move assignment", "[depth_view]" )
+{
+  xag_network xag{};
+  depth_view<xag_network> dxag;
+  {
+    auto tmp = new depth_view<xag_network>{xag};
+    dxag = std::move(*tmp); // move assignment
+    delete tmp;
+  }
+
+  const auto a = dxag.create_pi();
+  const auto b = dxag.create_pi();
+  const auto c = dxag.create_pi();
+
+  dxag.create_po( dxag.create_xor( b, dxag.create_and( dxag.create_xor( a, b ), dxag.create_xor( b, c ) ) ) );
+
+  CHECK( dxag.depth() == 3u );
+}
+


### PR DESCRIPTION
The existing event mechanism is buggy that it constantly causing segmentation fault due to access to already freed object. To solve this I've used a `std::weak_ptr` that wraps `this` instead of `this` directly in the event callbacks. I've also added a helper CRTP class `event_crtp` for managing the point automatically. Only a few changes are necessary for each view/algorithm that is interested in registering for event callbacks. Absolutely NO need for customized copy/move constructors and assignments - everything is handled by `event_crtp`.

Note that a new file `include/mockturtle/utils/event_crtp.hpp` is added.