### PR TITLE
Coverage analysis with codecov.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,38 @@
+name: Coverage CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build-gcc9-codecov:
+    runs-on: ubuntu-latest
+    name: GNU GCC 9 and run codecov
+    
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Build mockturtle
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_CXX_COMPILER=g++-9 -DMOCKTURTLE_TEST=ON -DENABLE_COVERAGE=ON ..
+        make run_tests
+    - name: Run tests
+      run: |
+        cd build
+        ./test/run_tests "~[quality]"
+    - name: Run lcov
+      run: |
+        sudo apt-get install lcov
+        lcov -t "result" -o lcov.info -c -d .
+        lcov -e lcov.info "*mockturtle/include*" -o lcov_filtered.info
+        lcov -l lcov_filtered.info
+    - name: CodeCov
+      run: |
+        bash <(curl -s https://codecov.io/bash) -f lcov_filtered.info || echo "Codecov did not collect coverage reports"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -99,24 +99,6 @@ jobs:
       run: |
         cd build
         ./test/run_tests "~[quality]"
-  build-clang8:
-    runs-on: ubuntu-18.04
-    name: Clang 8
-    
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Build mockturtle
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_CXX_COMPILER=clang++-8 -DMOCKTURTLE_TEST=ON ..
-        make run_tests
-    - name: Run tests
-      run: |
-        cd build
-        ./test/run_tests "~[quality]"
   build-clang9:
     runs-on: ubuntu-latest
     name: Clang 9

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,24 +27,6 @@ jobs:
       run: |
         cd build
         ./test/run_tests "~[quality]"
-  build-gcc8:
-    runs-on: ubuntu-18.04
-    name: GNU GCC 8
-    
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Build mockturtle
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_CXX_COMPILER=g++-8 -DMOCKTURTLE_TEST=ON ..
-        make run_tests
-    - name: Run tests
-      run: |
-        cd build
-        ./test/run_tests "~[quality]"
   build-gcc9:
     runs-on: ubuntu-latest
     name: GNU GCC 9

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-gcc7:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: GNU GCC 7
     
     steps:
@@ -100,7 +100,7 @@ jobs:
         cd build
         ./test/run_tests "~[quality]"
   build-clang8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Clang 8
     
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
         cd build
         ./test/run_tests "~[quality]"
   build-gcc8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: GNU GCC 8
     
     steps:


### PR DESCRIPTION
This PR integrates the code coverage analysis app `codecov`.

This PR also removes some GitHub flow actions for Ubuntu due to the decision by `virtual-environments` not to support "GCC and clang versions less than 9.x on Ubuntu" anymore: https://github.com/actions/virtual-environments/issues/2950
