### PR TITLE
Convert k-LUT networks into gate-based networks

### DIFF
--- a/include/mockturtle/algorithms/gates_to_nodes.hpp
+++ b/include/mockturtle/algorithms/gates_to_nodes.hpp
@@ -133,6 +133,224 @@ NtkDest gates_to_nodes( NtkSource const& ntk )
   return dest;
 }
 
+/*! \brief Translates a node-based network into a gate-based network.
+ *
+ * A gate will be created in the gate-based network for every node based on the
+ * node function (LUT). If there is some node whose function cannot be trivially
+ * decomposed into supported gates, an error will be raised and this function will
+ * terminate with a `false` return value.
+ *
+ * The source network will not be modified. A reference to an empty destination
+ * network should be provided.
+ *
+ * **Required network functions for parameter ntk_src (type NtkSource):**
+ * - `foreach_pi`
+ * - `foreach_gate`
+ * - `foreach_fanin`
+ * - `get_constant`
+ * - `get_node`
+ * - `is_constant`
+ * - `is_pi`
+ * - `is_complemented`
+ * - `node_function`
+ *
+ * **Required network functions for parameter ntk_dest (type NtkDest):**
+ * - `create_pi`
+ * - `create_po`
+ * - `create_not`
+ * - `get_constant`
+ *
+ * \param ntk_dest The translated gate-based network (e.g. xag_network, xmg_network)
+ * \param ntk_src A node-based network (e.g. klut_network)
+ * \return Whether the translation is successful 
+ */
+template<class NtkDest, class NtkSource>
+bool nodes_to_gates( NtkDest& ntk_dest, NtkSource const& ntk_src )
+{
+  static_assert( is_network_type_v<NtkDest>, "NtkDest is not a network type" );
+  static_assert( has_create_pi_v<NtkDest>, "NtkDest does not implement the create_pi method" );
+  static_assert( has_create_po_v<NtkDest>, "NtkDest does not implement the create_po method" );
+  static_assert( has_create_not_v<NtkDest>, "NtkDest does not implement the create_not method" );
+  static_assert( has_get_constant_v<NtkDest>, "NtkDest does not implement the get_constant method" );
+
+  static_assert( is_network_type_v<NtkSource>, "NtkSource is not a network type" );
+  static_assert( has_foreach_pi_v<NtkSource>, "NtkSource does not implement the foreach_pi method" );
+  static_assert( has_foreach_gate_v<NtkSource>, "NtkSource does not implement the foreach_gate method" );
+  static_assert( has_foreach_fanin_v<NtkSource>, "NtkSource does not implement the foreach_fanin method" );
+  static_assert( has_get_constant_v<NtkSource>, "NtkSource does not implement the get_constant method" );
+  static_assert( has_get_node_v<NtkSource>, "NtkSource does not implement the get_node method" );
+  static_assert( has_is_constant_v<NtkSource>, "NtkSource does not implement the is_constant method" );
+  static_assert( has_is_pi_v<NtkSource>, "NtkSource does not implement the is_pi method" );
+  static_assert( has_is_complemented_v<NtkSource>, "NtkSource does not implement the is_complemented method" );
+  static_assert( has_node_function_v<NtkSource>, "NtkSource does not implement the node_function method" );
+
+  node_map<signal<NtkDest>, NtkSource> node_to_signal( ntk_src );
+
+  ntk_src.foreach_pi( [&]( auto const& n ) {
+    node_to_signal[n] = ntk_dest.create_pi();
+  } );
+
+  node_to_signal[ntk_src.get_constant( false )] = ntk_dest.get_constant( false );
+  if ( ntk_src.get_node( ntk_src.get_constant( false ) ) != ntk_src.get_node( ntk_src.get_constant( true ) ) )
+  {
+    node_to_signal[ntk_src.get_constant( true )] = ntk_dest.get_constant( true );
+  }
+
+  bool success = true;
+  ntk_src.foreach_gate( [&]( auto const& n ) {
+    std::vector<signal<NtkDest>> children;
+    ntk_src.foreach_fanin( n, [&]( auto const& c ) {
+      children.push_back( ntk_src.is_complemented( c ) ? ntk_dest.create_not( node_to_signal[c] ) : node_to_signal[c] );
+    } );
+
+    if ( children.size() == 1u )
+    {
+      if constexpr ( has_is_buf_v<NtkSource> )
+      {
+        if ( ntk_src.is_buf( n ) )
+        {
+          node_to_signal[n] = children[0];
+          return true;
+        }
+      }
+      if constexpr ( has_is_not_v<NtkSource> )
+      {
+        if ( ntk_src.is_not( n ) )
+        {
+          node_to_signal[n] = !children[0];
+          return true;
+        }
+      }
+    }
+    else if ( children.size() == 2u )
+    {
+      if constexpr ( has_is_and_v<NtkSource> && has_create_and_v<NtkDest> )
+      {
+        if ( ntk_src.is_and( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_and( children[0], children[1] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_or_v<NtkSource> && has_create_or_v<NtkDest> )
+      {
+        if ( ntk_src.is_or( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_or( children[0], children[1] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_nand_v<NtkSource> && has_create_nand_v<NtkDest> )
+      {
+        if ( ntk_src.is_nand( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_nand( children[0], children[1] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_nor_v<NtkSource> && has_create_nor_v<NtkDest> )
+      {
+        if ( ntk_src.is_nor( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_nor( children[0], children[1] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_lt_v<NtkSource> && has_create_lt_v<NtkDest> )
+      {
+        if ( ntk_src.is_lt( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_lt( children[0], children[1] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_le_v<NtkSource> && has_create_le_v<NtkDest> )
+      {
+        if ( ntk_src.is_le( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_le( children[0], children[1] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_gt_v<NtkSource> && has_create_le_v<NtkDest> )
+      {
+        if ( ntk_src.is_gt( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_not( ntk_dest.create_le( children[0], children[1] ) );
+          return true;
+        }
+      }
+      if constexpr ( has_is_ge_v<NtkSource> && has_create_lt_v<NtkDest> )
+      {
+        if ( ntk_src.is_ge( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_not( ntk_dest.create_lt( children[0], children[1] ) );
+          return true;
+        }
+      }
+      if constexpr ( has_is_xor_v<NtkSource> && has_create_xor_v<NtkDest> )
+      {
+        if ( ntk_src.is_xor( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_xor( children[0], children[1] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_xnor_v<NtkSource> && has_create_xnor_v<NtkDest> )
+      {
+        if ( ntk_src.is_xnor( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_xnor( children[0], children[1] );
+          return true;
+        }
+      }
+    }
+    else if ( children.size() == 3u )
+    {
+      if constexpr ( has_is_maj_v<NtkSource> && has_create_maj_v<NtkDest> )
+      {
+        if ( ntk_src.is_maj( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_maj( children[0], children[1], children[2] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_ite_v<NtkSource> && has_create_ite_v<NtkDest> )
+      {
+        if ( ntk_src.is_ite( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_ite( children[0], children[1], children[2] );
+          return true;
+        }
+      }
+      if constexpr ( has_is_xor3_v<NtkSource> && has_create_xor3_v<NtkDest> )
+      {
+        if ( ntk_src.is_xor3( n ) )
+        {
+          node_to_signal[n] = ntk_dest.create_xor3( children[0], children[1], children[2] );
+          return true;
+        }
+      }
+    }
+
+    fmt::print( "[e] Node function {} cannot be mapped into gates!\n", kitty::to_hex( ntk_src.node_function( n ) ) );
+    success = false;
+    return false;
+  } );
+
+  if ( !success )
+  {
+    return false;
+  }
+
+  /* outputs */
+  ntk_src.foreach_po( [&]( auto const& s ) {
+    ntk_dest.create_po( ntk_src.is_complemented( s ) ? ntk_dest.create_not( node_to_signal[s] ) : node_to_signal[s] );
+  } );
+
+  return true;
+}
+
 /*! \brief Creates a new network with a single node per output.
  *
  * This method can be applied to networks with a small number of primary inputs,

--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -509,6 +509,99 @@ signal create_maj( signal a, signal b, signal c )
   {
     return n > 1 && !is_ci( n );
   }
+
+  bool is_buf( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 2 );
+  }
+
+  bool is_not( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 3 );
+  }
+
+  bool is_and( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 4 );
+  }
+
+  bool is_nand( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 5 );
+  }
+
+  bool is_or( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 6 );
+  }
+
+  bool is_nor( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 7 );
+  }
+
+  bool is_lt( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 8 );
+  }
+
+  bool is_ge( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 9 );
+  }
+
+  bool is_gt( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 10 );
+  }
+
+  bool is_le( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 11 );
+  }
+
+  bool is_xor( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 12 );
+  }
+
+  bool is_xnor( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 13 );
+  }
+
+  bool is_maj( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 14 );
+  }
+
+  bool is_ite( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 16 );
+  }
+
+  bool is_xor3( node const& n ) const
+  {
+    return n > 0 && !is_ci( n ) && ( _storage->nodes[n].data[1].h1 == 18 );
+  }
+
+  bool is_nary_and( node const& n ) const
+  {
+    (void)n;
+    return false;
+  }
+
+  bool is_nary_or( node const& n ) const
+  {
+    (void)n;
+    return false;
+  }
+
+  bool is_nary_xor( node const& n ) const
+  {
+    (void)n;
+    return false;
+  }
 #pragma endregion
 
 #pragma region Functional properties

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -941,6 +941,36 @@ template<class Ntk>
 inline constexpr bool has_is_on_critical_path_v = has_is_on_critical_path<Ntk>::value;
 #pragma endregion
 
+#pragma region has_is_buf
+template<class Ntk, class = void>
+struct has_is_buf : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_buf<Ntk, std::void_t<decltype( std::declval<Ntk>().is_buf( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_buf_v = has_is_buf<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_not
+template<class Ntk, class = void>
+struct has_is_not : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_not<Ntk, std::void_t<decltype( std::declval<Ntk>().is_not( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_not_v = has_is_not<Ntk>::value;
+#pragma endregion
+
 #pragma region has_is_and
 template<class Ntk, class = void>
 struct has_is_and : std::false_type
@@ -954,6 +984,21 @@ struct has_is_and<Ntk, std::void_t<decltype( std::declval<Ntk>().is_and( std::de
 
 template<class Ntk>
 inline constexpr bool has_is_and_v = has_is_and<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_nand
+template<class Ntk, class = void>
+struct has_is_nand : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_nand<Ntk, std::void_t<decltype( std::declval<Ntk>().is_nand( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_nand_v = has_is_nand<Ntk>::value;
 #pragma endregion
 
 #pragma region has_is_or
@@ -971,6 +1016,81 @@ template<class Ntk>
 inline constexpr bool has_is_or_v = has_is_or<Ntk>::value;
 #pragma endregion
 
+#pragma region has_is_nor
+template<class Ntk, class = void>
+struct has_is_nor : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_nor<Ntk, std::void_t<decltype( std::declval<Ntk>().is_nor( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_nor_v = has_is_nor<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_lt
+template<class Ntk, class = void>
+struct has_is_lt : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_lt<Ntk, std::void_t<decltype( std::declval<Ntk>().is_lt( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_lt_v = has_is_lt<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_le
+template<class Ntk, class = void>
+struct has_is_le : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_le<Ntk, std::void_t<decltype( std::declval<Ntk>().is_le( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_le_v = has_is_le<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_gt
+template<class Ntk, class = void>
+struct has_is_gt : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_gt<Ntk, std::void_t<decltype( std::declval<Ntk>().is_gt( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_gt_v = has_is_gt<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_ge
+template<class Ntk, class = void>
+struct has_is_ge : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_ge<Ntk, std::void_t<decltype( std::declval<Ntk>().is_ge( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_ge_v = has_is_ge<Ntk>::value;
+#pragma endregion
+
 #pragma region has_is_xor
 template<class Ntk, class = void>
 struct has_is_xor : std::false_type
@@ -984,6 +1104,21 @@ struct has_is_xor<Ntk, std::void_t<decltype( std::declval<Ntk>().is_xor( std::de
 
 template<class Ntk>
 inline constexpr bool has_is_xor_v = has_is_xor<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_xnor
+template<class Ntk, class = void>
+struct has_is_xnor : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_xnor<Ntk, std::void_t<decltype( std::declval<Ntk>().is_xnor( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_xnor_v = has_is_xnor<Ntk>::value;
 #pragma endregion
 
 #pragma region has_is_maj


### PR DESCRIPTION
I implemented `nodes_to_gates` in parallel to the existing `gates_to_nodes` to convert `klut_network` to other network types for interfacing with ABC-produced XAGs written in the `.bench` format. However, later on, I found a way in ABC to produce `lorina`-readable Verilog files (See Note below), and this code is not needed for me anymore. I am not sure if this functionality will be useful for someone else in the future...

Note: ABC seems to have some bug when calling `if -K 2; write_verilog`. It produces lines like `assign c = a & (b | ~a);`, which causes parsing errors in `lorina`. This can be solved by using `&if` instead. The commands that eventually worked for me are:
```&read $file; &if -K 2 -a; &put; write_verilog $name.v```