### PR TITLE
Window rewriting

### DIFF
--- a/include/mockturtle/algorithms/network_fuzz_tester.hpp
+++ b/include/mockturtle/algorithms/network_fuzz_tester.hpp
@@ -108,7 +108,7 @@ public:
     }
   }
 
-  template<typename Fn, typename Ntk>
+  template<typename Ntk, typename Fn>
   void rerun_on_benchmark( Fn&& fn )
   {
     /* read benchmark from a file */

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -179,17 +179,23 @@ public:
     , st( st )
   {
     auto const update_level_of_new_node = [&]( const auto& n ) {
+      stopwatch t( st.time_total );
+
       ntk.resize_levels();
       update_node_level( n );
     };
 
     auto const update_level_of_existing_node = [&]( node const& n, const auto& old_children ) {
+      stopwatch t( st.time_total );
+
       (void)old_children;
       ntk.resize_levels();
       update_node_level( n );
     };
 
     auto const update_level_of_deleted_node = [&]( node const& n ) {
+      stopwatch t( st.time_total );
+
       assert( ntk.fanout_size( n ) == 0u );
       ntk.set_level( n, -1 );
     };

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -427,6 +427,7 @@ private:
         {
           ntk.incr_fanout_size( ntk.get_node( repl->second ) );
           substitutions.emplace_back( *repl );
+          ++st.num_restrashes;
         }
       }
 

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -571,8 +571,12 @@ private:
           });
         }
       }
+
+      /* clean the level */
+      levels[level_index].clear();
     }
     levels.clear();
+    levels.resize( ntk.depth() );
   }
 
   /* eagerly update the node levels without topologically sorting (may

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -376,7 +376,7 @@ private:
                                                {
                                                  ntk.decr_fanout_size( nn );
                                                }
-                                               /* remove the node if it's fanout_size becomes 0 */
+                                               /* remove the node if its fanout_size becomes 0 */
                                                if ( ntk.fanout_size( nn ) == 0 )
                                                {
                                                  ntk.take_out_node( nn );
@@ -406,8 +406,7 @@ private:
       substitutions.pop_front();
 
       // for ( auto index = 1u; index < _storage->nodes.size(); ++index )
-      const auto parents = ntk.fanout( old_node );
-      for ( auto index : parents )
+      for ( auto index : ntk.fanout( old_node ) )
       {
         /* skip CIs and dead nodes */
         if ( ntk.is_dead( index ) )

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -71,9 +71,6 @@ struct window_rewriting_stats
   /*! \brief Time for updating level information. */
   stopwatch<>::duration time_levels{0};
 
-  /*! \brief Time for updating window outputs. */
-  stopwatch<>::duration time_update_vector{0};
-
   /*! \brief Time for topological sorting. */
   stopwatch<>::duration time_topo_sort{0};
 
@@ -93,7 +90,6 @@ struct window_rewriting_stats
     time_optimize += other.time_optimize;
     time_substitute += other.time_substitute;
     time_levels += other.time_levels;
-    time_update_vector += other.time_update_vector;
     time_topo_sort += other.time_topo_sort;
     time_encode += other.time_encode;
     num_substitutions += other.num_substitutions;
@@ -105,7 +101,7 @@ struct window_rewriting_stats
   void report() const
   {
     stopwatch<>::duration time_other =
-      time_total - time_window - time_topo_sort - time_optimize - time_substitute - time_levels - time_update_vector;
+      time_total - time_window - time_topo_sort - time_optimize - time_substitute - time_levels;
 
     fmt::print( "===========================================================================\n" );
     fmt::print( "[i] Windowing =  {:7.2f} ({:5.2f}%) (#win = {})\n",
@@ -119,7 +115,6 @@ struct window_rewriting_stats
                 to_seconds( time_substitute ) / to_seconds( time_total ) * 100,
                 num_restrashes );
     fmt::print( "[i] Upd.levels = {:7.2f} ({:5.2f}%)\n", to_seconds( time_levels ), to_seconds( time_levels ) / to_seconds( time_total ) * 100 );
-    fmt::print( "[i] Upd.win =    {:7.2f} ({:5.2f}%)\n", to_seconds( time_update_vector ), to_seconds( time_update_vector ) / to_seconds( time_total ) * 100 );
     fmt::print( "[i] Other =      {:7.2f} ({:5.2f}%)\n", to_seconds( time_other ), to_seconds( time_other ) / to_seconds( time_total ) * 100 );
     fmt::print( "---------------------------------------------------------------------------\n" );
     fmt::print( "[i] TOTAL =      {:7.2f}\n", to_seconds( time_total ) );
@@ -249,13 +244,14 @@ public:
           outputs.push_back( o );
         });
 
-        std::vector<signal> new_outputs;
         uint32_t counter{0};
-
         ++st.num_substitutions;
+
+        std::list<std::pair<node, signal>> substitutions;
         insert( ntk, std::begin( signals ), std::end( signals ), *il_opt,
                 [&]( signal const& _new )
                 {
+                  assert( !ntk.is_dead( ntk.get_node( _new ) ) );
                   auto const _old = outputs.at( counter++ );
                   if ( _old == _new )
                   {
@@ -274,13 +270,15 @@ public:
                     return false;
                   }
 
-                  auto const updates = substitute_node( ntk.get_node( _old ), topo_win.is_complemented( _old ) ? !_new : _new );
-                  update_vector( outputs, updates );
+                  substitutions.emplace_back( std::make_pair( ntk.get_node( _old ), ntk.is_complemented( _old ) ? !_new : _new ) );
                   return true;
                 });
 
+        substitute_nodes( substitutions );
+
         /* recompute levels and depth */
         // call_with_stopwatch( st.time_levels, [&]() { ntk.update_levels(); } );
+        update_depth();
 
         /* ensure that no dead nodes are reachable */
         assert( count_reachable_dead_nodes( ntk ) == 0u );
@@ -353,59 +351,100 @@ private:
     }
   }
 
-  /* substitute the node with a signal and return all strashing updates */
-  std::vector<std::pair<node, signal>> substitute_node( node const& old_node, signal const& new_signal )
+  void substitute_nodes( std::list<std::pair<node, signal>> substitutions )
   {
     stopwatch t( st.time_substitute );
 
-    std::vector<std::pair<node, signal>> updates;
-    std::stack<std::pair<node, signal>> to_substitute;
-    to_substitute.push( {old_node, new_signal} );
-    while ( !to_substitute.empty() )
+    auto clean_substitutions = [&]( node const& n )
     {
-      const auto [_old, _new] = to_substitute.top();
-      to_substitute.pop();
+      substitutions.erase( std::remove_if( std::begin( substitutions ), std::end( substitutions ),
+                                           [&]( auto const& s ){
+                                             if ( s.first == n )
+                                             {
+                                               node const nn = ntk.get_node( s.second );
+                                               if ( ntk.is_dead( nn ) )
+                                                 return true;
 
-      auto const p = std::make_pair( _old, _new );
-      if ( std::find( std::begin( updates ), std::end( updates ), p ) == std::end( updates ) )
-      {
-        updates.push_back( p );
-      }
+                                               /* deref fanout_size of the node */
+                                               if ( ntk.fanout_size( nn ) > 0 )
+                                               {
+                                                 ntk.decr_fanout_size( nn );
+                                               }
+                                               /* remove the node if it's fanout_size becomes 0 */
+                                               if ( ntk.fanout_size( nn ) == 0 )
+                                               {
+                                                 ntk.take_out_node( nn );
+                                               }
+                                               /* remove substitution from list */
+                                               return true;
+                                             }
+                                             return false; /* keep */
+                                           } ),
+                           std::end( substitutions ) );
+    };
 
-      const auto parents = ntk.fanout( _old );
-      for ( auto n : parents )
+    /* register event to delete substitutions if their right-hand side
+       nodes get deleted */
+    ntk._events->on_delete.push_back( clean_substitutions );
+
+    /* increment fanout_size of all signals to be used in
+       substitutions to ensure that they will not be deleted */
+    for ( const auto& s : substitutions )
+    {
+      ntk.incr_fanout_size( ntk.get_node( s.second ) );
+    }
+
+    while ( !substitutions.empty() )
+    {
+      auto const [old_node, new_signal] = substitutions.front();
+      substitutions.pop_front();
+
+      // for ( auto index = 1u; index < _storage->nodes.size(); ++index )
+      const auto parents = ntk.fanout( old_node );
+      for ( auto index : parents )
       {
-        if ( const auto repl = ntk.replace_in_node( n, _old, _new ); repl )
+        /* skip CIs and dead nodes */
+        if ( ntk.is_dead( index ) )
+          continue;
+
+        /* skip nodes that will be deleted */
+        if ( std::find_if( std::begin( substitutions ), std::end( substitutions ),
+                           [&index]( auto s ){ return s.first == index; } ) != std::end( substitutions ) )
+          continue;
+
+        /* replace in node */
+        if ( const auto repl = ntk.replace_in_node( index, old_node, new_signal ); repl )
         {
-          to_substitute.push( *repl );
-          ++st.num_restrashes;
+          ntk.incr_fanout_size( ntk.get_node( repl->second ) );
+          substitutions.emplace_back( *repl );
         }
       }
 
-      /* check outputs */
-      ntk.replace_in_outputs( _old, _new );
+      /* replace in outputs */
+      ntk.replace_in_outputs( old_node, new_signal );
 
-      /* reset fan-in of old node */
-      ntk.take_out_node( _old );
-    }
-
-    return updates;
-  }
-
-  void update_vector( std::vector<signal>& vs, std::vector<std::pair<node, signal>> const& updates )
-  {
-    stopwatch t( st.time_update_vector );
-
-    for ( auto it = std::begin( vs ); it != std::end( vs ); ++it )
-    {
-      for ( auto it2 = std::begin( updates ); it2 != std::end( updates ); ++it2 )
+      /* replace in substitutions */
+      for ( auto& s : substitutions )
       {
-        if ( ntk.get_node( *it ) == it2->first )
+        if ( ntk.get_node( s.second ) == old_node )
         {
-          *it = ntk.is_complemented( *it ) ? !it2->second : it2->second;
+          s.second = ntk.is_complemented( s.second ) ? !new_signal : new_signal;
+          ntk.incr_fanout_size( ntk.get_node( new_signal ) );
         }
       }
+
+      /* finally remove the node: note that we never decrement the
+         fanout_size of the old_node. instead, we remove the node and
+         reset its fanout_size to 0 knowing that it must be 0 after
+         substituting all references. */
+      assert( !ntk.is_dead( old_node ) );
+      ntk.take_out_node( old_node );
+
+      /* decrement fanout_size when released from substitution list */
+      ntk.decr_fanout_size( ntk.get_node( new_signal ) );
     }
+
+    ntk._events->on_delete.pop_back();
   }
 
   /* recursively update the node levels and the depth of the critical path */
@@ -424,18 +463,32 @@ private:
     } );
     ++max_level;
 
-    if ( ntk.depth() < max_level )
-    {
-      ntk.set_depth( max_level );
-    }
-
     if ( curr_level != max_level )
     {
       ntk.set_level( n, max_level );
-
       ntk.foreach_fanout( n, [&]( const auto& p ) {
-        update_node_level( p );
+        if ( !ntk.is_dead( p ) )
+        {
+          update_node_level( p );
+        }
       } );
+    }
+  }
+
+  void update_depth()
+  {
+    uint32_t max_level{0};
+    ntk.foreach_co( [&]( signal s ){
+      assert( !ntk.is_dead( ntk.get_node( s ) ) );
+      if ( ntk.level( ntk.get_node( s ) ) > max_level )
+      {
+        max_level = ntk.level( ntk.get_node( s ) );
+      }
+    });
+
+    if ( ntk.depth() != max_level )
+    {
+      ntk.set_depth( max_level );
     }
   }
 

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -452,6 +452,10 @@ private:
 
       /* decrement fanout_size when released from substitution list */
       ntk.decr_fanout_size( ntk.get_node( new_signal ) );
+      if ( ntk.fanout_size( ntk.get_node( new_signal ) ) == 0 )
+      {
+        ntk.take_out_node( ntk.get_node( new_signal ) );
+      }
     }
 
     ntk._events->on_delete.pop_back();

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -93,6 +93,7 @@ struct window_rewriting_stats
     time_topo_sort += other.time_topo_sort;
     time_encode += other.time_encode;
     num_substitutions += other.num_substitutions;
+    num_restrashes += other.num_restrashes;
     num_windows += other.num_windows;
     gain += other.gain;
     return *this;

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -51,6 +51,27 @@ struct window_rewriting_params
   uint64_t cut_size{6};
   uint64_t num_levels{5};
 
+  /* Level information guides the windowing construction and as such impacts QoR:
+     -- dont_update: fastest, but levels are wrong (QoR degrades)
+     -- eager: fast, some levels are wrong
+     -- precise: fast, all levels are correct (best QoR)
+     -- recompute: slow, same as precise (used only for debugging)
+  */
+  enum
+  {
+    /* do not update any levels */
+    dont_update,
+    /* eagerly update the levels of changed nodes but avoid
+       topological sorting (some levels will be wrong) */
+    eager,
+    /* precisely update the levels of changed nodes bottom-to-top and
+       in topological order */
+    precise,
+    /* recompute all levels (also precise, but more expensive to
+       compute) */
+    recompute,
+  } level_update_strategy = dont_update;
+
   bool filter_cyclic_substitutions{false};
 }; /* window_rewriting_params */
 
@@ -76,6 +97,9 @@ struct window_rewriting_stats
 
   /*! \brief Time for encoding index_list. */
   stopwatch<>::duration time_encode{0};
+
+  /*! \brief Time for detecting cycles. */
+  stopwatch<>::duration time_cycle{0};
 
   /*! \brief Total number of calls to the resub. engine. */
   uint64_t num_substitutions{0};
@@ -178,26 +202,24 @@ public:
     : ntk( ntk )
     , ps( ps )
     , st( st )
+    /* initialize levels to network depth */
+    , levels( ntk.depth() )
   {
     auto const update_level_of_new_node = [&]( const auto& n ) {
       stopwatch t( st.time_total );
-
-      ntk.resize_levels();
-      update_node_level( n );
+      update_levels( n );
     };
 
     auto const update_level_of_existing_node = [&]( node const& n, const auto& old_children ) {
-      stopwatch t( st.time_total );
-
       (void)old_children;
-      ntk.resize_levels();
-      update_node_level( n );
+      stopwatch t( st.time_total );
+      update_levels( n );
     };
 
     auto const update_level_of_deleted_node = [&]( node const& n ) {
       stopwatch t( st.time_total );
-
       assert( ntk.fanout_size( n ) == 0u );
+      assert( ntk.is_dead( n ) );
       ntk.set_level( n, -1 );
     };
 
@@ -212,7 +234,7 @@ public:
 
     create_window_impl windowing( ntk );
     uint32_t const size = ntk.size();
-    for ( uint32_t n = 0u; n < std::min( size, ntk.size() ); ++n )
+    for ( uint32_t n = 0u; n < size; ++n )
     {
       if ( ntk.is_constant( n ) || ntk.is_ci( n ) || ntk.is_dead( n ) )
       {
@@ -254,6 +276,9 @@ public:
         uint32_t counter{0};
         ++st.num_substitutions;
 
+        /* ensure that no dead nodes are reachable */
+        assert( count_reachable_dead_nodes( ntk ) == 0u );
+
         std::list<std::pair<node, signal>> substitutions;
         insert( ntk, std::begin( signals ), std::end( signals ), *il_opt,
                 [&]( signal const& _new )
@@ -267,7 +292,8 @@ public:
 
                   /* ensure that _old is not in the TFI of _new */
                   // assert( !is_contained_in_tfi( ntk, ntk.get_node( _new ), ntk.get_node( _old ) ) );
-                  if ( ps.filter_cyclic_substitutions && is_contained_in_tfi( ntk, ntk.get_node( _new ), ntk.get_node( _old ) ) )
+                  if ( ps.filter_cyclic_substitutions &&
+                       call_with_stopwatch( st.time_window, [&](){ return is_contained_in_tfi( ntk, ntk.get_node( _new ), ntk.get_node( _old ) ); }) )
                   {
                     std::cout << "undo resubstitution " << ntk.get_node( _old ) << std::endl;
                     substitutions.emplace_back( std::make_pair( ntk.get_node( _old ), ntk.is_complemented( _old ) ? !_new : _new ) );                    
@@ -286,11 +312,19 @@ public:
                   return true;
                 });
 
+        /* ensure that no dead nodes are reachable */
+        assert( count_reachable_dead_nodes( ntk ) == 0u );
         substitute_nodes( substitutions );
 
         /* recompute levels and depth */
-        // call_with_stopwatch( st.time_levels, [&]() { ntk.update_levels(); } );
-        update_depth();
+        if ( ps.level_update_strategy == window_rewriting_params::recompute )
+        {
+          call_with_stopwatch( st.time_levels, [&]() { ntk.update_levels(); } );
+        }
+        if ( ps.level_update_strategy != window_rewriting_params::dont_update )
+        {
+          update_depth();
+        }
 
         /* ensure that no dead nodes are reachable */
         assert( count_reachable_dead_nodes( ntk ) == 0u );
@@ -298,8 +332,12 @@ public:
         /* ensure that the network structure is still acyclic */
         assert( network_is_acylic( ntk ) );
 
-        /* ensure that the levels and depth is correct */
-        assert( check_network_levels( ntk ) );
+        if ( ps.level_update_strategy == window_rewriting_params::precise ||
+             ps.level_update_strategy == window_rewriting_params::recompute )
+        {
+          /* ensure that the levels and depth is correct */
+          assert( check_network_levels( ntk ) );
+        }
 
         /* update internal data structures in windowing */
         windowing.resize( ntk.size() );
@@ -415,12 +453,16 @@ private:
       {
         /* skip CIs and dead nodes */
         if ( ntk.is_dead( index ) )
+        {
           continue;
+        }
 
         /* skip nodes that will be deleted */
         if ( std::find_if( std::begin( substitutions ), std::end( substitutions ),
                            [&index]( auto s ){ return s.first == index; } ) != std::end( substitutions ) )
+        {
           continue;
+        }
 
         /* replace in node */
         if ( const auto repl = ntk.replace_in_node( index, old_node, new_signal ); repl )
@@ -462,11 +504,82 @@ private:
     ntk._events->on_delete.pop_back();
   }
 
-  /* recursively update the node levels and the depth of the critical path */
-  void update_node_level( node const& n )
+  void update_levels( node const& n )
+  {
+    ntk.resize_levels();
+    if ( ps.level_update_strategy == window_rewriting_params::precise )
+    {
+      assert( count_reachable_dead_nodes_from_node( ntk, n ) == 0u );
+      assert( count_nodes_with_dead_fanins( ntk, n ) == 0u );
+      call_with_stopwatch( st.time_levels, [&]() { update_node_level_precise( n ); } );
+    }
+    else if ( ps.level_update_strategy == window_rewriting_params::eager )
+    {
+      assert( count_reachable_dead_nodes_from_node( ntk, n ) == 0u );
+      assert( count_nodes_with_dead_fanins( ntk, n ) == 0u );
+      call_with_stopwatch( st.time_levels, [&]() { update_node_level_eager( n ); } );
+    }
+
+    /* levels can be wrong until substitute_nodes has finished */
+    // assert( check_network_levels( ntk ) );
+  }
+
+  /* precisely update node levels using an iterative topological sorting approach */
+  void update_node_level_precise( node const& n )
+  {
+    /* compute level of current node */
+    uint32_t level_offset{0};
+    ntk.foreach_fanin( n, [&]( signal const& fi ){
+      level_offset = std::max( ntk.level( ntk.get_node( fi ) ), level_offset );
+    });
+    ++level_offset;
+
+    /* add node into levels */
+    levels[0].emplace_back( n );
+
+    for ( uint32_t level_index = 0u; level_index < levels.size(); ++level_index )
+    {
+      if ( levels[level_index].empty() )
+        continue;
+
+      for ( uint32_t node_index = 0u; node_index < levels[level_index].size(); ++node_index )
+      {
+        node const p = levels[level_index][node_index];
+
+        /* recompute level of this node */
+        uint32_t lvl{0};
+        ntk.foreach_fanin( p, [&]( signal const& fi ){
+          lvl = std::max( ntk.level( ntk.get_node( fi ) ), lvl );
+        });
+        ++lvl;
+
+        /* update level and add fanouts to levels[.] if the recomputed
+           level is different from the current level */
+        if ( lvl != ntk.level( p ) )
+        {
+          ntk.set_level( p, lvl );
+          ntk.foreach_fanout( p, [&]( node const& fo ){
+            assert( std::max( ntk.level( fo ), lvl + 1 ) >= level_offset );
+            uint32_t const pos = std::max( ntk.level( fo ), lvl + 1 ) - level_offset;
+            assert( pos >= 0u );
+            assert( pos >= level_index );
+            if ( levels.size() <= pos )
+            {
+              levels.resize( std::max( uint32_t( levels.size() << 1 ), pos + 1 ) );
+            }
+            levels[pos].emplace_back( fo );
+          });
+        }
+      }
+    }
+    levels.clear();
+  }
+
+  /* eagerly update the node levels without topologically sorting (may
+     stack-overflow if the network is deep)*/
+  void update_node_level_eager( node const& n )
   {
     uint32_t const curr_level = ntk.level( n );
-
     uint32_t max_level = 0;
     ntk.foreach_fanin( n, [&]( const auto& f ) {
       auto const p = ntk.get_node( f );
@@ -484,21 +597,21 @@ private:
       ntk.foreach_fanout( n, [&]( const auto& p ) {
         if ( !ntk.is_dead( p ) )
         {
-          update_node_level( p );
+          update_node_level_eager( p );
         }
       } );
     }
   }
 
+  /* update network depth (needs level information!) */
   void update_depth()
   {
+    stopwatch t( st.time_levels );
+
     uint32_t max_level{0};
-    ntk.foreach_co( [&]( signal s ){
+    ntk.foreach_co( [&]( signal const& s ){
       assert( !ntk.is_dead( ntk.get_node( s ) ) );
-      if ( ntk.level( ntk.get_node( s ) ) > max_level )
-      {
-        max_level = ntk.level( ntk.get_node( s ) );
-      }
+      max_level = std::max( ntk.level( ntk.get_node( s ) ), max_level );
     });
 
     if ( ntk.depth() != max_level )
@@ -511,9 +624,11 @@ private:
   Ntk& ntk;
   window_rewriting_params ps;
   window_rewriting_stats& st;
-}; /* window_rewriting_impl */
 
-} /* detail */
+  std::vector<std::vector<node>> levels;
+};
+
+} /* namespace detail */
 
 template<class Ntk>
 void window_rewriting( Ntk& ntk, window_rewriting_params const& ps = {}, window_rewriting_stats* pst = nullptr )

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -269,10 +269,15 @@ public:
                   if ( ps.filter_cyclic_substitutions && is_contained_in_tfi( ntk, ntk.get_node( _new ), ntk.get_node( _old ) ) )
                   {
                     std::cout << "undo resubstitution " << ntk.get_node( _old ) << std::endl;
-                    if ( ntk.fanout_size( ntk.get_node( _new ) ) == 0u )
+                    substitutions.emplace_back( std::make_pair( ntk.get_node( _old ), ntk.is_complemented( _old ) ? !_new : _new ) );                    
+                    for ( auto it = std::rbegin( substitutions ); it != std::rend( substitutions ); ++it )
                     {
-                      ntk.take_out_node( ntk.get_node( _new ) );
+                      if ( ntk.fanout_size( ntk.get_node( it->second ) ) == 0u )
+                      {
+                        ntk.take_out_node( ntk.get_node( it->second ) );
+                      }
                     }
+                    substitutions.clear();
                     return false;
                   }
 

--- a/include/mockturtle/utils/debugging_utils.hpp
+++ b/include/mockturtle/utils/debugging_utils.hpp
@@ -222,6 +222,7 @@ void count_nodes_with_dead_fanins_recur( Ntk const& ntk, typename Ntk::node cons
   {
     return;
   }
+  ntk.paint( n );
 
   ntk.foreach_fanin( n, [&]( signal const& s ){
     if ( ntk.is_dead( ntk.get_node( s ) ) )
@@ -233,16 +234,15 @@ void count_nodes_with_dead_fanins_recur( Ntk const& ntk, typename Ntk::node cons
     }
   });
 
-  ntk.paint( n );
   ntk.foreach_fanout( n, [&]( node const& fo ){
-    count_reachable_dead_nodes_from_node_recur( ntk, fo, nodes );
+    count_nodes_with_dead_fanins_recur( ntk, fo, nodes );
   });
 }
 
 } /* namespace detail */
 
 template<typename Ntk>
-inline uint64_t count_nodes_with_dead_fanins( Ntk const& ntk, typename Ntk::node const& n )
+uint64_t count_nodes_with_dead_fanins( Ntk const& ntk, typename Ntk::node const& n )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_color_v<Ntk>, "Ntk does not implement the color function" );
@@ -255,7 +255,6 @@ inline uint64_t count_nodes_with_dead_fanins( Ntk const& ntk, typename Ntk::node
   static_assert( has_paint_v<Ntk>, "Ntk does not implement the paint function" );
 
   using node = typename Ntk::node;
-  using signal = typename Ntk::signal;
 
   ntk.new_color();
 

--- a/include/mockturtle/utils/window_utils.hpp
+++ b/include/mockturtle/utils/window_utils.hpp
@@ -664,7 +664,7 @@ void expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::node> const& 
 namespace detail
 {
 
-template<typename Ntk>
+template<typename Ntk, bool auto_resize = true>
 void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::node> const& inputs, std::vector<typename Ntk::node>& nodes,
                                    std::vector<std::vector<typename Ntk::node>>& levels )
 {
@@ -685,6 +685,13 @@ void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::nod
   {
     uint32_t const node_level = ntk.level( i );
     ntk.paint( i );
+    if constexpr ( auto_resize )
+    {
+      if ( levels.size() <= node_level )
+      {
+        levels.resize( std::max( uint32_t( 2*levels.size() ), node_level ) );
+      }
+    }
     levels.at( node_level ).push_back( i );
     if ( std::find( std::begin( used ), std::end( used ), node_level ) == std::end( used ) )
     {
@@ -697,6 +704,13 @@ void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::nod
   {
     uint32_t const node_level = ntk.level( n );
     ntk.paint( n );
+    if constexpr ( auto_resize )
+    {
+      if ( levels.size() <= node_level )
+      {
+        levels.resize( std::max( uint32_t( 2 * levels.size() ), node_level ) );
+      }
+    }
     levels.at( node_level ).push_back( n );
     if ( std::find( std::begin( used ), std::end( used ), node_level ) == std::end( used ) )
     {
@@ -733,6 +747,13 @@ void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::nod
           /* update data structured */
           uint32_t const node_level = ntk.level( fo );
           ntk.paint( fo );
+          if constexpr ( auto_resize )
+          {
+            if ( levels.size() <= node_level )
+            {
+              levels.resize( std::max( uint32_t( 2*levels.size() ), node_level ) );
+            }
+          }
           levels.at( node_level ).push_back( fo );
           if ( std::find( std::begin( used ), std::end( used ), node_level ) == std::end( used ) )
           {
@@ -777,11 +798,11 @@ void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::nod
  * - `new_color`
  * - `paint`
  */
-template<typename Ntk>
+template<typename Ntk, bool auto_resize = true>
 void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::node> const& inputs, std::vector<typename Ntk::node>& nodes )
 {
   std::vector<std::vector<typename Ntk::node>> levels;
-  detail::levelized_expand_towards_tfo( ntk, inputs, nodes, levels );
+  detail::levelized_expand_towards_tfo<Ntk, auto_resize>( ntk, inputs, nodes, levels );
 }
 
 namespace detail


### PR DESCRIPTION
This PR updates `window_rewriting`. The implementation becomes more robust, different strategies for updating level information are introduced.

Summary:
- Different strategies to update node level after window substitution (`dont_update`, `eager`, `precise`, `recompute`)
- New debugging utils: `count_nodes_with_dead_fanins`, `count_reachable_dead_nodes_from_node`
- Support for auto-resizing `levels` in `levelized_expand_towards_tfo` if network depth has not been update