### PR TITLE
exclude problematic C++ feature from Clang9.

### DIFF
--- a/include/mockturtle/algorithms/aqfp_resynthesis/detail/dag_gen.hpp
+++ b/include/mockturtle/algorithms/aqfp_resynthesis/detail/dag_gen.hpp
@@ -141,6 +141,8 @@ private:
   }
 };
 
+#if !__clang__ || __clang_major > 9__
+
 /*! \brief Generate all DAGs satisfying the parameters. */
 template<typename NodeT = int>
 class dag_generator
@@ -381,5 +383,7 @@ private:
     return res;
   }
 };
+
+#endif
 
 } // namespace mockturtle

--- a/include/mockturtle/algorithms/aqfp_resynthesis/detail/dag_gen.hpp
+++ b/include/mockturtle/algorithms/aqfp_resynthesis/detail/dag_gen.hpp
@@ -141,7 +141,7 @@ private:
   }
 };
 
-#if !__clang__ || __clang_major > 9__
+#if !__clang__ || __clang_major__ > 9
 
 /*! \brief Generate all DAGs satisfying the parameters. */
 template<typename NodeT = int>

--- a/include/mockturtle/algorithms/node_resynthesis/cached.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/cached.hpp
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#if !__clang__ || __clang_major > 9__
+
 #include <cstdint>
 #if __GNUC__ == 7
 #include <experimental/filesystem>
@@ -309,3 +311,5 @@ private:
   mutable uint32_t _cache_misses{};
 };
 } /* namespace mockturtle */
+
+#endif

--- a/include/mockturtle/algorithms/node_resynthesis/cached.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/cached.hpp
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#if !__clang__ || __clang_major > 9__
+#if !__clang__ || __clang_major__ > 9
 
 #include <cstdint>
 #if __GNUC__ == 7

--- a/include/mockturtle/algorithms/node_resynthesis/composed.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/composed.hpp
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#if !__clang__ || __clang_major > 9__
+
 #include <cstdint>
 #include <string>
 
@@ -76,3 +78,5 @@ auto cached_exact_xag_resynthesis( std::string const& cache_filename, uint32_t i
 }
 
 } /* mockturtle */
+
+#endif

--- a/include/mockturtle/algorithms/node_resynthesis/composed.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/composed.hpp
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#if !__clang__ || __clang_major > 9__
+#if !__clang__ || __clang_major__ > 9
 
 #include <cstdint>
 #include <string>

--- a/test/algorithms/aqfp_resynthesis/dag_gen.cpp
+++ b/test/algorithms/aqfp_resynthesis/dag_gen.cpp
@@ -199,6 +199,7 @@ TEST_CASE( "Sublist generation", "[aqfp_resyn]" )
   CHECK( t5 == s5 );
 }
 
+#if !__clang__ || __clang_major__ > 9
 TEST_CASE( "DAG generation", "[aqfp_resyn]" )
 {
   using Ntk = mockturtle::aqfp_dag<>;
@@ -221,3 +222,4 @@ TEST_CASE( "DAG generation", "[aqfp_resyn]" )
 
   CHECK( generated_dags.size() == 3018u );
 }
+#endif

--- a/test/algorithms/node_resynthesis/cached.cpp
+++ b/test/algorithms/node_resynthesis/cached.cpp
@@ -9,6 +9,7 @@
 
 using namespace mockturtle;
 
+#if !__clang__ || __clang_major__ > 9
 TEST_CASE( "Exact XAG for MAJ cached", "[cached]" )
 {
 #if __GNUC__ == 7
@@ -50,3 +51,4 @@ TEST_CASE( "Exact XAG for MAJ cached", "[cached]" )
   CHECK( !fs::exists( "mockturtle-test-cache.db.bak" ) );
   fs::remove( "mockturtle-test-cache.db" );
 }
+#endif

--- a/test/algorithms/quality.cpp
+++ b/test/algorithms/quality.cpp
@@ -406,6 +406,7 @@ TEST_CASE( "Test quality improvement of cut rewriting with AIG exact synthesis",
   CHECK( v == std::vector<uint32_t>{{0, 30, 4, 6, 108, 11, 75, 43, 171, 450, 5}} );
 }
 
+#if !__clang__ || __clang_major__ > 9
 TEST_CASE( "Test quality improvement of cut rewriting with AIG cached-exact synthesis", "[quality]" )
 {
   /* applies exact synthesis to 4-feasible cuts, uses a cache to store/load (function, network)-pairs from a file */
@@ -423,6 +424,7 @@ TEST_CASE( "Test quality improvement of cut rewriting with AIG cached-exact synt
 
   CHECK( v == std::vector<uint32_t>{{0, 30, 4, 6, 108, 11, 75, 43, 171, 450, 5}} );
 }
+#endif
 
 TEST_CASE( "Test quality improvement of cut rewriting with XAG NPN4 resynthesis", "[quality]" )
 {


### PR DESCRIPTION
This PR exclude some C++ features that proved to be hard to compile in the CI system (Clang 9 on Ubuntu 20.04).