### PR TITLE
Consistently linking all libraries with `SYSTEM` attribute

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 
 if (NOT TARGET fmt)
   add_library(fmt INTERFACE) # v6.3.0
-  target_include_directories(fmt INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/fmt)
+  target_include_directories(fmt SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/fmt)
   target_compile_definitions(fmt INTERFACE FMT_HEADER_ONLY)
 endif()
 
@@ -16,18 +16,18 @@ endif()
 
 if (NOT TARGET range)
   add_library(rang INTERFACE)
-  target_include_directories(rang INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/rang)
+  target_include_directories(rang SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/rang)
 endif()
 
 if (NOT TARGET lorina)
   add_library(lorina INTERFACE) # v0.1
-  target_include_directories(lorina INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/lorina)
+  target_include_directories(lorina SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/lorina)
   target_link_libraries(lorina INTERFACE rang fmt)
 endif()
 
 if (NOT TARGET json)
   add_library(json INTERFACE) # v3.5.0
-  target_include_directories(json INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/json)
+  target_include_directories(json SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/json)
 endif()
 
 if (NOT TARGET percy)
@@ -59,7 +59,7 @@ if (NOT TARGET bill)
     set(BILL_Z3_INCLUDE_PATH "" CACHE PATH "Path to Z3 includes, e.g., z3++.h")
     set(BILL_Z3_LIBRARY_PATH "" CACHE PATH "Path to Z3 library, e.g., libz3.a")
     if(NOT "${BILL_Z3_INCLUDE_PATH}" STREQUAL "")
-      target_include_directories(bill INTERFACE ${BILL_Z3_INCLUDE_PATH})
+      target_include_directories(bill SYSTEM INTERFACE ${BILL_Z3_INCLUDE_PATH})
     endif()
     if(NOT "${BILL_Z3_LIBRARY_PATH}" STREQUAL "")
       target_link_directories(bill INTERFACE ${BILL_Z3_LIBRARY_PATH})
@@ -74,7 +74,7 @@ endif()
 
 if (NOT TARGET abcresub)
   add_library(abcresub INTERFACE)
-  target_include_directories(abcresub INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/abcresub)
+  target_include_directories(abcresub SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/abcresub)
 endif()
 
 if (NOT TARGET libabcesop)
@@ -85,6 +85,6 @@ endif()
 if (ENABLE_MATPLOTLIB AND NOT TARGET matplot)
   find_package(Python3 COMPONENTS Development NumPy)
   add_library(matplot INTERFACE)
-  target_include_directories(matplot INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/matplot/ ${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS})
+  target_include_directories(matplot SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/matplot/ ${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS})
   target_link_libraries(matplot INTERFACE Python3::Python Python3::NumPy)
 endif()


### PR DESCRIPTION
This PR builds upon #437 by consistently linking all libraries as `SYSTEM` because compiler warnings generated in third-party code are still propagated to including projects.