### PR TITLE
Network names for `names_view`

### DIFF
--- a/include/mockturtle/io/blif_reader.hpp
+++ b/include/mockturtle/io/blif_reader.hpp
@@ -96,6 +96,11 @@ public:
 
   virtual void on_model( const std::string& model_name ) const override
   {
+    if constexpr ( has_set_network_name_v<Ntk> )
+    {
+      ntk_.set_network_name( model_name );
+    }
+
     (void)model_name;
   }
 

--- a/include/mockturtle/io/verilog_reader.hpp
+++ b/include/mockturtle/io/verilog_reader.hpp
@@ -98,6 +98,11 @@ public:
   void on_module_header( const std::string& module_name, const std::vector<std::string>& inouts ) const override
   {
     (void)inouts;
+    if constexpr ( has_set_network_name_v<Ntk> )
+    {
+      ntk_.set_network_name( module_name );
+    }
+
     name_ = module_name;
   }
 

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -1871,6 +1871,36 @@ template<class Ntk>
 inline constexpr bool has_incr_trav_id_v = has_incr_trav_id<Ntk>::value;
 #pragma endregion
 
+#pragma region has_get_network_name
+template<class Ntk, class = void>
+struct has_get_network_name : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_get_network_name<Ntk, std::void_t<decltype( std::declval<Ntk>().get_network_name() )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_get_network_name_v = has_get_network_name<Ntk>::value;
+#pragma endregion
+
+#pragma region has_set_network_name
+template<class Ntk, class = void>
+struct has_set_network_name : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_set_network_name<Ntk, std::void_t<decltype( std::declval<Ntk>().set_network_name( std::string() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_set_network_name_v = has_set_network_name<Ntk>::value;
+#pragma endregion
+
 #pragma region has_get_name
 template<class Ntk, class = void>
 struct has_get_name : std::false_type

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -49,15 +49,14 @@ public:
   using signal = typename Ntk::signal;
 
 public:
-  names_view( Ntk const& ntk = Ntk() )
-    : Ntk( ntk )
+  template<typename StrType = const char*>
+  names_view( Ntk const& ntk = Ntk(), StrType name = "" )
+      : Ntk( ntk ), _network_name{ name }
   {
   }
 
   names_view( names_view<Ntk> const& named_ntk )
-    : Ntk( named_ntk )
-    , _signal_names( named_ntk._signal_names )
-    , _output_names( named_ntk._output_names )
+      : Ntk( named_ntk ), _network_name( named_ntk._network_name ), _signal_names( named_ntk._signal_names ), _output_names( named_ntk._output_names )
   {
   }
 
@@ -66,12 +65,12 @@ public:
     std::map<signal, std::string> new_signal_names;
     std::vector<signal> current_pis;
     Ntk::foreach_pi( [&]( auto const& n ) {
-        current_pis.emplace_back( Ntk::make_signal( n ) );
-      });
+      current_pis.emplace_back( Ntk::make_signal( n ) );
+    } );
     named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
-        if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
-          new_signal_names[named_ntk.make_signal( n )] = it->second;
-      } );
+      if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
+        new_signal_names[named_ntk.make_signal( n )] = it->second;
+    } );
 
     Ntk::operator=( named_ntk );
     _signal_names = new_signal_names;
@@ -96,6 +95,17 @@ public:
     {
       set_output_name( index, name );
     }
+  }
+
+  template<typename StrType = const char*>
+  void set_network_name( StrType name ) noexcept
+  {
+    _network_name = name;
+  }
+
+  std::string get_network_name() const noexcept
+  {
+    return _network_name;
   }
 
   bool has_name( signal const& s ) const
@@ -129,14 +139,15 @@ public:
   }
 
 private:
+  std::string _network_name;
   std::map<signal, std::string> _signal_names;
   std::map<uint32_t, std::string> _output_names;
 }; /* names_view */
 
 template<class T>
-names_view(T const&) -> names_view<T>;
+names_view( T const& ) -> names_view<T>;
 
 template<class T>
-names_view(T const&, typename T::signal const&) -> names_view<T>;
+names_view( T const&, typename T::signal const& ) -> names_view<T>;
 
 } // namespace mockturtle

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -24,7 +24,22 @@ void test_create_names_view()
   auto const f = ntk.create_and( t1, t2 );
   ntk.create_po( f );
 
-  names_view<Ntk> named_ntk;
+  CHECK( has_get_network_name_v<names_view<Ntk>> );
+  CHECK( has_set_network_name_v<names_view<Ntk>> );
+  CHECK( has_has_name_v<names_view<Ntk>> );
+  CHECK( has_get_name_v<names_view<Ntk>> );
+  CHECK( has_set_name_v<names_view<Ntk>> );
+  CHECK( has_has_output_name_v<names_view<Ntk>> );
+  CHECK( has_get_output_name_v<names_view<Ntk>> );
+  CHECK( has_set_output_name_v<names_view<Ntk>> );
+
+  names_view<Ntk> named_ntk{ ntk, "network" };
+
+  CHECK( named_ntk.get_network_name() == "network" );
+
+  named_ntk.set_network_name( "named network" );
+
+  CHECK( named_ntk.get_network_name() == "named network" );
 
   CHECK( !named_ntk.has_name( a ) );
   CHECK( !named_ntk.has_name( b ) );


### PR DESCRIPTION
This PR extends the functionality of `names_view`. It can now additionally store a name for the overall network, which can be set via `set_network_name` and accessed via `get_network_name`. Respective traits have been added to `traits.hpp` and the functionality is covered via a test case.

`blif_reader` and `verilog_reader` have been extended to make use of the new functionality. Please verify whether this is intended behavior.