### PR TITLE
Include <memory> header in events.hpp

### DIFF
--- a/include/mockturtle/networks/events.hpp
+++ b/include/mockturtle/networks/events.hpp
@@ -39,6 +39,7 @@
 #include "../traits.hpp"
 
 #include <iostream>
+#include <memory>
 
 namespace mockturtle
 {


### PR DESCRIPTION
`events.hpp` makes heavy use of `std::shared_ptr`. Hence, it should include the `<memory>` header. Otherwise, one relies on the including file to include `<memory>` first. This lead to a compile error on my side, so I thought a fix might be helpful.

For me, https://include-what-you-use.org/ has proven helpful to avoid such issues.