### PR TITLE
Fixed internal compiler error when compiling with gcc

### DIFF
--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -64,7 +64,7 @@ public:
   {
     std::map<signal, std::string> new_signal_names;
     std::vector<signal> current_pis;
-    Ntk::foreach_pi( [&]( auto const& n ) {
+    Ntk::foreach_pi( [this, &current_pis]( auto const& n ) {
       current_pis.emplace_back( Ntk::make_signal( n ) );
     } );
     named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
@@ -74,6 +74,7 @@ public:
 
     Ntk::operator=( named_ntk );
     _signal_names = new_signal_names;
+    _network_name = named_ntk._network_name;
     return *this;
   }
 


### PR DESCRIPTION
This PR fixes an internal compiler error that can be thrown by gcc when trying to capture `this` in a lambda without explicitly stating it in the capture list.

The consequences of the event can be seen in action for instance [here](https://github.com/marcelwa/fiction/pull/11/checks?check_run_id=2717696523) and [here](https://github.com/marcelwa/fiction/pull/11/checks?check_run_id=2717696512).