### PR TITLE
[WIP - don't merge] Allow mockturtle to run on big-endian platforms. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,79 @@
+---
+notifications:
+  email: false
+
+os: linux
+dist: focal
+
+jobs:
+  include:
+    - name: Build and run tests (amd64)
+      arch: amd64 
+      language: cpp 
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env: COMPILER=g++-8
+      script:
+        - mkdir -p build
+        - cd build
+        - cmake -DCMAKE_BUILD_TYPE=Release -DMOCKTURTLE_TEST=ON ..
+
+    - name: Build and run tests (arm64)
+      arch: arm64 
+      language: cpp 
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env: COMPILER=g++-8
+      script:
+        - mkdir -p build
+        - cd build
+        - cmake -DCMAKE_BUILD_TYPE=Release -DMOCKTURTLE_TEST=ON ..
+        - make -j2 run_tests
+        - ./test/run_tests "~[quality]"
+
+    - name: Build and run tests (ppc64le)
+      arch: ppc64le 
+      language: cpp 
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env: COMPILER=g++-8
+      script:
+        - mkdir -p build
+        - cd build
+        - cmake -DCMAKE_BUILD_TYPE=Release -DMOCKTURTLE_TEST=ON ..
+        - make -j2 run_tests
+        - ./test/run_tests "~[quality]"
+
+    - name: Build and run tests (s390x)
+      arch: s390x 
+      language: cpp 
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env: COMPILER=g++-8
+      script:
+        - mkdir -p build
+        - cd build
+        - cmake -DCMAKE_BUILD_TYPE=Release -DMOCKTURTLE_TEST=ON ..
+        - make -j2 run_tests
+        - ./test/run_tests "~[quality]"
+  

--- a/include/mockturtle/endianness.hpp
+++ b/include/mockturtle/endianness.hpp
@@ -1,0 +1,84 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2021  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// As I adapted this from RAPIDJSON, here is its MIT liscense header:
+
+// Tencent is pleased to support the open source community by making RAPIDJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#define MOCKTURTLE_LITTLEENDIAN 0
+#define MOCKTURTLE_BIGENDIAN 1
+
+#ifndef MOCKTURTLE_ENDIAN
+// Detect with GCC 4.6's macro
+#ifdef __BYTE_ORDER__
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_LITTLEENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_BIGENDIAN
+#else
+#error Unknown machine endianness detected. User needs to define MOCKTURTLE_ENDIAN.
+#endif // __BYTE_ORDER__
+// Detect with GLIBC's endian.h
+#elif defined( __GLIBC__ )
+#include <endian.h>
+#if ( __BYTE_ORDER == __LITTLE_ENDIAN )
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_LITTLEENDIAN
+#elif ( __BYTE_ORDER == __BIG_ENDIAN )
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_BIGENDIAN
+#else
+#error Unknown machine endianness detected. User needs to define MOCKTURTLE_ENDIAN.
+#endif // __GLIBC__
+// Detect with _LITTLE_ENDIAN and _BIG_ENDIAN macro
+#elif defined( _LITTLE_ENDIAN ) && !defined( _BIG_ENDIAN )
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_LITTLEENDIAN
+#elif defined( _BIG_ENDIAN ) && !defined( _LITTLE_ENDIAN )
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_BIGENDIAN
+// Detect with architecture macros
+#elif defined( __sparc ) || defined( __sparc__ ) || defined( _POWER ) || defined( __powerpc__ ) || defined( __ppc__ ) || defined( __hpux ) || defined( __hppa ) || defined( _MIPSEB ) || defined( _POWER ) || defined( __s390__ )
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_BIGENDIAN
+#elif defined( __i386__ ) || defined( __alpha__ ) || defined( __ia64 ) || defined( __ia64__ ) || defined( _M_IX86 ) || defined( _M_IA64 ) || defined( _M_ALPHA ) || defined( __amd64 ) || defined( __amd64__ ) || defined( _M_AMD64 ) || defined( __x86_64 ) || defined( __x86_64__ ) || defined( _M_X64 ) || defined( __bfin__ )
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_LITTLEENDIAN
+#elif defined( _MSC_VER ) && ( defined( _M_ARM ) || defined( _M_ARM64 ) )
+#define MOCKTURTLE_ENDIAN MOCKTURTLE_LITTLEENDIAN
+#elif defined( MOCKTURTLE_DOXYGEN_RUNNING )
+#define MOCKTURTLE_ENDIAN
+#else
+#error Unknown machine endianness detected. User needs to define MOCKTURTLE_ENDIAN.
+#endif
+#endif // MOCKTURTLE_ENDIAN

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include "../endianness.hpp"
 #include "../traits.hpp"
 #include "../utils/algorithm.hpp"
 #include "detail/foreach.hpp"
@@ -126,8 +127,13 @@ public:
     union {
       struct
       {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+        uint64_t index : 63;
+        uint64_t complement : 1;
+#else
         uint64_t complement : 1;
         uint64_t index : 63;
+#endif
       };
       uint64_t data;
     };

--- a/include/mockturtle/networks/aqfp.hpp
+++ b/include/mockturtle/networks/aqfp.hpp
@@ -41,6 +41,7 @@
 #include <fmt/format.h>
 #include <kitty/kitty.hpp>
 
+#include "../endianness.hpp"
 #include "../traits.hpp"
 #include "../utils/algorithm.hpp"
 #include "detail/foreach.hpp"
@@ -106,8 +107,13 @@ public:
     {
       struct
       {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+        uint64_t index : 63;
+        uint64_t complement : 1;
+#else
         uint64_t complement : 1;
         uint64_t index : 63;
+#endif
       };
       uint64_t data;
     };

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -45,6 +45,7 @@
 #include <kitty/dynamic_truth_table.hpp>
 #include <kitty/operators.hpp>
 
+#include "../endianness.hpp"
 #include "../traits.hpp"
 #include "../utils/algorithm.hpp"
 #include "detail/foreach.hpp"
@@ -110,8 +111,13 @@ public:
     union {
       struct
       {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+        uint64_t index : 63;
+        uint64_t complement : 1;
+#else
         uint64_t complement : 1;
         uint64_t index : 63;
+#endif
       };
       uint64_t data;
     };

--- a/include/mockturtle/networks/storage.hpp
+++ b/include/mockturtle/networks/storage.hpp
@@ -42,6 +42,8 @@
 
 #include <parallel_hashmap/phmap.h>
 
+#include "../endianness.hpp"
+
 namespace mockturtle
 {
 
@@ -58,8 +60,14 @@ public:
   union {
     struct
     {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+      uint64_t index : _len - PointerFieldSize;
+      uint64_t weight : PointerFieldSize;
+#else
       uint64_t weight : PointerFieldSize;
       uint64_t index : _len - PointerFieldSize;
+#endif;
+
     };
     uint64_t data;
   };
@@ -92,15 +100,27 @@ union cauint64_t {
   uint64_t n{0};
   struct
   {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+    uint64_t h2 : 32;
+    uint64_t h1 : 32;
+#else
     uint64_t h1 : 32;
     uint64_t h2 : 32;
+#endif;    
   };
   struct
   {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+    uint64_t q4 : 16;
+    uint64_t q3 : 16;
+    uint64_t q2 : 16;
+    uint64_t q1 : 16;
+#else
     uint64_t q1 : 16;
     uint64_t q2 : 16;
     uint64_t q3 : 16;
     uint64_t q4 : 16;
+#endif; 
   };
 };
 

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -46,6 +46,7 @@
 #include <kitty/dynamic_truth_table.hpp>
 #include <kitty/operators.hpp>
 
+#include "../endianness.hpp"
 #include "../traits.hpp"
 #include "../utils/algorithm.hpp"
 #include "detail/foreach.hpp"
@@ -125,8 +126,13 @@ public:
     union {
       struct
       {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+        uint64_t index : 63;
+        uint64_t complement : 1;
+#else
         uint64_t complement : 1;
         uint64_t index : 63;
+#endif;
       };
       uint64_t data;
     };

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -45,6 +45,7 @@
 #include <kitty/dynamic_truth_table.hpp>
 #include <kitty/operators.hpp>
 
+#include "../endianness.hpp"
 #include "../traits.hpp"
 #include "../utils/algorithm.hpp"
 #include "detail/foreach.hpp"
@@ -109,8 +110,13 @@ public:
     union {
       struct
       {
+#if MOCKTURTLE_ENDIAN == MOCKTURTLE_BIGENDIAN
+        std::size_t index : 63;
+        std::size_t complement : 1;
+#else
         std::size_t complement : 1;
         std::size_t index : 63;
+#endif
       };
       std::size_t data;
     };


### PR DESCRIPTION
Most of the code is not influenced by the endianness. However the
combination of bit-filed struct and union is.

For example. Take this code:
```c++
union {
    struct
    {
        uint64_t complement : 1;
        uint64_t index : 63;
    };
    uint64_t data;
};
```

If we try to change the value of 'complement' using (data ^ 1), then
things will break. This commit adds compile-time macros to identify the
endianness of the platform, and change the order of 'complement' and
'index' accordingly. (Everything else is taken care by the compiler.)

It might be a good idea to also wait for `kitty` to merge  https://github.com/msoeken/kitty/pull/122
and update `kitty`