### PR TITLE
Minor fix in window-based resub engine

### DIFF
--- a/include/mockturtle/algorithms/resubstitution.hpp
+++ b/include/mockturtle/algorithms/resubstitution.hpp
@@ -516,7 +516,7 @@ public:
       simulate( leaves, divs, mffc );
     });
 
-    auto care = kitty::create<TTdc>( static_cast<unsigned int>( leaves.size() ) );
+    auto care = kitty::create<TTdc>( ps.max_pis );
     call_with_stopwatch( st.time_dont_care, [&]() {
       if ( ps.use_dont_cares )
       {


### PR DESCRIPTION
Fix the issue #479.
The care truth table should use `ps.max_pis` as number of variables, instead of `leaves.size()`. Although these two are usually the same, there is a problem when the computed cut is smaller than its maximum allowed size.