### PR TITLE
Attempt to fix compilation error while compiling with ClangCL on Windows

### DIFF
--- a/include/mockturtle/utils/super_utils.hpp
+++ b/include/mockturtle/utils/super_utils.hpp
@@ -71,7 +71,7 @@ struct composed_gate
   kitty::dynamic_truth_table function;
 
   /* area */
-  double area{ 0.0f };
+  double area{ 0.0 };
 
   /* pin-to-pin delays */
   std::array<float, NInputs> tdelay{};

--- a/include/mockturtle/utils/tech_library.hpp
+++ b/include/mockturtle/utils/tech_library.hpp
@@ -101,7 +101,7 @@ struct supergate
   composed_gate<NInputs> const* root{};
 
   /* area */
-  float area{ 0 };
+  double area{ 0.0 };
 
   /* pin-to-pin delay */
   std::array<float, NInputs> tdelay{};
@@ -422,7 +422,7 @@ private:
                                   gate.area,
                                   {},
                                   perm,
-                                  neg};
+                                  static_cast<uint8_t>(neg)};
 
           for ( auto i = 0u; i < perm.size() && i < NInputs; ++i )
           {
@@ -484,7 +484,7 @@ private:
                                     gate.area,
                                     {},
                                     perm,
-                                    phase};
+                                    static_cast<uint8_t>(phase)};
 
             for ( auto i = 0u; i < perm.size() && i < NInputs; ++i )
             {


### PR DESCRIPTION
First of all, thanks for the updates to the technology mapper! It works great but it, unfortunately, has some trouble compiling under Windows when compiling with the ClangCL toolset for Visual Studio. You can see the precise errors for instance [here](https://github.com/marcelwa/fiction/pull/11/checks?check_run_id=3314630767).

This commit tries to fix these issues by correcting some types and adding casts.