### PR TITLE
incomplete node map

### DIFF
--- a/docs/utils/util_data_structures.rst
+++ b/docs/utils/util_data_structures.rst
@@ -22,14 +22,34 @@ Node map
 
 **Header:** ``mockturtle/utils/node_map.hpp``
 
-.. doc_overview_table:: classmockturtle_1_1node__map
-   :column: Method
+This group of containers helps to store and access values associated to
+nodes in a network.
 
-   node_map
-   operator[]
-   reset
+Three implementations are provided, two using `std::vector` and one
+using `std::unordered_map` as internal storage.  Using `std::vector`,
+the default implementation of `node_map` pre-allocates memory for all
+nodes and provides a fast way to access the data. When only a subset of
+nodes are associated with values, both `unordered_node_map` and 
+`incomplete_node_map` provide interfaces to check whether a value
+is available. Using `std::unordered_map`, the former uses less memory
+but has a slower access speed; the latter uses `std::vector` together with
+validity tags to trade efficiency with memory.
+
+**Example**
+
+.. code-block:: c++
+
+   aig_network aig = ...
+   node_map<std::string, aig_network> node_names( aig );
+   aig.foreach_node( [&]( auto n ) {
+     node_names[n] = "some string";
+   } );
+
 
 .. doxygenclass:: mockturtle::node_map
+   :members:
+
+.. doxygenclass:: mockturtle::incomplete_node_map
    :members:
 
 .. doxygenfunction:: mockturtle::initialize_copy_network

--- a/include/mockturtle/algorithms/dont_cares.hpp
+++ b/include/mockturtle/algorithms/dont_cares.hpp
@@ -141,8 +141,8 @@ kitty::dynamic_truth_table observability_dont_cares( Ntk const& ntk, node<Ntk> c
 
 namespace detail {
 
-template<class Ntk, class TT>
-void clearTFO_rec( Ntk const& ntk, unordered_node_map<TT, Ntk>& tts, node<Ntk> const& n, std::set<node<Ntk>>& roots, int level )
+template<class Ntk, class Container>
+void clearTFO_rec( Ntk const& ntk, Container& tts, node<Ntk> const& n, std::set<node<Ntk>>& roots, int level )
 {
   if ( ntk.visited( n ) == ntk.trav_id() ) /* visited */
   {
@@ -163,8 +163,8 @@ void clearTFO_rec( Ntk const& ntk, unordered_node_map<TT, Ntk>& tts, node<Ntk> c
   });
 }
 
-template<class Ntk>
-void simulate_TFO_rec( Ntk const& ntk, node<Ntk> const& n, partial_simulator const& sim, unordered_node_map<kitty::partial_truth_table, Ntk>& tts, int level )
+template<class Ntk, class Container>
+void simulate_TFO_rec( Ntk const& ntk, node<Ntk> const& n, partial_simulator const& sim, Container& tts, int level )
 {
   if ( ntk.visited( n ) == ntk.trav_id() ) /* visited */
   {
@@ -206,8 +206,8 @@ void simulate_TFO_rec( Ntk const& ntk, node<Ntk> const& n, partial_simulator con
  * \param tts Stores the simulation signatures of each node. Can be empty or incomplete.
  * \param levels Level of tansitive fanout to consider. -1 = consider until PO.
  */
-template<class Ntk>
-kitty::partial_truth_table observability_dont_cares( Ntk const& ntk, node<Ntk> const& n, partial_simulator const& sim, unordered_node_map<kitty::partial_truth_table, Ntk>& tts, int levels = -1 )
+template<class Ntk, class Container = unordered_node_map<kitty::partial_truth_table, Ntk>>
+kitty::partial_truth_table observability_dont_cares( Ntk const& ntk, node<Ntk> const& n, partial_simulator const& sim, Container& tts, int levels = -1 )
 {
   std::set<node<Ntk>> roots;
   unordered_node_map<kitty::partial_truth_table, Ntk> tts_roots( ntk );

--- a/include/mockturtle/algorithms/pattern_generation.hpp
+++ b/include/mockturtle/algorithms/pattern_generation.hpp
@@ -118,7 +118,6 @@ class patgen_impl
 public:
   using node = typename Ntk::node;
   using signal = typename Ntk::signal;
-  //using TT = unordered_node_map<kitty::partial_truth_table, Ntk>;
   using TT = incomplete_node_map<kitty::partial_truth_table, Ntk>;
 
   explicit patgen_impl( Ntk& ntk, Simulator& sim, pattern_generation_params const& ps, validator_params& vps, pattern_generation_stats& st )

--- a/include/mockturtle/algorithms/pattern_generation.hpp
+++ b/include/mockturtle/algorithms/pattern_generation.hpp
@@ -118,7 +118,8 @@ class patgen_impl
 public:
   using node = typename Ntk::node;
   using signal = typename Ntk::signal;
-  using TT = unordered_node_map<kitty::partial_truth_table, Ntk>;
+  //using TT = unordered_node_map<kitty::partial_truth_table, Ntk>;
+  using TT = incomplete_node_map<kitty::partial_truth_table, Ntk>;
 
   explicit patgen_impl( Ntk& ntk, Simulator& sim, pattern_generation_params const& ps, validator_params& vps, pattern_generation_stats& st )
       : ntk( ntk ), ps( ps ), st( st ), vps( vps ), validator( ntk, vps ),

--- a/include/mockturtle/algorithms/sim_resub.hpp
+++ b/include/mockturtle/algorithms/sim_resub.hpp
@@ -134,7 +134,7 @@ struct sim_resub_stats
  *
  * Please refer to the following paper for further details.
  *
- * [1] A Simulation-Guided Paradigm for Logic Synthesisand Verification. TCAD, 2021.
+ * [1] A Simulation-Guided Paradigm for Logic Synthesis and Verification. TCAD, 2021.
  *
  * Interfaces of the resubstitution functor:
  * - Constructor: `resub_fn( Ntk const& ntk, resubstitution_params const& ps, ResubFnSt& st,`

--- a/include/mockturtle/algorithms/sim_resub.hpp
+++ b/include/mockturtle/algorithms/sim_resub.hpp
@@ -150,7 +150,7 @@ struct sim_resub_stats
  * \param ResubFn Resubstitution functor to compute the resubstitution.
  * \param MffcRes Typename of `potential_gain` needed by the resubstitution functor.
  */
-template<class Ntk, typename validator_t = circuit_validator<Ntk, bill::solvers::bsat2, false, true, false>, class ResynEngine = xag_resyn_decompose<kitty::partial_truth_table, unordered_node_map<kitty::partial_truth_table, Ntk>>, typename MffcRes = uint32_t>
+template<class Ntk, typename validator_t = circuit_validator<Ntk, bill::solvers::bsat2, false, true, false>, class ResynEngine = xag_resyn_decompose<kitty::partial_truth_table, incomplete_node_map<kitty::partial_truth_table, Ntk>>, typename MffcRes = uint32_t>
 class simulation_based_resub_engine
 {
 public:
@@ -171,6 +171,7 @@ public:
     }
 
     add_event = ntk.events().register_add_event( [&]( const auto& n ) {
+      tts.resize();
       call_with_stopwatch( st.time_sim, [&]() {
         simulate_node<Ntk>( ntk, n, tts, sim );
       });
@@ -322,7 +323,7 @@ private:
   resubstitution_params const& ps;
   stats& st;
 
-  unordered_node_map<TT, Ntk> tts;
+  incomplete_node_map<TT, Ntk> tts;
   partial_simulator sim;
 
   validator_t validator;

--- a/include/mockturtle/algorithms/sim_resub.hpp
+++ b/include/mockturtle/algorithms/sim_resub.hpp
@@ -134,7 +134,7 @@ struct sim_resub_stats
  *
  * Please refer to the following paper for further details.
  *
- * [1] Simulation-Guided Boolean Resubstitution. IWLS 2020 (arXiv:2007.02579).
+ * [1] A Simulation-Guided Paradigm for Logic Synthesisand Verification. TCAD, 2021.
  *
  * Interfaces of the resubstitution functor:
  * - Constructor: `resub_fn( Ntk const& ntk, resubstitution_params const& ps, ResubFnSt& st,`

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -181,7 +181,7 @@ public:
    * \param num_pis Number of primary inputs, which is the same as the length of a simulation pattern.
    * \param num_patterns Number of initial random simulation patterns.
    */
-  partial_simulator( unsigned num_pis, unsigned num_patterns, std::default_random_engine::result_type seed = 1 )
+  partial_simulator( uint32_t num_pis, uint32_t num_patterns, std::default_random_engine::result_type seed = 1 )
     : num_patterns( num_patterns )
   {
     assert( num_pis > 0u );
@@ -303,7 +303,7 @@ public:
 
   bit_packed_simulator() {}
 
-  bit_packed_simulator( unsigned num_pis, unsigned num_patterns, std::default_random_engine::result_type seed = 1 )
+  bit_packed_simulator( uint32_t num_pis, uint32_t num_patterns, std::default_random_engine::result_type seed = 1 )
     : partial_simulator( num_pis, num_patterns, seed ), packed_patterns( num_patterns )
   {
     fill_cares( num_pis );
@@ -685,7 +685,7 @@ void update_const_pi( Ntk const& ntk, Container& node_to_value, Simulator const&
 
 /*! \brief (Re-)simulate `n` and its transitive fanin cone.
  * 
- * Note that re-simulation (when `node_to_value.has( n ) == false`) is only done
+ * Note that re-simulation (when `node_to_value.has( n ) == true`) is only done
  * for the last block, no matter how many bits are used in this block.
  * Hence, it is advised to call `simulate_nodes` with `simulate_whole_tt = false`
  * whenever `sim.num_bits() % 64 == 0`.

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -558,8 +558,8 @@ node_map<SimulationType, Ntk> simulate_nodes( Ntk const& ntk, Simulator const& s
  * \param node_to_value A map from nodes to values
  * \param sim Simulator, which implements the simulator interface
  */
-template<class SimulationType, class Ntk, class Simulator = default_simulator<SimulationType>>
-void simulate_nodes( Ntk const& ntk, unordered_node_map<SimulationType, Ntk>& node_to_value, Simulator const& sim = Simulator() )
+template<class SimulationType, class Ntk, class Simulator = default_simulator<SimulationType>, class Container = unordered_node_map<SimulationType, Ntk>>
+void simulate_nodes( Ntk const& ntk, Container& node_to_value, Simulator const& sim = Simulator() )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
@@ -610,10 +610,10 @@ void simulate_nodes( Ntk const& ntk, unordered_node_map<SimulationType, Ntk>& no
 namespace detail
 {
 /* Forward declaration */
-template<class Ntk, class Simulator> void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim );
+template<class Ntk, class Simulator, class Container> void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim );
 
-template<class Ntk, class Simulator>
-void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
+template<class Ntk, class Simulator, class Container>
+void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
   ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
@@ -630,8 +630,8 @@ void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered
   node_to_value[n] = ntk.compute( n, fanin_values.begin(), fanin_values.end() );
 }
 
-template<class Ntk, class Simulator>
-void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
+template<class Ntk, class Simulator, class Container>
+void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
   ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
@@ -648,14 +648,14 @@ void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, unorde
   ntk.compute( n, node_to_value[n], fanin_values.begin(), fanin_values.end() );
 }
 
-template<class Ntk, class Simulator>
-void update_const_pi( Ntk const& ntk, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
+template<class Ntk, class Simulator, class Container>
+void update_const_pi( Ntk const& ntk, Container& node_to_value, Simulator const& sim )
 {
   /* constants */
-  node_to_value[ntk.get_node( ntk.get_constant( false ) )] = sim.compute_constant( ntk.constant_value( ntk.get_node( ntk.get_constant( false ) ) ) );
+  node_to_value[ntk.get_constant( false )] = sim.compute_constant( ntk.constant_value( ntk.get_node( ntk.get_constant( false ) ) ) );
   if ( ntk.get_node( ntk.get_constant( false ) ) != ntk.get_node( ntk.get_constant( true ) ) )
   {
-    node_to_value[ntk.get_node( ntk.get_constant( true ) )] = sim.compute_constant( ntk.constant_value( ntk.get_node( ntk.get_constant( true ) ) ) );
+    node_to_value[ntk.get_constant( true )] = sim.compute_constant( ntk.constant_value( ntk.get_node( ntk.get_constant( true ) ) ) );
   }
 
   /* pis */
@@ -674,8 +674,8 @@ void update_const_pi( Ntk const& ntk, unordered_node_map<kitty::partial_truth_ta
  * whenever `sim.num_bits() % 64 == 0`.
  * 
  */
-template<class Ntk, class Simulator = partial_simulator>
-void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim )
+template<class Ntk, class Simulator = partial_simulator, class Container = unordered_node_map<kitty::partial_truth_table, Ntk>>
+void simulate_node( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
@@ -711,8 +711,8 @@ void simulate_node( Ntk const& ntk, typename Ntk::node const& n, unordered_node_
  * In contrast, when this parameter is false, only the last block of `partial_truth_table` will be re-computed,
  * and it is assumed that `node_to_value.has( n )` is true for every node.
  */
-template<class Ntk, class Simulator = partial_simulator>
-void simulate_nodes( Ntk const& ntk, unordered_node_map<kitty::partial_truth_table, Ntk>& node_to_value, Simulator const& sim, bool simulate_whole_tt )
+template<class Ntk, class Simulator = partial_simulator, class Container = unordered_node_map<kitty::partial_truth_table, Ntk>>
+void simulate_nodes( Ntk const& ntk, Container& node_to_value, Simulator const& sim, bool simulate_whole_tt )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -263,6 +263,15 @@ public:
     }
   }
 
+  /*! \brief Erase a key (if it exists). */
+  void erase( signal const& f )
+  {
+    if ( has( ntk->get_node( f ) ) )
+    {
+      data->erase( ntk->node_to_index( ntk->get_node( f ) ) );
+    }
+  }
+
   /*! \brief Mutable access to value by node. */
   reference operator[]( node const& n )
   {
@@ -394,14 +403,24 @@ public:
   /*! \brief Erase a key (if it exists). */
   void erase( node const& n )
   {
-    (*data)[ntk->node_to_index( n )].emplace<0>( {} );
+    (*data)[ntk->node_to_index( n )] = std::monostate();
+  }
+
+  /*! \brief Erase a key (if it exists). */
+  void erase( signal const& f )
+  {
+    (*data)[ntk->node_to_index( ntk->get_node( f ) )] = std::monostate();
   }
 
   /*! \brief Mutable access to value by node. */
-  void set( node const& n, T const& val )
+  T& operator[]( node const& n )
   {
     assert( ntk->node_to_index( n ) < data->size() && "index out of bounds" );
-    (*data)[ntk->node_to_index( n )] = val;
+    if ( !has( n ) )
+    {
+      (*data)[ntk->node_to_index( n )] = T();
+    }
+    return std::get<T>( (*data)[ntk->node_to_index( n )] );
   }
 
   /*! \brief Constant access to value by node. */
@@ -418,10 +437,15 @@ public:
    * are the same in the network implementation, this method is disabled.
    */
   template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
-  void set( signal const& f, T const& val )
+  T& operator[]( signal const& f )
   {
-    assert( ntk->node_to_index( ntk->get_node( f ) ) < data->size() && "index out of bounds" );
-    (*data)[ntk->node_to_index( ntk->get_node( f ) )] = val;
+    auto n = ntk->get_node( f );
+    assert( ntk->node_to_index( n ) < data->size() && "index out of bounds" );
+    if ( !has( n ) )
+    {
+      (*data)[ntk->node_to_index( n )] = T();
+    }
+    return std::get<T>( (*data)[ntk->node_to_index( n )] );
   }
 
   /*! \brief Constant access to value by signal.

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
+#include <variant>
 
 #include "../traits.hpp"
 
@@ -49,25 +50,12 @@ namespace mockturtle
  * This container helps to store and access values associated to nodes
  * in a network.
  *
- * Two implementations are provided one using std::vector and another
+ * Two implementations are provided, one using std::vector and another
  * using std::unordered_map as internal storage.  The former
  * implementation can be pre-allocated and provides a fast way to
  * access the data.  The later implementation offers a way to
  * associate values to a subset of nodes and to check whether a value
  * is available.
- *
- * Example
- *
-   \verbatim embed:rst
-
-   .. code-block:: c++
-
-      aig_network aig = ...
-      node_map<std::string, aig_network> node_names( aig );
-      aig.foreach_node( [&]( auto n ) {
-        node_names[n] = "some string";
-      } );
-   \endverbatim
  */
 template<class T, class Ntk, class Impl = std::vector<T>>
 class node_map;
@@ -212,6 +200,8 @@ private:
  *
  * The implementation uses an std::unordered_map as underlying data
  * structure which is indexed by the node's index.
+ * 
+ * This implementation is aliased as `unordered_node_map`.
  *
  * **Required network functions:**
  * - `get_node`
@@ -326,6 +316,160 @@ protected:
 /*! \brief Template alias `unordered_node_map` */
 template<class T, class Ntk>
 using unordered_node_map = node_map<T, Ntk, std::unordered_map<typename Ntk::node, T>>;
+
+/*! \brief Vector-based node map with validity query
+ *
+ * This container is initialized with a network to derive the size
+ * according to the number of nodes.  The container can be accessed
+ * via nodes, or indirectly via signals, from which the corresponding
+ * node is derived.
+ *
+ * The implementation uses a vector as underlying data structure, so
+ * that it benefits from fast access. It is supplemented with an
+ * additional validity field such that it can be used like an
+ * `unordered_node_map`.
+ *
+ * **Required network functions:**
+ * - `size`
+ * - `get_node`
+ * - `node_to_index`
+ *
+ */
+template<class T, class Ntk>
+class incomplete_node_map
+{
+public:
+  using node = typename Ntk::node;
+  using signal = typename Ntk::signal;
+
+  using container_type = std::vector<std::variant<std::monostate, T>>;
+
+public:
+  /*! \brief Default constructor. */
+  explicit incomplete_node_map( Ntk const& ntk )
+      : ntk( &ntk ),
+        data( std::make_shared<container_type>( ntk.size() ) )
+  {
+    static_assert( !std::is_same_v<T, std::monostate>, "T cannot be std::monostate" );
+    static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+    static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
+    static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+    static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
+  }
+
+  /*! \brief Constructor with default value.
+   *
+   * Initializes all values in the container to `init_value`.
+   */
+  incomplete_node_map( Ntk const& ntk, T const& init_value )
+      : ntk( &ntk ),
+        data( std::make_shared<container_type>( ntk.size(), init_value ) )
+  {
+    static_assert( !std::is_same_v<T, std::monostate>, "T cannot be std::monostate" );
+    static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+    static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
+    static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+    static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
+  }
+
+  /*! \brief Number of keys stored in the data structure. */
+  auto size() const
+  {
+    return data->size();
+  }
+
+  /*! \brief Check if a key is already defined. */
+  bool has( node const& n ) const
+  {
+    return std::holds_alternative<T>( (*data)[ntk->node_to_index( n )] );
+  }
+
+  /*! \brief Check if a key is already defined. */
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
+  bool has( signal const& f ) const
+  {
+    return std::holds_alternative<T>( (*data)[ntk->node_to_index( ntk->get_node( f ) )] );
+  }
+
+  /*! \brief Erase a key (if it exists). */
+  void erase( node const& n )
+  {
+    (*data)[ntk->node_to_index( n )].emplace<0>( {} );
+  }
+
+  /*! \brief Mutable access to value by node. */
+  void set( node const& n, T const& val )
+  {
+    assert( ntk->node_to_index( n ) < data->size() && "index out of bounds" );
+    (*data)[ntk->node_to_index( n )] = val;
+  }
+
+  /*! \brief Constant access to value by node. */
+  T const& operator[]( node const& n ) const
+  {
+    assert( ntk->node_to_index( n ) < data->size() && "index out of bounds" );
+    assert( has( n ) );
+    return std::get<T>( (*data)[ntk->node_to_index( n )] );
+  }
+
+  /*! \brief Mutable access to value by signal.
+   *
+   * This method derives the node from the signal.  If the node and signal type
+   * are the same in the network implementation, this method is disabled.
+   */
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
+  void set( signal const& f, T const& val )
+  {
+    assert( ntk->node_to_index( ntk->get_node( f ) ) < data->size() && "index out of bounds" );
+    (*data)[ntk->node_to_index( ntk->get_node( f ) )] = val;
+  }
+
+  /*! \brief Constant access to value by signal.
+   *
+   * This method derives the node from the signal.  If the node and signal type
+   * are the same in the network implementation, this method is disabled.
+   */
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
+  T const& operator[]( signal const& f ) const
+  {
+    assert( ntk->node_to_index( ntk->get_node( f ) ) < data->size() && "index out of bounds" );
+    assert( has( ntk->get_node( f ) ) );
+    return std::get<T>( (*data)[ntk->node_to_index( ntk->get_node( f ) )] );
+  }
+
+  /*! \brief Resets the size of the map.
+   *
+   * This function should be called, if the network changed in size.  Then, the
+   * map is cleared, and resized to the current network's size.  All values are
+   * initialized with `init_value`.
+   *
+   * \param init_value Initialization value after resize
+   */
+  void reset( T const& init_value = {} )
+  {
+    data->clear();
+    data->resize( ntk->size(), init_value );
+  }
+
+  /*! \brief Resizes the map.
+   *
+   * This function should be called, if the node_map's size needs to
+   * be changed without clearing its data.
+   *
+   * \param init_value Initialization value after resize
+   */
+  void resize( T const& init_value = {} )
+  {
+    if ( ntk->size() > data->size() )
+    {
+      data->resize( ntk->size(), init_value );
+    }
+  }
+
+private:
+  Ntk const *ntk;
+  std::shared_ptr<container_type> data;
+};
 
 /*! \brief Initializes a network for copying together with node map.
  *

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -317,6 +317,10 @@ public:
     data->clear();
   }
 
+  void resize()
+  {
+  }
+
 protected:
   Ntk const *ntk;
   std::shared_ptr<container_type> data;
@@ -479,14 +483,12 @@ public:
    *
    * This function should be called, if the node_map's size needs to
    * be changed without clearing its data.
-   *
-   * \param init_value Initialization value after resize
    */
-  void resize( T const& init_value = {} )
+  void resize()
   {
     if ( ntk->size() > data->size() )
     {
-      data->resize( ntk->size(), init_value );
+      data->resize( ntk->size() );
     }
   }
 

--- a/include/mockturtle/utils/node_map.hpp
+++ b/include/mockturtle/utils/node_map.hpp
@@ -264,6 +264,7 @@ public:
   }
 
   /*! \brief Erase a key (if it exists). */
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   void erase( signal const& f )
   {
     if ( has( ntk->get_node( f ) ) )
@@ -411,6 +412,7 @@ public:
   }
 
   /*! \brief Erase a key (if it exists). */
+  template<typename _Ntk = Ntk, typename = std::enable_if_t<!std::is_same_v<typename _Ntk::signal, typename _Ntk::node>>>
   void erase( signal const& f )
   {
     (*data)[ntk->node_to_index( ntk->get_node( f ) )] = std::monostate();
@@ -469,11 +471,23 @@ public:
    *
    * This function should be called, if the network changed in size.  Then, the
    * map is cleared, and resized to the current network's size.  All values are
+   * initialized with the place holder (empty) element.
+   */
+  void reset()
+  {
+    data->clear();
+    data->resize( ntk->size() );
+  }
+
+  /*! \brief Resets the size of the map.
+   *
+   * This function should be called, if the network changed in size.  Then, the
+   * map is cleared, and resized to the current network's size.  All values are
    * initialized with `init_value`.
    *
    * \param init_value Initialization value after resize
    */
-  void reset( T const& init_value = {} )
+  void reset( T const& init_value )
   {
     data->clear();
     data->resize( ntk->size(), init_value );

--- a/test/utils/node_map.cpp
+++ b/test/utils/node_map.cpp
@@ -107,6 +107,85 @@ void test_hash_node_map()
   CHECK( total == ntk.size() );
 }
 
+template<typename Ntk>
+void test_incomplete_node_map()
+{
+  /* create a full adder in a network */
+  Ntk ntk;
+
+  const auto a = ntk.create_pi();
+  const auto b = ntk.create_pi();
+  const auto c = ntk.create_pi();
+
+  const auto [sum, carry] = full_adder( ntk, a, b, c );
+
+  ntk.create_po( sum );
+  ntk.create_po( carry );
+
+  /* create incomplete node map */
+  incomplete_node_map<uint32_t, Ntk> map{ntk};
+  ntk.foreach_node( [&]( auto n ) {
+    CHECK( !map.has( n ) );
+  } );
+
+  ntk.foreach_node( [&]( auto n, auto i ) {
+    map[n] = i;
+  } );
+
+  ntk.foreach_node( [&]( auto n ) {
+    CHECK( map.has( n ) );
+  } );
+
+  uint32_t total{0};
+  ntk.foreach_node( [&]( auto n ) {
+    total += map[n];
+  } );
+
+  CHECK( total == ( ntk.size() * ( ntk.size() - 1 ) ) / 2 );
+
+  /* reset all values to 1 */
+  map.reset();
+  ntk.foreach_node( [&]( auto n ) {
+    CHECK( !map.has( n ) );
+  } );
+
+  ntk.foreach_node( [&]( auto n ) {
+    map[n] = 1;
+  } );
+
+  total = 0;
+  ntk.foreach_node( [&]( auto n ) {
+    total += map[n];
+  } );
+
+  CHECK( total == ntk.size() );
+
+  /* test erase */
+  map.erase( a );
+  CHECK( !map.has( a ) );
+
+  /* test resize */
+  const auto d = ntk.create_pi();
+  map.resize();
+  CHECK( !map.has( d ) );
+
+  map[d] = map[a] = 1;
+  total = 0;
+  ntk.foreach_node( [&]( auto n ) {
+    total += map[n];
+  } );
+  CHECK( total == ntk.size() );
+
+  /* reset with initial value 10 */
+  map.reset( 10 );
+  /* create with initial value 10 */
+  incomplete_node_map<uint32_t, Ntk> map2( ntk, 10 );
+  
+  ntk.foreach_node( [&]( auto n ) {
+    CHECK( map[n] == map2[n] );
+  } );
+}
+
 template<typename Ntk, typename Container>
 void test_copy_ctor()
 {
@@ -305,6 +384,15 @@ TEST_CASE( "create unordered node map for full adder", "[node_map]" )
   test_hash_node_map<xag_network>();
   test_hash_node_map<xmg_network>();
   test_hash_node_map<klut_network>();
+}
+
+TEST_CASE( "create incomplete node map for full adder", "[node_map]" )
+{
+  test_incomplete_node_map<aig_network>();
+  test_incomplete_node_map<mig_network>();
+  test_incomplete_node_map<xag_network>();
+  test_incomplete_node_map<xmg_network>();
+  test_incomplete_node_map<klut_network>();
 }
 
 TEST_CASE( "Copy construction", "[node_map]" )


### PR DESCRIPTION
`incomplete_node_map` has similar interfaces as `unordered_node_map`, e.g. `has`, `erase`. They can hold "empty" values. `unordered_node_map` uses `std::unordered_map` (i.e. hash map) as the underlying data structure, which saves memory when the map is sparse. `incomplete_node_map` uses `std::vector` together with `std::variant` to mark data validity, which has a faster access time and is more cache-friendly when elements are frequently accessed.

A simple runtime experiment:
```c++
partial_simulator sim( aig.num_pis(), 1024 );
//unordered_node_map<kitty::partial_truth_table, aig_network> tts( aig );
incomplete_node_map<kitty::partial_truth_table, aig_network> tts( aig );
simulate_nodes( aig, tts, sim );
std::vector<bool> pattern( aig.num_pis(), false );
sim.add_pattern( pattern );
aig.foreach_po( [&]( auto const f ){
    simulate_node( aig, aig.get_node( f ), tts, sim );
});
```
Using `incomplete_node_map` instead of `unordered_node_map` in the second line provides about 20% speed up when using large benchmarks (e.g. IWLS `leon2`).