### PR TITLE
Static parameter objects & custom cost function

### DIFF
--- a/include/mockturtle/algorithms/resyn_engines/mig_resyn.hpp
+++ b/include/mockturtle/algorithms/resyn_engines/mig_resyn.hpp
@@ -290,7 +290,7 @@ public:
    * \param tts A data structure (e.g. std::vector<TT>) that stores the truth tables of the divisor functions.
    * \param max_size Maximum number of nodes allowed in the dependency circuit.
    */
-  template<class iterator_type, class truth_table_storage_type, typename = std::enable_if_t<static_params::uniform_div_cost && !static_params::preserve_depth>>
+  template<class iterator_type, class truth_table_storage_type, bool enabled = static_params::uniform_div_cost && !static_params::preserve_depth, typename = std::enable_if_t<enabled>>
   std::optional<index_list_t> operator()( TT const& target, TT const& care, iterator_type begin, iterator_type end, truth_table_storage_type const& tts, uint32_t max_size = std::numeric_limits<uint32_t>::max() )
   {
     divisors.emplace_back( ~target );
@@ -311,11 +311,13 @@ public:
     return compute_function( care );
   }
 
-  template<class iterator_type, class truth_table_storage_type, class Fn, typename = std::enable_if_t<!static_params::uniform_div_cost && !static_params::preserve_depth>>
+  template<class iterator_type, class truth_table_storage_type, class Fn, bool enabled = !static_params::uniform_div_cost && !static_params::preserve_depth, typename = std::enable_if_t<enabled>>
   std::optional<index_list_t> operator()( TT const& target, TT const& care, iterator_type begin, iterator_type end, truth_table_storage_type const& tts, Fn&& size_cost, uint32_t max_size = std::numeric_limits<uint32_t>::max() )
-  {}
+  {
+    static_assert( !static_params::uniform_div_cost && !static_params::preserve_depth, "" );
+  }
 
-  template<class iterator_type, class truth_table_storage_type, class Fn, typename = std::enable_if_t<!static_params::uniform_div_cost && static_params::preserve_depth>>
+  template<class iterator_type, class truth_table_storage_type, class Fn, bool enabled = !static_params::uniform_div_cost && static_params::preserve_depth, typename = std::enable_if_t<enabled>>
   std::optional<index_list_t> operator()( TT const& target, TT const& care, iterator_type begin, iterator_type end, truth_table_storage_type const& tts, Fn&& size_cost, Fn&& depth_cost, uint32_t max_size = std::numeric_limits<uint32_t>::max(), uint32_t max_depth = std::numeric_limits<uint32_t>::max() )
   {}
 

--- a/include/mockturtle/algorithms/resyn_engines/xag_resyn.hpp
+++ b/include/mockturtle/algorithms/resyn_engines/xag_resyn.hpp
@@ -35,6 +35,7 @@
 
 #include "../../utils/index_list.hpp"
 #include "../../utils/stopwatch.hpp"
+#include "../../utils/node_map.hpp"
 
 #include <kitty/kitty.hpp>
 #include <fmt/format.h>
@@ -229,7 +230,8 @@ public:
    * \param tts A data structure (e.g. std::vector<TT>) that stores the truth tables of the divisor functions.
    * \param max_size Maximum number of nodes allowed in the dependency circuit.
    */
-  template<class iterator_type, typename = std::enable_if_t<static_params::uniform_div_cost && !static_params::preserve_depth>>
+  template<class iterator_type, 
+           bool enabled = static_params::uniform_div_cost && !static_params::preserve_depth, typename = std::enable_if_t<enabled>>
   std::optional<index_list_t> operator()( TT const& target, TT const& care, iterator_type begin, iterator_type end, typename static_params::truth_table_storage_type const& tts, uint32_t max_size = std::numeric_limits<uint32_t>::max() )
   {
     static_assert( static_params::copy_tts || std::is_same_v<typename std::iterator_traits<iterator_type>::value_type, typename static_params::node_type>, "iterator_type does not dereference to static_params::node_type" );
@@ -255,11 +257,13 @@ public:
     return compute_function( max_size );
   }
 
-  template<class iterator_type, class Fn, typename = std::enable_if_t<!static_params::uniform_div_cost && !static_params::preserve_depth>>
+  template<class iterator_type, class Fn, 
+           bool enabled = !static_params::uniform_div_cost && !static_params::preserve_depth, typename = std::enable_if_t<enabled>>
   std::optional<index_list_t> operator()( TT const& target, TT const& care, iterator_type begin, iterator_type end, typename static_params::truth_table_storage_type const& tts, Fn&& size_cost, uint32_t max_size = std::numeric_limits<uint32_t>::max() )
   {}
 
-  template<class iterator_type, class Fn, typename = std::enable_if_t<!static_params::uniform_div_cost && static_params::preserve_depth>>
+  template<class iterator_type, class Fn, 
+           bool enabled = !static_params::uniform_div_cost && static_params::preserve_depth, typename = std::enable_if_t<enabled>>
   std::optional<index_list_t> operator()( TT const& target, TT const& care, iterator_type begin, iterator_type end, typename static_params::truth_table_storage_type const& tts, Fn&& size_cost, Fn&& depth_cost, uint32_t max_size = std::numeric_limits<uint32_t>::max(), uint32_t max_depth = std::numeric_limits<uint32_t>::max() )
   {}
 
@@ -860,7 +864,7 @@ private:
   std::array<TT, 2> on_off_sets;
   std::array<uint32_t, 2> num_bits; /* number of bits in on-set and off-set */
 
-  const static_params::truth_table_storage_type* ptts;
+  const typename static_params::truth_table_storage_type* ptts;
   std::vector<std::conditional_t<static_params::copy_tts, TT, typename static_params::node_type>> divisors;
 
   index_list_t index_list;

--- a/include/mockturtle/algorithms/sim_resub.hpp
+++ b/include/mockturtle/algorithms/sim_resub.hpp
@@ -150,7 +150,7 @@ struct sim_resub_stats
  * \param ResubFn Resubstitution functor to compute the resubstitution.
  * \param MffcRes Typename of `potential_gain` needed by the resubstitution functor.
  */
-template<class Ntk, typename validator_t = circuit_validator<Ntk, bill::solvers::bsat2, false, true, false>, class ResynEngine = xag_resyn_decompose<kitty::partial_truth_table, incomplete_node_map<kitty::partial_truth_table, Ntk>>, typename MffcRes = uint32_t>
+template<class Ntk, typename validator_t = circuit_validator<Ntk, bill::solvers::bsat2, false, true, false>, class ResynEngine = xag_resyn_decompose<kitty::partial_truth_table, xag_resyn_static_params_for_sim_resub<Ntk>>, typename MffcRes = uint32_t>
 class simulation_based_resub_engine
 {
 public:
@@ -217,13 +217,6 @@ public:
 
   std::optional<signal> run( node const& n, std::vector<node> const& divs, mffc_result_t potential_gain, uint32_t& last_gain )
   {
-    typename ResynEngine::params ps_resyn;
-    ps_resyn.reserve = divs.size() + 2;
-    if constexpr ( std::is_same_v<typename ResynEngine::params, xag_resyn_params> )
-    {
-      ps_resyn.max_binates = ps.max_divisors_k;
-    }
-
     for ( auto j = 0u; j < ps.max_trials; ++j )
     {
       check_tts( n );
@@ -238,7 +231,7 @@ public:
 
       const auto res = call_with_stopwatch( st.time_resyn, [&]() {
         ++st.num_resyn;
-        ResynEngine engine( st.resyn_st, ps_resyn );
+        ResynEngine engine( st.resyn_st );
         return engine( tts[n], care, std::begin( divs ), std::end( divs ), tts, std::min( potential_gain - 1, ps.max_inserts ) );
       });
 

--- a/test/algorithms/resyn_engines/mig_resyn.cpp
+++ b/test/algorithms/resyn_engines/mig_resyn.cpp
@@ -83,21 +83,21 @@ void test_2resub()
 
 TEST_CASE( "MIG resynthesis engines -- 0-resub", "[mig_resyn]" )
 {
-  test_0resub<mig_resyn_bottomup<kitty::partial_truth_table>>();
-  test_0resub<mig_resyn_topdown<kitty::partial_truth_table>>();
-  test_0resub<mig_resyn_akers>();
+  test_0resub<mig_resyn_bottomup<kitty::partial_truth_table, mig_resyn_static_params>>();
+  test_0resub<mig_resyn_topdown<kitty::partial_truth_table, mig_resyn_static_params>>();
+  test_0resub<mig_resyn_akers<mig_resyn_static_params>>();
 }
 
 TEST_CASE( "MIG resynthesis engines -- 1-resub", "[mig_resyn]" )
 {
-  test_1resub<mig_resyn_bottomup<kitty::partial_truth_table>>();
-  test_1resub<mig_resyn_topdown<kitty::partial_truth_table>>();
-  test_1resub<mig_resyn_akers>();
+  test_1resub<mig_resyn_bottomup<kitty::partial_truth_table, mig_resyn_static_params>>();
+  test_1resub<mig_resyn_topdown<kitty::partial_truth_table, mig_resyn_static_params>>();
+  test_1resub<mig_resyn_akers<mig_resyn_static_params>>();
 }
 
 TEST_CASE( "MIG resynthesis engines -- 2-resub", "[mig_resyn]" )
 {
-  test_2resub<mig_resyn_bottomup<kitty::partial_truth_table>>();
-  test_2resub<mig_resyn_topdown<kitty::partial_truth_table>>();
-  test_2resub<mig_resyn_akers>();
+  test_2resub<mig_resyn_bottomup<kitty::partial_truth_table, mig_resyn_static_params>>();
+  test_2resub<mig_resyn_topdown<kitty::partial_truth_table, mig_resyn_static_params>>();
+  test_2resub<mig_resyn_akers<mig_resyn_static_params>>();
 }

--- a/test/algorithms/resyn_engines/xag_resyn.cpp
+++ b/test/algorithms/resyn_engines/xag_resyn.cpp
@@ -10,6 +10,20 @@
 
 using namespace mockturtle;
 
+template<class TT>
+struct aig_resyn_sparams_copy : public xag_resyn_static_params_default<TT>
+{
+  static constexpr bool use_xor = false;
+  static constexpr bool copy_tts = true;
+};
+
+template<class TT>
+struct aig_resyn_sparams_no_copy : public xag_resyn_static_params_default<TT>
+{
+  static constexpr bool use_xor = false;
+  static constexpr bool copy_tts = false;
+};
+
 template<class TT = kitty::partial_truth_table>
 void test_aig_kresub( TT const& target, TT const& care, std::vector<TT> const& tts, uint32_t num_inserts )
 {
@@ -21,7 +35,7 @@ void test_aig_kresub( TT const& target, TT const& care, std::vector<TT> const& t
   }
   partial_simulator sim( tts );
 
-  xag_resyn_decompose<TT, std::vector<TT>, false, true> engine_copy( st );
+  xag_resyn_decompose<TT, aig_resyn_sparams_copy<TT>> engine_copy( st );
   const auto res = engine_copy( target, care, divs.begin(), divs.end(), tts, num_inserts );
   CHECK( res );
   CHECK( (*res).num_gates() == num_inserts );
@@ -31,7 +45,7 @@ void test_aig_kresub( TT const& target, TT const& care, std::vector<TT> const& t
   CHECK( kitty::implies( target & care, ans ) );
   CHECK( kitty::implies( ~target & care, ~ans ) );
 
-  xag_resyn_decompose<TT, std::vector<TT>, false, false, uint32_t> engine_no_copy( st );
+  xag_resyn_decompose<TT, aig_resyn_sparams_no_copy<TT>> engine_no_copy( st );
   const auto res2 = engine_no_copy( target, care, divs.begin(), divs.end(), tts, num_inserts );
   CHECK( res2 );
   CHECK( (*res2).num_gates() == num_inserts );
@@ -200,7 +214,7 @@ void test_xag_n_input_functions( uint32_t& success_counter, uint32_t& failed_cou
 TEST_CASE( "Synthesize XAGs for all 3-input functions", "[xag_resyn]" )
 {
   using truth_table_type = kitty::static_truth_table<3>;
-  using engine_t = xag_resyn_decompose<truth_table_type, std::vector<truth_table_type>, true, false, uint32_t>;
+  using engine_t = xag_resyn_decompose<truth_table_type>;
   uint32_t success_counter{0};
   uint32_t failed_counter{0};
   test_xag_n_input_functions<engine_t, 3>( success_counter, failed_counter );
@@ -208,7 +222,7 @@ TEST_CASE( "Synthesize XAGs for all 3-input functions", "[xag_resyn]" )
   CHECK( success_counter == 254 );
   CHECK( failed_counter == 2 );
 
-  using engine_abc_t = xag_resyn_abc<truth_table_type, true>;
+  using engine_abc_t = xag_resyn_abc<truth_table_type>;
   success_counter = 0;
   failed_counter = 0;
   test_xag_n_input_functions<engine_abc_t, 3>( success_counter, failed_counter );
@@ -220,7 +234,7 @@ TEST_CASE( "Synthesize XAGs for all 3-input functions", "[xag_resyn]" )
 TEST_CASE( "Synthesize XAGs for all 4-input functions", "[xag_resyn]" )
 {
   using truth_table_type = kitty::static_truth_table<4>;
-  using engine_t = xag_resyn_decompose<truth_table_type, std::vector<truth_table_type>, true, false, uint32_t>;
+  using engine_t = xag_resyn_decompose<truth_table_type>;
   uint32_t success_counter{0};
   uint32_t failed_counter{0};
   test_xag_n_input_functions<engine_t, 4>( success_counter, failed_counter );

--- a/test/utils/network_utils.cpp
+++ b/test/utils/network_utils.cpp
@@ -10,6 +10,14 @@
 
 using namespace mockturtle;
 
+template<class TT>
+struct aig_resyn_sparams_node_map : public xag_resyn_static_params
+{
+  using truth_table_storage_type = node_map<TT, aig_network>;
+  using node_type = typename aig_network::node;
+  static constexpr bool use_xor = false;
+};
+
 TEST_CASE( "clone a window, optimize it, and insert it back", "[network_utils]" )
 {
   using node = aig_network::node;
@@ -44,9 +52,8 @@ TEST_CASE( "clone a window, optimize it, and insert it back", "[network_utils]" 
   
   /* optimize the window */
   using TT = kitty::static_truth_table<2>;
-  using ResynEngine = xag_resyn_decompose<TT, node_map<TT, aig_network>>;
+  using ResynEngine = xag_resyn_decompose<TT, aig_resyn_sparams_node_map<TT>>;
   typename ResynEngine::stats engine_st;
-  typename ResynEngine::params engine_ps;
 
   default_simulator<TT> sim;
   auto tts = simulate_nodes<TT, aig_network>( win, sim );
@@ -70,7 +77,7 @@ TEST_CASE( "clone a window, optimize it, and insert it back", "[network_utils]" 
         }
       });
 
-      ResynEngine engine( engine_st, engine_ps );
+      ResynEngine engine( engine_st );
       auto const il = engine( tts[root], ~tts[win.get_constant( false )], divs.begin(), divs.end(), tts, 2 );
       if ( il )
       {


### PR DESCRIPTION
- The parameter objects for resynthesis engines have been made static. The advantage is that these configurations become static constants, are decided at compile-time, and some code depending on them can get optimized out. The disadvantage is that customizing them becomes more complicated -- one has to define a new struct inheriting from the default one, and specialize the parameters they want. A static parameter object (type) is passed to the engine as a template argument.
- Interfaces (but not implementations) for custom cost functions in resynthesis. Two types of costs are identified: size-like cost and depth-like cost. They cannot be unified because their calculations are defined differently. For each of them, the cost for newly created gates in the resynthesis solution is a (customizable) constant (which can be different for different gate types), and the cost for divisors is passed as a callback/query function. The size-cost of a solution is defined as `sum(s_cost(g)) + sum(s_cost(d))`, where `g` is summed over all newly created gates and `d` is summed over all chosen (used) divisors. The depth-cost of a solution is defined as `max(d_cost(d) + sum(d_cost(g)))`, where the maximum is considered for all paths from a leaf to the root, `d` is the leaf divisor, and `g` is summed over all newly created gates on the path.

Note: Interfaces of resynthesis engines to support cost functions are defined, but not implemented yet. The implementations will be merged via a future PR.
