### PR TITLE
Exclude problematic C++ feature from Clang 10

### DIFF
--- a/include/mockturtle/algorithms/aqfp_resynthesis/detail/dag_gen.hpp
+++ b/include/mockturtle/algorithms/aqfp_resynthesis/detail/dag_gen.hpp
@@ -141,7 +141,7 @@ private:
   }
 };
 
-#if !__clang__ || __clang_major__ > 9
+#if !__clang__ || __clang_major__ > 10
 
 /*! \brief Generate all DAGs satisfying the parameters. */
 template<typename NodeT = int>

--- a/include/mockturtle/algorithms/node_resynthesis/cached.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/cached.hpp
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#if !__clang__ || __clang_major__ > 9
+#if !__clang__ || __clang_major__ > 10
 
 #include <cstdint>
 #if __GNUC__ == 7

--- a/include/mockturtle/algorithms/node_resynthesis/composed.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/composed.hpp
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#if !__clang__ || __clang_major__ > 9
+#if !__clang__ || __clang_major__ > 10
 
 #include <cstdint>
 #include <string>

--- a/test/algorithms/aqfp_resynthesis/dag_gen.cpp
+++ b/test/algorithms/aqfp_resynthesis/dag_gen.cpp
@@ -199,7 +199,7 @@ TEST_CASE( "Sublist generation", "[aqfp_resyn]" )
   CHECK( t5 == s5 );
 }
 
-#if !__clang__ || __clang_major__ > 9
+#if !__clang__ || __clang_major__ > 10
 TEST_CASE( "DAG generation", "[aqfp_resyn]" )
 {
   using Ntk = mockturtle::aqfp_dag<>;

--- a/test/algorithms/node_resynthesis/cached.cpp
+++ b/test/algorithms/node_resynthesis/cached.cpp
@@ -9,7 +9,7 @@
 
 using namespace mockturtle;
 
-#if !__clang__ || __clang_major__ > 9
+#if !__clang__ || __clang_major__ > 10
 TEST_CASE( "Exact XAG for MAJ cached", "[cached]" )
 {
 #if __GNUC__ == 7

--- a/test/algorithms/quality.cpp
+++ b/test/algorithms/quality.cpp
@@ -451,7 +451,7 @@ TEST_CASE( "Test quality improvement of cut rewriting with AIG exact synthesis",
   CHECK( v == std::vector<uint32_t>{{0, 30, 4, 6, 108, 11, 75, 43, 171, 450, 5}} );
 }
 
-#if !__clang__ || __clang_major__ > 9
+#if !__clang__ || __clang_major__ > 10
 TEST_CASE( "Test quality improvement of cut rewriting with AIG cached-exact synthesis", "[quality]" )
 {
   /* applies exact synthesis to 4-feasible cuts, uses a cache to store/load (function, network)-pairs from a file */


### PR DESCRIPTION
Continuing #464, exclude them also for Clang 10, as mentioned in #514.