### PR TITLE
Convert to hex a truth table before printing in simulation.rst

### DIFF
--- a/docs/algorithms/simulation.rst
+++ b/docs/algorithms/simulation.rst
@@ -47,7 +47,7 @@ Simulate values for all nodes.
    const auto tts = simulate_nodes<kitty::dynamic_truth_table>( aig, sim );
 
    aig.foreach_node( [&]( auto const& n, auto i ) {
-     std::cout << fmt::format( "truth table of node {} is {}\n", i, tts[n] );
+     std::cout << fmt::format( "truth table of node {} is {}\n", i, kitty::to_hex( tts[n] ) );
    } );
 
 .. doxygenfunction:: mockturtle::simulate


### PR DESCRIPTION
Hello,

I tried to use the example provided in `simulation.rst` but it seems it's missing a conversion to compile properly (like what is done a few lines before for `foreach_po`).