### PR TITLE
Fix a bug when creating `pi` and using `pi_index`

### DIFF
--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -189,7 +189,7 @@ public:
 
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
-    node.children[0].data = node.children[1].data = node.children[2].data = ~static_cast<uint64_t>( 0 );
+    node.children[0].data = node.children[1].data = node.children[2].data = _storage->inputs.size();
     _storage->inputs.emplace_back( index );
     ++_storage->data.num_pis;
     return {index, 0};
@@ -254,7 +254,7 @@ public:
 
   bool is_pi( node const& n ) const
   {
-    return _storage->nodes[n].children[0].data == ~static_cast<uint64_t>( 0 ) && _storage->nodes[n].children[1].data == ~static_cast<uint64_t>( 0 ) && _storage->nodes[n].children[2].data == ~static_cast<uint64_t>( 0 );
+    return _storage->nodes[n].children[0].data == _storage->nodes[n].children[1].data && _storage->nodes[n].children[0].data == _storage->nodes[n].children[2].data && _storage->nodes[n].children[0].data < static_cast<uint64_t>(_storage->data.num_pis);
   }
 
   bool is_ro( node const& n ) const

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -188,7 +188,7 @@ public:
 
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
-    node.children[0].data = node.children[1].data = node.children[2].data = ~static_cast<std::size_t>( 0 );
+    node.children[0].data = node.children[1].data = node.children[2].data = _storage->inputs.size();
     _storage->inputs.emplace_back( index );
     ++_storage->data.num_pis;
     return {index, 0};
@@ -255,7 +255,7 @@ public:
 
   bool is_pi( node const& n ) const
   {
-    return _storage->nodes[n].children[0].data == ~static_cast<std::size_t>( 0 ) && _storage->nodes[n].children[1].data == ~static_cast<std::size_t>( 0 ) && _storage->nodes[n].children[2].data == ~static_cast<std::size_t>( 0 );
+    return _storage->nodes[n].children[0].data == _storage->nodes[n].children[1].data && _storage->nodes[n].children[0].data == _storage->nodes[n].children[2].data && _storage->nodes[n].children[0].data < static_cast<uint64_t>(_storage->data.num_pis);
   }
 
   bool is_ro( node const& n ) const

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -52,9 +52,15 @@ TEST_CASE( "create and use primary inputs in an AIG", "[aig]" )
   CHECK( has_create_pi_v<aig_network> );
 
   auto a = aig.create_pi();
+  auto b = aig.create_pi();
 
-  CHECK( aig.size() == 2 );
-  CHECK( aig.num_pis() == 1 );
+  CHECK( aig.size() == 3 ); // constate + two primary inputs
+  CHECK( aig.num_pis() == 2 );
+  CHECK( aig.num_gates() == 0 );
+  CHECK( aig.is_pi( aig.get_node( a ) ) );
+  CHECK( aig.is_pi( aig.get_node( b ) ) );
+  CHECK( aig.pi_index( aig.get_node( a ) ) == 0 );
+  CHECK( aig.pi_index( aig.get_node( b ) ) == 1 );
 
   CHECK( std::is_same_v<std::decay_t<decltype( a )>, aig_network::signal> );
 

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -54,7 +54,7 @@ TEST_CASE( "create and use primary inputs in an AIG", "[aig]" )
   auto a = aig.create_pi();
   auto b = aig.create_pi();
 
-  CHECK( aig.size() == 3 ); // constate + two primary inputs
+  CHECK( aig.size() == 3 ); // constant + two primary inputs
   CHECK( aig.num_pis() == 2 );
   CHECK( aig.num_gates() == 0 );
   CHECK( aig.is_pi( aig.get_node( a ) ) );

--- a/test/networks/mig.cpp
+++ b/test/networks/mig.cpp
@@ -52,7 +52,7 @@ TEST_CASE( "create and use primary inputs in an MIG", "[mig]" )
   auto a = mig.create_pi();
   auto b = mig.create_pi();
 
-  CHECK( mig.size() == 3 ); // constate + two primary inputs
+  CHECK( mig.size() == 3 ); // constant + two primary inputs
   CHECK( mig.num_pis() == 2 );
   CHECK( mig.num_gates() == 0 );
   CHECK( mig.is_pi( mig.get_node( a ) ) );

--- a/test/networks/mig.cpp
+++ b/test/networks/mig.cpp
@@ -50,10 +50,15 @@ TEST_CASE( "create and use primary inputs in an MIG", "[mig]" )
   CHECK( has_create_pi_v<mig_network> );
 
   auto a = mig.create_pi();
+  auto b = mig.create_pi();
 
-  CHECK( mig.size() == 2 );
-  CHECK( mig.num_pis() == 1 );
+  CHECK( mig.size() == 3 ); // constate + two primary inputs
+  CHECK( mig.num_pis() == 2 );
   CHECK( mig.num_gates() == 0 );
+  CHECK( mig.is_pi( mig.get_node( a ) ) );
+  CHECK( mig.is_pi( mig.get_node( b ) ) );
+  CHECK( mig.pi_index( mig.get_node( a ) ) == 0 );
+  CHECK( mig.pi_index( mig.get_node( b ) ) == 1 );
 
   CHECK( std::is_same_v<std::decay_t<decltype( a )>, mig_network::signal> );
 

--- a/test/networks/xag.cpp
+++ b/test/networks/xag.cpp
@@ -92,9 +92,15 @@ TEST_CASE( "create and use primary inputs in an xag", "[xag]" )
   CHECK( has_create_pi_v<xag_network> );
 
   auto a = xag.create_pi();
+  auto b = xag.create_pi();
 
-  CHECK( xag.size() == 2 );
-  CHECK( xag.num_pis() == 1 );
+  CHECK( xag.size() == 3 ); // constate + two primary inputs
+  CHECK( xag.num_pis() == 2 );
+  CHECK( xag.num_gates() == 0 );
+  CHECK( xag.is_pi( xag.get_node( a ) ) );
+  CHECK( xag.is_pi( xag.get_node( b ) ) );
+  CHECK( xag.pi_index( xag.get_node( a ) ) == 0 );
+  CHECK( xag.pi_index( xag.get_node( b ) ) == 1 );
 
   CHECK( std::is_same_v<std::decay_t<decltype( a )>, xag_network::signal> );
 

--- a/test/networks/xag.cpp
+++ b/test/networks/xag.cpp
@@ -94,7 +94,7 @@ TEST_CASE( "create and use primary inputs in an xag", "[xag]" )
   auto a = xag.create_pi();
   auto b = xag.create_pi();
 
-  CHECK( xag.size() == 3 ); // constate + two primary inputs
+  CHECK( xag.size() == 3 ); // constant + two primary inputs
   CHECK( xag.num_pis() == 2 );
   CHECK( xag.num_gates() == 0 );
   CHECK( xag.is_pi( xag.get_node( a ) ) );

--- a/test/networks/xmg.cpp
+++ b/test/networks/xmg.cpp
@@ -53,10 +53,15 @@ TEST_CASE( "create and use primary inputs in an xmg", "[xmg]" )
   CHECK( has_create_pi_v<xmg_network> );
 
   auto a = xmg.create_pi();
+  auto b = xmg.create_pi();
 
-  CHECK( xmg.size() == 2 );
-  CHECK( xmg.num_pis() == 1 );
+  CHECK( xmg.size() == 3 ); // constate + two primary inputs
+  CHECK( xmg.num_pis() == 2 );
   CHECK( xmg.num_gates() == 0 );
+  CHECK( xmg.is_pi( xmg.get_node( a ) ) );
+  CHECK( xmg.is_pi( xmg.get_node( b ) ) );
+  CHECK( xmg.pi_index( xmg.get_node( a ) ) == 0 );
+  CHECK( xmg.pi_index( xmg.get_node( b ) ) == 1 );
 
   CHECK( std::is_same_v<std::decay_t<decltype( a )>, xmg_network::signal> );
 

--- a/test/networks/xmg.cpp
+++ b/test/networks/xmg.cpp
@@ -55,7 +55,7 @@ TEST_CASE( "create and use primary inputs in an xmg", "[xmg]" )
   auto a = xmg.create_pi();
   auto b = xmg.create_pi();
 
-  CHECK( xmg.size() == 3 ); // constate + two primary inputs
+  CHECK( xmg.size() == 3 ); // constant + two primary inputs
   CHECK( xmg.num_pis() == 2 );
   CHECK( xmg.num_gates() == 0 );
   CHECK( xmg.is_pi( xmg.get_node( a ) ) );


### PR DESCRIPTION
Both `mig` and `xmg` uses the same logic as `aig` to retrieve a primary
input index from its node.  However, they create primary inputs
differently: instead of making their children equal to the `pi` index,
as in a `aig`, the make them equal to the numerical limit of `uint64_t`.
Effectively this means that the `pi_index` method on `mig` and `xmg` in
broken.

This commit solves the issue. Someone must check the other networks to
see if the problem also exists, e.g., `aqfp` seems to suffer from it
too.