### PR TITLE
Misc fixes

### DIFF
--- a/include/mockturtle/algorithms/aqfp_resynthesis/detail/db_utils.hpp
+++ b/include/mockturtle/algorithms/aqfp_resynthesis/detail/db_utils.hpp
@@ -47,7 +47,7 @@
 namespace mockturtle
 {
 
-void generate_aqfp_dags( const mockturtle::dag_generator_params& params, const std::string& file_prefix, uint32_t num_threads )
+inline void generate_aqfp_dags( const mockturtle::dag_generator_params& params, const std::string& file_prefix, uint32_t num_threads )
 {
   auto t0 = std::chrono::high_resolution_clock::now();
 
@@ -90,8 +90,8 @@ void generate_aqfp_dags( const mockturtle::dag_generator_params& params, const s
   std::cerr << fmt::format( "Number of DAGs of different input counts: [3 -> {},  4 -> {}, 5 -> {}]\n", counts_inp[3u], counts_inp[4u], counts_inp[5u] );
 }
 
-void compute_aqfp_dag_costs( const std::unordered_map<uint32_t, double>& gate_costs, const std::unordered_map<uint32_t, double>& splitters,
-                             const std::string& dag_file_prefix, const std::string& cost_file_prefix, uint32_t num_threads )
+inline void compute_aqfp_dag_costs( const std::unordered_map<uint32_t, double>& gate_costs, const std::unordered_map<uint32_t, double>& splitters,
+                                    const std::string& dag_file_prefix, const std::string& cost_file_prefix, uint32_t num_threads )
 {
   auto t0 = std::chrono::high_resolution_clock::now();
 
@@ -150,8 +150,8 @@ void compute_aqfp_dag_costs( const std::unordered_map<uint32_t, double>& gate_co
   std::cerr << fmt::format( "Number of DAGs processed {:10d}\nTime elapsed in seconds {:9.3f}\n", count, d2.count() / 1000.0 );
 }
 
-void generate_aqfp_db( const std::unordered_map<uint32_t, double>& gate_costs, const std::unordered_map<uint32_t, double>& splitters,
-                       const std::string& dag_file_prefix, const std::string& cost_file_prefix, const std::string& db_file_prefix, uint32_t num_threads )
+inline void generate_aqfp_db( const std::unordered_map<uint32_t, double>& gate_costs, const std::unordered_map<uint32_t, double>& splitters,
+                              const std::string& dag_file_prefix, const std::string& cost_file_prefix, const std::string& db_file_prefix, uint32_t num_threads )
 {
   auto t0 = std::chrono::high_resolution_clock::now();
 
@@ -255,7 +255,7 @@ void generate_aqfp_db( const std::unordered_map<uint32_t, double>& gate_costs, c
   std::cerr << fmt::format( "Number of DAGs processed {:10d}\nTime elapsed in seconds {:9.3f}\n", count, d2.count() / 1000.0 );
 }
 
-void generate_aqfp_db(
+inline void generate_aqfp_db(
     const mockturtle::dag_generator_params& params,
     const std::unordered_map<uint32_t, double>& gate_costs,
     const std::unordered_map<uint32_t, double>& splitters,

--- a/include/mockturtle/algorithms/cleanup.hpp
+++ b/include/mockturtle/algorithms/cleanup.hpp
@@ -246,7 +246,7 @@ std::vector<signal<NtkDest>> cleanup_dangling( NtkSource const& ntk, NtkDest& de
  * - `is_constant`
  */
 template<class NtkSrc, class NtkDest = NtkSrc>
-NtkDest cleanup_dangling( NtkSrc const& ntk )
+[[nodiscard]] NtkDest cleanup_dangling( NtkSrc const& ntk )
 {
   static_assert( is_network_type_v<NtkSrc>, "NtkSrc is not a network type" );
   static_assert( is_network_type_v<NtkDest>, "NtkDest is not a network type" );
@@ -310,7 +310,7 @@ NtkDest cleanup_dangling( NtkSrc const& ntk )
  * - `node_function`
  */
 template<class Ntk>
-Ntk cleanup_luts( Ntk const& ntk )
+[[nodiscard]] Ntk cleanup_luts( Ntk const& ntk )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );

--- a/include/mockturtle/generators/self_dualize.hpp
+++ b/include/mockturtle/generators/self_dualize.hpp
@@ -53,7 +53,7 @@ namespace mockturtle
  *   = (x0 * fi(x1, ..., xn)) + (!x0 * !fi(!x1, ..., !xn)).
  *
  */
-aig_network self_dualize_aig( aig_network const& src_aig )
+inline aig_network self_dualize_aig( aig_network const& src_aig )
 {
   using node = node<aig_network>;
   using signal = signal<aig_network>;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,4 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
+#include <mockturtle/mockturtle.hpp>
+
 #include <iostream>


### PR DESCRIPTION
- Added `[[nodiscard]]` to the return value of cleanup methods (#526)
- Added missing `inline`s (#525)
- Include `mockturtle.hpp` in `test.cpp` such that all files will be included at least once in the tests. (However, it doesn't prevent people from forgetting to include new files in `mockturtle.hpp`!)