### PR TITLE
Fuzz test external tool commands; examples

### DIFF
--- a/examples/draw.cpp
+++ b/examples/draw.cpp
@@ -1,0 +1,33 @@
+/* This example code makes it easy to visualize small AIG benchmarks.
+ */
+
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/io/aiger_reader.hpp>
+#include <mockturtle/io/write_dot.hpp>
+#include <lorina/aiger.hpp>
+
+using namespace mockturtle;
+
+int main( int argc, char* argv[] )
+{
+  if( argc != 2 )
+  {
+    std::cout << "Please give exactly one argument, which is the AIG file to be visualized\n";
+    std::cout << "For example: ./draw test.aig\n";
+    return -1;
+  }
+
+  aig_network aig;
+  if ( lorina::read_aiger( argv[1], aiger_reader( aig ) ) != lorina::return_code::success )
+  {
+    std::cout << "[e] couldn't read input file\n";
+    return -1;
+  }
+
+  write_dot( aig, std::string( argv[1] ) + ".dot" );
+  std::system( std::string( "dot -Tpng -O " + std::string( argv[1] ) + ".dot" ).c_str() );
+  std::system( std::string( "rm " + std::string( argv[1] ) + ".dot" ).c_str() );
+  std::system( std::string( "open " + std::string( argv[1] ) + ".dot.png" ).c_str() );
+
+  return 0;
+}

--- a/examples/fuzz.cpp
+++ b/examples/fuzz.cpp
@@ -1,0 +1,54 @@
+/* This example code demonstrates how to fuzz test mockturtle's algorithms.
+ */
+
+// common
+#include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/views/color_view.hpp>
+
+// algorithm under test
+#include <mockturtle/algorithms/cut_rewriting.hpp>
+#include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
+
+// fuzzer
+#include <mockturtle/utils/debugging_utils.hpp>
+#include <mockturtle/algorithms/network_fuzz_tester.hpp>
+#include <mockturtle/generators/random_logic_generator.hpp>
+#include <lorina/lorina.hpp>
+
+// cec
+#include <mockturtle/algorithms/equivalence_checking.hpp>
+#include <mockturtle/algorithms/miter.hpp>
+
+using namespace mockturtle;
+
+int main()
+{
+  xag_npn_resynthesis<aig_network> resyn;
+  auto opt = [&]( aig_network aig ) -> bool {
+    aig_network const aig_copy = cleanup_dangling( aig );
+
+    cut_rewriting_params ps;
+    ps.cut_enumeration_ps.cut_size = 4;
+    aig = cut_rewriting( aig, resyn, ps );
+
+    color_view caig{aig};
+    if ( !network_is_acyclic( caig ) )
+      return false;
+
+    return *equivalence_checking( *miter<aig_network>( aig_copy, aig ) );
+  };
+
+  fuzz_tester_params ps;
+  ps.num_iterations_step = 1000;
+  ps.num_pis_max = 100;
+  ps.num_gates_max = 1000;
+  ps.file_format = fuzz_tester_params::aiger;
+  ps.filename = "fuzz.aig";
+
+  auto gen = default_random_aig_generator();
+  network_fuzz_tester<aig_network, decltype(gen)> fuzzer( gen, ps );
+  fuzzer.run_incremental( opt );
+
+  return 0;
+}

--- a/examples/fuzz_abc.cpp
+++ b/examples/fuzz_abc.cpp
@@ -1,7 +1,6 @@
 /* This example code demonstrates how to use mockturtle's
  * fuzz tester to test ABC commands.
  */
-#ifndef _MSC_VER
 
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/algorithms/network_fuzz_tester.hpp>
@@ -11,6 +10,7 @@ using namespace mockturtle;
 
 int main( int argc, char* argv[] )
 {
+#ifndef _MSC_VER
   if( argc != 2 )
   {
     std::cout << "Please give exactly one argument, which is the optimization command(s) to test in ABC\n";
@@ -33,7 +33,7 @@ int main( int argc, char* argv[] )
   auto gen = default_random_aig_generator();
   network_fuzz_tester<aig_network, decltype(gen)> fuzzer( gen, ps );
   fuzzer.run_incremental( fn );
+#endif
 
   return 0;
 }
-#endif

--- a/examples/fuzz_abc.cpp
+++ b/examples/fuzz_abc.cpp
@@ -1,6 +1,7 @@
 /* This example code demonstrates how to use mockturtle's
  * fuzz tester to test ABC commands.
  */
+#ifndef _MSC_VER
 
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/algorithms/network_fuzz_tester.hpp>
@@ -35,3 +36,4 @@ int main( int argc, char* argv[] )
 
   return 0;
 }
+#endif

--- a/examples/fuzz_abc.cpp
+++ b/examples/fuzz_abc.cpp
@@ -1,0 +1,37 @@
+/* This example code demonstrates how to use mockturtle's
+ * fuzz tester to test ABC commands.
+ */
+
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/algorithms/network_fuzz_tester.hpp>
+#include <mockturtle/generators/random_logic_generator.hpp>
+
+using namespace mockturtle;
+
+int main( int argc, char* argv[] )
+{
+  if( argc != 2 )
+  {
+    std::cout << "Please give exactly one argument, which is the optimization command(s) to test in ABC\n";
+    std::cout << "(excluding read, write and cec)\n";
+    std::cout << "If there are spaces, use double quotes\n";
+    std::cout << "For example: ./fuzz_abc \"drw -C 10; resub\"\n";
+    return -1;
+  }
+
+  auto fn = [&]( std::string const& filename ) -> std::string {
+    return "abc -c \"read " + filename + "; " + std::string( argv[1] ) + "; write fuzz_opt.aig\"";
+  };
+
+  fuzz_tester_params ps;
+  ps.num_gates_max = 500;
+  ps.file_format = fuzz_tester_params::aiger;
+  ps.filename = "fuzz.aig";
+  ps.outputfile = "fuzz_opt.aig";
+
+  auto gen = default_random_aig_generator();
+  network_fuzz_tester<aig_network, decltype(gen)> fuzzer( gen, ps );
+  fuzzer.run_incremental( fn );
+
+  return 0;
+}

--- a/examples/minimize.cpp
+++ b/examples/minimize.cpp
@@ -30,6 +30,7 @@ int main( int argc, char* argv[] )
   };
 
   /* Use this lambda function for debugging external tools or algorithms that segfaults */
+  /* Note that this version is not supported on Windows platform */
   auto make_command = []( std::string const& filename ) -> std::string {
     return "abc -c \"read " + filename + "; rewrite\"";
   };
@@ -42,8 +43,8 @@ int main( int argc, char* argv[] )
   ps.max_size = 0;
   ps.verbose = true;
   testcase_minimizer<aig_network> minimizer( ps );
-  //minimizer.run( opt );
-  minimizer.run( make_command );
+  minimizer.run( opt );
+  //minimizer.run( make_command );
 
   return 0;
 }

--- a/examples/minimize.cpp
+++ b/examples/minimize.cpp
@@ -3,13 +3,10 @@
  */
 
 #include <mockturtle/networks/aig.hpp>
-#include <mockturtle/io/write_aiger.hpp>
-#include <mockturtle/io/aiger_reader.hpp>
-#include <mockturtle/algorithms/cleanup.hpp>
 #include <mockturtle/algorithms/sim_resub.hpp>
 #include <mockturtle/algorithms/testcase_minimizer.hpp>
 #include <mockturtle/utils/debugging_utils.hpp>
-#include <lorina/aiger.hpp>
+#include <mockturtle/views/color_view.hpp>
 
 using namespace mockturtle;
 
@@ -24,18 +21,17 @@ int main( int argc, char* argv[] )
 
   /* Use this lambda function for debugging mockturtle algorithms */
   auto opt = []( aig_network aig ) -> bool {
-    if ( !network_is_acyclic( aig ) ) return true;
     resubstitution_params ps;
     ps.max_pis = 100;
     ps.max_inserts = 20u;
 
     sim_resubstitution( aig, ps );
-    return !network_is_acyclic( aig );
+    return !network_is_acyclic( color_view{aig} ); // return true if buggy
   };
 
   /* Use this lambda function for debugging external tools or algorithms that segfaults */
   auto make_command = []( std::string const& filename ) -> std::string {
-    return "./examples/simresub " + filename;
+    return "abc -c \"read " + filename + "; rewrite\"";
   };
 
   testcase_minimizer_params ps;

--- a/examples/minimize.cpp
+++ b/examples/minimize.cpp
@@ -1,0 +1,53 @@
+/* This example code demonstrates how to use mockturtle's
+ * testcase minimizer to minimize bug-triggering testcases.
+ */
+
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/io/write_aiger.hpp>
+#include <mockturtle/io/aiger_reader.hpp>
+#include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/algorithms/sim_resub.hpp>
+#include <mockturtle/algorithms/testcase_minimizer.hpp>
+#include <mockturtle/utils/debugging_utils.hpp>
+#include <lorina/aiger.hpp>
+
+using namespace mockturtle;
+
+int main( int argc, char* argv[] )
+{
+  if( argc != 2 )
+  {
+    std::cout << "Please give exactly one argument, which is the filename of the initial testcase (without extension)\n";
+    std::cout << "For example: ./minimize fuzz\n";
+    return -1;
+  }
+
+  /* Use this lambda function for debugging mockturtle algorithms */
+  auto opt = []( aig_network aig ) -> bool {
+    if ( !network_is_acyclic( aig ) ) return true;
+    resubstitution_params ps;
+    ps.max_pis = 100;
+    ps.max_inserts = 20u;
+
+    sim_resubstitution( aig, ps );
+    return !network_is_acyclic( aig );
+  };
+
+  /* Use this lambda function for debugging external tools or algorithms that segfaults */
+  auto make_command = []( std::string const& filename ) -> std::string {
+    return "./examples/simresub " + filename;
+  };
+
+  testcase_minimizer_params ps;
+  ps.file_format = testcase_minimizer_params::aiger;
+  ps.path = "."; // current directory
+  ps.init_case = std::string( argv[1] );
+  ps.minimized_case = ps.init_case + "_minimized";
+  ps.max_size = 0;
+  ps.verbose = true;
+  testcase_minimizer<aig_network> minimizer( ps );
+  //minimizer.run( opt );
+  minimizer.run( make_command );
+
+  return 0;
+}

--- a/include/mockturtle/algorithms/network_fuzz_tester.hpp
+++ b/include/mockturtle/algorithms/network_fuzz_tester.hpp
@@ -305,7 +305,11 @@ private:
 
     std::array<char, 128> buffer;
     std::string result;
+    #ifdef _MSC_VER
+    std::unique_ptr<FILE, decltype( &pclose )> pipe( _popen( command.c_str(), "r" ), _pclose );
+    #else
     std::unique_ptr<FILE, decltype( &pclose )> pipe( popen( command.c_str(), "r" ), pclose );
+    #endif
     if ( !pipe )
     {
       throw std::runtime_error( "popen() failed" );

--- a/include/mockturtle/algorithms/network_fuzz_tester.hpp
+++ b/include/mockturtle/algorithms/network_fuzz_tester.hpp
@@ -39,6 +39,8 @@
 #include <lorina/lorina.hpp>
 #include <fmt/format.h>
 #include <optional>
+#include <array>
+#include <cstdio>
 
 namespace mockturtle
 {

--- a/include/mockturtle/algorithms/network_fuzz_tester.hpp
+++ b/include/mockturtle/algorithms/network_fuzz_tester.hpp
@@ -100,7 +100,7 @@ struct fuzz_tester_params
  * lambda function taking a network as input and returning a Boolean,
  * which is true if the algorithm behaves as expected; or (2) a lambda
  * function making a command string to be called, taking a filename string
- * as input.
+ * as input (not supported on Windows platform).
  *
   \verbatim embed:rst
 
@@ -138,6 +138,7 @@ public:
     , ps( ps )
   {}
 
+#ifndef _MSC_VER
   void run_incremental( std::function<std::string(std::string const&)>&& make_command )
   {
     run_incremental( make_callback( make_command ) );
@@ -147,6 +148,7 @@ public:
   {
     run( make_callback( make_command ) );
   }
+#endif
 
   void run_incremental( std::function<bool(Ntk)>&& fn )
   {
@@ -256,6 +258,7 @@ public:
   }
 
 private:
+#ifndef _MSC_VER
   inline std::function<bool(Ntk)> make_callback( std::function<std::string(std::string const&)>& make_command )
   {
     std::function<bool(Ntk)> fn = [&]( Ntk ntk ) -> bool {
@@ -292,6 +295,7 @@ private:
     };
     return fn;
   }
+#endif
 
   inline bool abc_cec()
   {

--- a/include/mockturtle/algorithms/network_fuzz_tester.hpp
+++ b/include/mockturtle/algorithms/network_fuzz_tester.hpp
@@ -306,7 +306,7 @@ private:
     std::array<char, 128> buffer;
     std::string result;
     #ifdef _MSC_VER
-    std::unique_ptr<FILE, decltype( &pclose )> pipe( _popen( command.c_str(), "r" ), _pclose );
+    std::unique_ptr<FILE, decltype( &_pclose )> pipe( _popen( command.c_str(), "r" ), _pclose );
     #else
     std::unique_ptr<FILE, decltype( &pclose )> pipe( popen( command.c_str(), "r" ), pclose );
     #endif

--- a/include/mockturtle/algorithms/network_fuzz_tester.hpp
+++ b/include/mockturtle/algorithms/network_fuzz_tester.hpp
@@ -90,9 +90,17 @@ struct fuzz_tester_params
  * testing is often useful to detect potential segmentation faults in
  * new implementations.  The generated benchmarks are saved first in a
  * file.  If a segmentation fault occurs, the file can be used to
- * reproduce and debug the problem. If the callback function returns
- * false, e.g. when the optimized result is incorrect, the fuzz tester
- * will also stop.
+ * reproduce and debug the problem.
+ *
+ * The entry function `run` generates different networks with the same
+ * number of PIs and gates. The function `run_incremental`, on the other
+ * hand, generates networks of increasing sizes.
+ *
+ * The script of algorithm(s) to be tested can be provided as (1) a
+ * lambda function taking a network as input and returning a Boolean,
+ * which is true if the algorithm behaves as expected; or (2) a lambda
+ * function making a command string to be called, taking a filename string
+ * as input.
  *
   \verbatim embed:rst
 
@@ -172,6 +180,12 @@ public:
         return;
       }
 
+      if ( ps.outputfile )
+      {
+        if ( !abc_cec() )
+          return;
+      }
+
       if ( ++counter_step >= ps.num_iterations_step )
       {
         counter_step = 0;
@@ -212,6 +226,12 @@ public:
       if ( !fn( ntk ) )
       {
         return;
+      }
+
+      if ( ps.outputfile )
+      {
+        if ( !abc_cec() )
+          return;
       }
     }
   }

--- a/include/mockturtle/algorithms/testcase_minimizer.hpp
+++ b/include/mockturtle/algorithms/testcase_minimizer.hpp
@@ -36,6 +36,8 @@
 #include "../io/aiger_reader.hpp"
 #include "../utils/debugging_utils.hpp"
 #include "../networks/aig.hpp"
+#include "../views/color_view.hpp"
+#include "cleanup.hpp"
 
 #include <lorina/lorina.hpp>
 #include <fmt/format.h>
@@ -197,7 +199,7 @@ public:
       return;
     }
 
-    if ( !test( make_command, ps.path + "/" + ps.init_case + file_extension ) )
+    if ( !test( make_command, ps.init_case ) )
     {
       fmt::print( "[e] The initial test case does not trigger the buggy behavior\n" );
       return;
@@ -220,7 +222,7 @@ public:
 
       write_testcase( "tmp" );
 
-      if ( test( make_command, ps.path + "/tmp" + file_extension ) )
+      if ( test( make_command, "tmp" ) )
       {
         fmt::print( "[i] Testcase with I/O = {}/{} gates = {} triggers the buggy behavior\n", ntk.num_pis(), ntk.num_pos(), ntk.num_gates() );
         write_testcase( ps.minimized_case );
@@ -290,7 +292,7 @@ private:
 
   bool test( std::function<std::string(std::string const&)> const& make_command, std::string const& filename )
   {
-    std::string const command = make_command( ps.path + "/" + filename );
+    std::string const command = make_command( ps.path + "/" + filename + file_extension );
     int status = std::system( command.c_str() );
     if ( status < 0 )
     {
@@ -374,7 +376,7 @@ private:
         if ( ps.verbose )
           fmt::print( "[i] Substitute gate {} with its {}-th fanin {}{}\n", n, ith_fanin, ntk.is_complemented( fi ) ? "!" : "", ntk.get_node( fi ) );
         ntk.substitute_node( n, fi );
-        assert( network_is_acyclic( ntk ) );
+        assert( network_is_acyclic( color_view{ntk} ) );
         break;
       }
       default:

--- a/include/mockturtle/algorithms/testcase_minimizer.hpp
+++ b/include/mockturtle/algorithms/testcase_minimizer.hpp
@@ -95,7 +95,7 @@ struct testcase_minimizer_params
  * making a command string to be called, taking a filename string as
  * input. The command should return 1 if the buggy behavior is observed
  * and 0 otherwise. In this case, if the command segfaults, it is counted
- * as a buggy behavior.
+ * as a buggy behavior. (The second case is not supported on Windows platform.)
  *
  *
   \verbatim embed:rst
@@ -192,6 +192,7 @@ public:
     }
   }
 
+#ifndef _MSC_VER
   void run( std::function<std::string(std::string const&)> const& make_command )
   {
     if ( !read_initial_testcase() )
@@ -240,6 +241,7 @@ public:
       }
     }
   }
+#endif
 
 private:
   bool read_initial_testcase()
@@ -290,6 +292,7 @@ private:
     return res;
   }
 
+#ifndef _MSC_VER
   bool test( std::function<std::string(std::string const&)> const& make_command, std::string const& filename )
   {
     std::string const command = make_command( ps.path + "/" + filename + file_extension );
@@ -319,6 +322,7 @@ private:
       }
     }
   }
+#endif
 
   bool reduce()
   {

--- a/include/mockturtle/algorithms/testcase_minimizer.hpp
+++ b/include/mockturtle/algorithms/testcase_minimizer.hpp
@@ -55,7 +55,7 @@ struct testcase_minimizer_params
     aiger
   } file_format = verilog;
 
-  /*! \brief Path to find the initial test case and to store the minmized test case. */
+  /*! \brief Path to find the initial test case and to store the minimized test case. */
   std::string path{"."};
 
   /*! \brief File name of the initial test case (excluding extension). */


### PR DESCRIPTION
- Fuzz tester supports testing external tools by calling system commands
- Example code of fuzz testing, test case minimization, and simple visualization of AIGs
- Disable on Windows the alternative ways of calling fuzz tester and testcase minimizer with a system command -- This could in principle be supported, but needs some investigation on how to get the return code on Windows...