### PR TITLE
Add general purpose metadata copying to replace names_view checks

### DIFF
--- a/include/mockturtle/algorithms/collapse_mapped.hpp
+++ b/include/mockturtle/algorithms/collapse_mapped.hpp
@@ -157,11 +157,7 @@ public:
         break;
       }
 
-      if constexpr ( has_has_name_v<NtkSource> && has_get_name_v<NtkSource> && has_set_name_v<NtkDest> )
-      {
-        if ( ntk.has_name( ntk.make_signal( n ) ) )
-          dest.set_name( dest_signal, ntk.get_name( ntk.make_signal( n ) ) );
-      }
+      dest.copy_signal_metadata( dest_signal, ntk, ntk.make_signal( n ) );
     } );
 
     /* nodes */
@@ -196,25 +192,17 @@ public:
 
     /* outputs */
     ntk.foreach_po( [&]( auto const& f, auto index ) {
-      (void)index;
-
+      uint32_t po;
       if ( ntk.is_complemented( f ) && node_driver_type[f] == driver_type::mixed )
       {
-        dest.create_po( opposites[ntk.get_node( f )] );
+        po = dest.create_po( opposites[ntk.get_node( f )] );
       }
       else
       {
-        dest.create_po( node_to_signal[f] );
+        po = dest.create_po( node_to_signal[f] );
       }
-
-      if constexpr ( has_has_output_name_v<NtkSource> && has_get_output_name_v<NtkSource> && has_set_output_name_v<NtkDest> )
-      {
-        if ( ntk.has_output_name( index ) )
-        {
-          dest.set_output_name( index, ntk.get_output_name( index ) );
-        }
-      }
-      });
+      dest.copy_output_metadata(po, ntk, index);
+    });
   }
 
 private:

--- a/include/mockturtle/algorithms/xag_optimization.hpp
+++ b/include/mockturtle/algorithms/xag_optimization.hpp
@@ -61,28 +61,31 @@ namespace mockturtle
 namespace detail
 {
 
+template<typename xag_network_>
 class xag_constant_fanin_optimization_impl
 {
 public:
-  xag_constant_fanin_optimization_impl( xag_network const& xag )
+  xag_constant_fanin_optimization_impl( xag_network_ const& xag )
       : xag( xag )
   {
   }
 
-  xag_network run()
+  xag_network_ run()
   {
-    xag_network dest;
+    xag_network_ dest;
+    dest.copy_network_metadata( xag );
 
-    node_map<xag_network::signal, xag_network> old2new( xag );
-    node_map<std::vector<xag_network::node>, xag_network> lfi( xag );
+    node_map<typename xag_network_::signal, xag_network_> old2new( xag );
+    node_map<std::vector<typename xag_network_::node>, xag_network_> lfi( xag );
 
     old2new[xag.get_node( xag.get_constant( false ) )] = dest.get_constant( false );
     if ( xag.get_node( xag.get_constant( true ) ) != xag.get_node( xag.get_constant( false ) ) )
     {
       old2new[xag.get_node( xag.get_constant( true ) )] = dest.get_constant( true );
     }
-    xag.foreach_pi( [&]( auto const& n ) {
+    xag.foreach_pi( [&]( typename xag_network_::node const& n ) {
       old2new[n] = dest.create_pi();
+      dest.copy_signal_metadata(old2new[n], xag, xag.make_signal( n ) );
       lfi[n].emplace_back( n );
     } );
     topo_view topo{xag};
@@ -92,8 +95,8 @@ public:
 
       if ( xag.is_xor( n ) )
       {
-        std::array<xag_network::signal*, 2> children{};
-        std::array<std::vector<xag_network::node>*, 2> clfi{};
+        std::array<typename xag_network_::signal*, 2> children{};
+        std::array<std::vector<typename xag_network_::node>*, 2> clfi{};
         xag.foreach_fanin( n, [&]( auto const& f, auto i ) {
           children[i] = &old2new[f];
           clfi[i] = &lfi[f];
@@ -115,7 +118,7 @@ public:
       else /* is AND */
       {
         lfi[n].emplace_back( n );
-        std::vector<xag_network::signal> children;
+        std::vector<typename xag_network_::signal> children;
         xag.foreach_fanin( n, [&]( auto const& f ) {
           children.push_back( old2new[f] ^ xag.is_complemented( f ) );
         } );
@@ -123,23 +126,26 @@ public:
       }
     } );
 
-    xag.foreach_po( [&]( auto const& f ) {
-      dest.create_po( old2new[f] ^ xag.is_complemented( f ) );
+    xag.foreach_po( [&]( auto const& f, auto i ) {
+      auto s = old2new[f] ^ xag.is_complemented( f );
+      dest.copy_signal_metadata(s, xag, f);
+      auto po = dest.create_po( s );
+      dest.copy_output_metadata(po, xag, i);
     } );
 
     return cleanup_dangling( dest );
   }
 
 private:
-  std::vector<xag_network::node> merge( std::vector<xag_network::node> const& s1, std::vector<xag_network::node> const& s2 ) const
+  std::vector<typename xag_network_::node> merge( std::vector<typename xag_network_::node> const& s1, std::vector<typename xag_network_::node> const& s2 ) const
   {
-    std::vector<xag_network::node> s;
+    std::vector<typename xag_network_::node> s;
     std::set_symmetric_difference( s1.cbegin(), s1.cend(), s2.cbegin(), s2.cend(), std::back_inserter( s ) );
     return s;
   }
 
 private:
-  xag_network const& xag;
+  xag_network_ const& xag;
 };
 
 } // namespace detail
@@ -153,7 +159,8 @@ private:
  * property of the XOR operation.  In such cases the AND gate can be replaced
  * by a constant or a fanin.
  */
-inline xag_network xag_constant_fanin_optimization( xag_network const& xag )
+template<typename xag_network_>
+inline xag_network_ xag_constant_fanin_optimization( xag_network_ const& xag )
 {
   return detail::xag_constant_fanin_optimization_impl( xag ).run();
 }
@@ -163,24 +170,29 @@ inline xag_network xag_constant_fanin_optimization( xag_network const& xag )
  * If an AND gate is satisfiability don't care for assignment 00, it can be
  * replaced by an XNOR gate, therefore reducing the multiplicative complexity.
  */
-inline xag_network xag_dont_cares_optimization( xag_network const& xag )
+template <typename xag_network_>
+inline xag_network_ xag_dont_cares_optimization( xag_network_ const& xag )
 {
-  node_map<xag_network::signal, xag_network> old_to_new( xag );
+  node_map<typename xag_network_::signal, xag_network_> old_to_new( xag );
 
-  xag_network dest;
+  xag_network_ dest;
+  dest.copy_network_metadata(xag);
+
   old_to_new[xag.get_constant( false )] = dest.get_constant( false );
 
   xag.foreach_pi( [&]( auto const& n ) {
-    old_to_new[n] = dest.create_pi();
+    auto pi = dest.create_pi();
+    old_to_new[n] = { pi, 0u };
+    dest.copy_signal_metadata(pi, xag, xag.make_signal( n ));
   } );
 
-  satisfiability_dont_cares_checker<xag_network> checker( xag );
+  satisfiability_dont_cares_checker<xag_network_> checker( xag );
 
-  topo_view<xag_network>{xag}.foreach_node( [&]( auto const& n ) {
+  topo_view<xag_network_>{xag}.foreach_node( [&]( auto const& n ) {
     if ( xag.is_constant( n ) || xag.is_pi( n ) )
       return;
 
-    std::array<xag_network::signal, 2> fanin{};
+    std::array<typename xag_network_::signal, 2> fanin{};
     xag.foreach_fanin( n, [&]( auto const& f, auto i ) {
       fanin[i] = old_to_new[f] ^ xag.is_complemented( f );
     } );
@@ -202,8 +214,11 @@ inline xag_network xag_dont_cares_optimization( xag_network const& xag )
     }
   } );
 
-  xag.foreach_po( [&]( auto const& f ) {
-    dest.create_po( old_to_new[f] ^ xag.is_complemented( f ) );
+  xag.foreach_po( [&]( auto const& f, auto i ) {
+    auto s = old_to_new[f] ^ xag.is_complemented( f );
+    dest.copy_signal_metadata(s, xag, f);
+    auto po = dest.create_po();
+    dest.copy_output_metadata(po, xag, i);
   } );
 
   return dest;
@@ -214,7 +229,8 @@ inline xag_network xag_dont_cares_optimization( xag_network const& xag )
  * See `exact_linear_resynthesis_optimization` for an example implementation
  * of this function.
  */
-inline xag_network linear_resynthesis_optimization( xag_network const& xag, std::function<xag_network(xag_network const&)> linear_resyn, std::function<void(std::vector<uint32_t> const&)> const& on_ignore_inputs = {} )
+template<typename xag_network_>
+inline xag_network_ linear_resynthesis_optimization( xag_network_ const& xag, std::function<xag_network_(xag_network_ const&)> linear_resyn, std::function<void(std::vector<uint32_t> const&)> const& on_ignore_inputs = {} )
 {
   const auto num_ands = *multiplicative_complexity( xag );
   if ( num_ands == 0u )
@@ -246,14 +262,14 @@ inline xag_network linear_resynthesis_optimization( xag_network const& xag, std:
 
 /*! \brief Optimizes XOR gates by exact linear network resynthesis
  */
-template<bill::solvers Solver = bill::solvers::glucose_41>
-inline xag_network exact_linear_resynthesis_optimization( xag_network const& xag, uint32_t conflict_limit = 0u )
+template<typename xag_network_, bill::solvers Solver = bill::solvers::glucose_41>
+inline xag_network_ exact_linear_resynthesis_optimization( xag_network_ const& xag, uint32_t conflict_limit = 0u )
 {
   exact_linear_synthesis_params ps;
   ps.conflict_limit = conflict_limit;
 
-  const auto linear_resyn = [&]( xag_network const& linear ) {
-    if ( const auto optimized = exact_linear_resynthesis<xag_network, Solver>( linear, ps ); optimized )
+  const auto linear_resyn = [&]( xag_network_ const& linear ) {
+    if ( const auto optimized = exact_linear_resynthesis<xag_network_, Solver>( linear, ps ); optimized )
     {
       return *optimized;
     }

--- a/include/mockturtle/interface.hpp
+++ b/include/mockturtle/interface.hpp
@@ -1015,6 +1015,23 @@ public:
   bool eval_fanins_color( node const& n, Pred&& pred ) const;
 #pragma endregion
 
+#pragma region Metadata copying
+  template<class Other>
+  void copy_network_metadata(Other &other) const;
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) const;
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) const;
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) const;
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) const;
+#pragma endregion
+
 #pragma region Signal naming
   /*! \brief Checks if a signal has a name. */
   bool has_name( signal const& s ) const;

--- a/include/mockturtle/io/write_blif.hpp
+++ b/include/mockturtle/io/write_blif.hpp
@@ -95,7 +95,15 @@ void write_blif( Ntk const& ntk, std::ostream& os, write_blif_params const& ps =
   topo_view topo_ntk{ntk};
 
   /* write model */
-  os << ".model top\n";
+  if constexpr ( has_get_network_name_v<Ntk>) {
+      if (ntk.get_network_name() == "") {
+	  os << ".model top\n";
+      } else {
+	  os << ".model " << ntk.get_network_name() << "\n";
+      }
+  } else {
+      os << ".model top\n";
+  }
 
   /* write inputs */
   if ( topo_ntk.num_pis() > 0u )

--- a/include/mockturtle/io/write_dot.hpp
+++ b/include/mockturtle/io/write_dot.hpp
@@ -59,7 +59,20 @@ public:
 public: /* callbacks */
   virtual std::string node_label( Ntk const& ntk, node<Ntk> const& n ) const
   {
-    return std::to_string( ntk.node_to_index( n ) );
+      if constexpr ( has_has_name_v<Ntk> && has_get_name_v<Ntk> && has_set_name_v<Ntk> )
+      {
+          signal<Ntk> s = ntk.make_signal( n );
+          if ( ntk.has_name( s ) ) {
+              return ntk.get_name( s );
+          }
+          if ( ntk.has_name( !s ) ) {
+              return ntk.get_name( !s );
+          }
+      }
+      if (ntk.is_constant(n)) {
+          return "constant";
+      }
+      return std::to_string( ntk.node_to_index( n ) );
   }
 
   virtual std::string node_shape( Ntk const& ntk, node<Ntk> const& n ) const

--- a/include/mockturtle/networks/abstract_xag.hpp
+++ b/include/mockturtle/networks/abstract_xag.hpp
@@ -623,6 +623,22 @@ public:
     const auto& node = _storage->nodes[n];
     detail::foreach_element_transform<uint32_t*, signal>( node.fanin, node.fanin + node.fanin_size, []( auto c ) -> signal { return { c, false }; }, fn );
   }
+
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
 #pragma endregion
 
 #pragma region Structural properties

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -1108,6 +1108,28 @@ public:
       fn( signal{_storage->nodes[n].children[1]}, 1 );
     }
   }
+
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) {
+      _storage->latch_information[dest] = other._storage->latch_information[source];
+  }
+
 #pragma endregion
 
 #pragma region Value simulation

--- a/include/mockturtle/networks/aqfp.hpp
+++ b/include/mockturtle/networks/aqfp.hpp
@@ -1111,6 +1111,28 @@ public:
       }
     }
   }
+
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) {
+      _storage->latch_information[dest] = other._storage->latch_information[source];
+  }
+
 #pragma endregion
 
   template<typename Iterator>

--- a/include/mockturtle/networks/cover.hpp
+++ b/include/mockturtle/networks/cover.hpp
@@ -865,6 +865,27 @@ public:
         fn );
   }
 
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) {
+      _storage->latch_information[dest] = other._storage->latch_information[source];
+  }
+
 #pragma endregion
 
 #pragma region Simulate values

--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -743,6 +743,28 @@ signal create_maj( signal a, signal b, signal c )
     using IteratorType = decltype( _storage->outputs.begin() );
     detail::foreach_element_transform<IteratorType, uint32_t>( _storage->nodes[n].children.begin(), _storage->nodes[n].children.end(), []( auto f ) { return f.index; }, fn );
   }
+
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) {
+      _storage->latch_information[dest] = other._storage->latch_information[source];
+  }
+
 #pragma endregion
 
 #pragma region Simulate values

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -1078,6 +1078,29 @@ public:
       fn( signal{_storage->nodes[n].children[2]}, 2 );
     }
   }
+
+
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) {
+      _storage->latch_information[dest] = other._storage->latch_information[source];
+  }
+
 #pragma endregion
 
 #pragma region Value simulation

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -1051,6 +1051,28 @@ public:
       fn( signal{_storage->nodes[n].children[1]}, 1 );
     }
   }
+
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) {
+      _storage->latch_information[dest] = other._storage->latch_information[source];
+  }
+
 #pragma endregion
 
 #pragma region Value simulation

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -1154,6 +1154,27 @@ public:
       fn( signal{_storage->nodes[n].children[2]}, 2 );
     }
   }
+
+  template<class Other>
+  void copy_network_metadata(Other &other) {
+  }
+
+  template<class Other>
+  void copy_node_metadata(node dest, Other &other, typename Other::node source) {
+  }
+
+  template<class Other>
+  void copy_signal_metadata(signal dest, Other &other, typename Other::signal source) {
+  }
+
+  template<class Other>
+  void copy_output_metadata(uint32_t dest, Other &other, uint32_t source) {
+  }
+
+  template<class Other>
+  void copy_latch_information(node dest, Other &other, typename Other::node source) {
+      _storage->latch_information[dest] = other._storage->latch_information[source];
+  }
 #pragma endregion
 
 #pragma region Value simulation

--- a/include/mockturtle/views/depth_view.hpp
+++ b/include/mockturtle/views/depth_view.hpp
@@ -236,9 +236,9 @@ public:
     _levels.resize();
   }
 
-  void create_po( signal const& f )
+  uint32_t create_po( signal const& f, std::string const& name = std::string() )
   {
-    Ntk::create_po( f );
+    Ntk::create_po( f, name );
     _depth = std::max( _depth, _levels[f] );
   }
 

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -114,3 +114,48 @@ TEST_CASE( "copy names", "[names_view]" )
   test_copy_names_view<xmg_network>();
   test_copy_names_view<klut_network>();
 }
+
+template<typename Ntk>
+void test_copy_metadata()
+{
+  Ntk ntk;
+
+  names_view<Ntk> named_ntk;
+  auto const a = ntk.create_pi();
+  auto const b = ntk.create_pi();
+  auto const c = ntk.create_pi();
+  auto const t1 = ntk.create_and( a, b );
+  auto const t2 = ntk.create_and( b, c );
+  auto const f = ntk.create_and( t1, t2 );
+  auto const po = ntk.create_po( f );
+  ntk.set_name( a, "a" );
+  ntk.set_name( b, "b" );
+  ntk.set_name( c, "c" );
+  ntk.set_output_name( po, "f" );
+  ntk.set_network_name( "test_network" );
+
+  names_view<Ntk> new_named_ntk;
+  auto const a_copy = ntk.create_pi();
+  auto const b_copy = ntk.create_pi();
+  auto const c_copy = ntk.create_pi();
+  auto const t1_copy = ntk.create_and( a, b );
+  auto const t2_copy = ntk.create_and( b, c );
+  auto const f_copy = ntk.create_and( t1, t2 );
+  auto const po_copy = ntk.create_po( f );
+
+  new_named_ntk.copy_signal_metadata(b_copy, ntk, a);
+  new_named_ntk.copy_signal_metadata(a_copy, ntk, b);
+  new_named_ntk.copy_output_metadata(po_copy, ntk, po);
+  new_named_ntk.copy_network_metadata(po_copy, ntk, po);
+
+  CHECK( new_named_ntk.has_name( a_copy ) );
+  CHECK( new_named_ntk.has_name( b_copy ) );
+  CHECK( !new_named_ntk.has_name( c ) );
+  CHECK( new_named_ntk.has_output_name( po) );
+  CHECK( new_named_ntk.has_network_name( po) );
+
+  CHECK( new_named_ntk.get_name( a_copy ) == "b" );
+  CHECK( new_named_ntk.get_name( b ) == "a" );
+  CHECK( new_named_ntk.get_output_name( po_copy ) == "f" );
+  CHECK( new_named_ntk.get_network_name() == "test_network" );
+}


### PR DESCRIPTION
Add general purpose polymorphic metadata copying to replace names_view checks everywhere and make it possible to propagate other types of metadata.

Everytime a network is copied, for example in resynthesis, we have to propagate the names by doing a type check and then a long call. This is missing from several locations in the code, and is bulky when implemented. The lack of a general method means any other metadata cannot be propagated without modifying mockturtle.