### PR TITLE
Fix instances where register IO is being ignored.

### DIFF
--- a/include/mockturtle/algorithms/cleanup.hpp
+++ b/include/mockturtle/algorithms/cleanup.hpp
@@ -46,6 +46,122 @@
 namespace mockturtle
 {
 
+template <class NtkSource, class NtkDest>
+typename NtkDest::signal copy_gate(const NtkSource &ntk, NtkDest &dest,
+                                 typename NtkSource::node node,
+                                 std::vector<signal<NtkDest>> children)
+{
+  if constexpr ( std::is_same_v<NtkSource, NtkDest> )
+  {
+    return dest.clone_node( ntk, node, children );
+  }
+  else
+  {
+    if constexpr ( has_is_and_v<NtkSource> )
+    {
+      static_assert( has_create_and_v<NtkDest>, "NtkDest cannot create AND gates" );
+      if ( ntk.is_and( node ) )
+      {
+        return dest.create_and( children[0], children[1] );
+      }
+    }
+    if constexpr ( has_is_or_v<NtkSource> )
+    {
+      static_assert( has_create_or_v<NtkDest>, "NtkDest cannot create OR gates" );
+      if ( ntk.is_or( node ) )
+      {
+        return dest.create_or( children[0], children[1] );
+      }
+    }
+    if constexpr ( has_is_xor_v<NtkSource> )
+    {
+      static_assert( has_create_xor_v<NtkDest>, "NtkDest cannot create XOR gates" );
+      if ( ntk.is_xor( node ) )
+      {
+        return dest.create_xor( children[0], children[1] );
+      }
+    }
+    if constexpr ( has_is_maj_v<NtkSource> )
+    {
+      static_assert( has_create_maj_v<NtkDest>, "NtkDest cannot create MAJ gates" );
+      if ( ntk.is_maj( node ) )
+      {
+        return dest.create_maj( children[0], children[1], children[2] );
+      }
+    }
+    if constexpr ( has_is_ite_v<NtkSource> )
+    {
+      static_assert( has_create_ite_v<NtkDest>, "NtkDest cannot create ITE gates" );
+      if ( ntk.is_ite( node ) )
+      {
+        return dest.create_ite( children[0], children[1], children[2] );
+      }
+    }
+    if constexpr ( has_is_xor3_v<NtkSource> )
+    {
+      static_assert( has_create_xor3_v<NtkDest>, "NtkDest cannot create XOR3 gates" );
+      if ( ntk.is_xor3( node ) )
+      {
+        return dest.create_xor3( children[0], children[1], children[2] );
+      }
+    }
+    if constexpr ( has_is_nary_and_v<NtkSource> )
+    {
+      static_assert( has_create_nary_and_v<NtkDest>, "NtkDest cannot create n-ary AND gates" );
+      if ( ntk.is_nary_and( node ) )
+      {
+        return dest.create_nary_and( children );
+      }
+    }
+    if constexpr ( has_is_nary_or_v<NtkSource> )
+    {
+      static_assert( has_create_nary_or_v<NtkDest>, "NtkDest cannot create n-ary OR gates" );
+      if ( ntk.is_nary_or( node ) )
+      {
+        return dest.create_nary_or( children );
+      }
+    }
+    if constexpr ( has_is_nary_xor_v<NtkSource> )
+    {
+      static_assert( has_create_nary_xor_v<NtkDest>, "NtkDest cannot create n-ary XOR gates" );
+      if ( ntk.is_nary_xor( node ) )
+      {
+        return dest.create_nary_xor( children );
+      }
+    }
+    if constexpr ( has_is_function_v<NtkSource> )
+    {
+      static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
+      return dest.create_node( children, ntk.node_function( node ) );
+    }
+    std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
+  }
+  throw;
+}
+
+/*
+ * Copy a non-constant and non
+ */
+template <class NtkSource, class NtkDest>
+typename NtkDest::signal copy_gate(const NtkSource &ntk, NtkDest &dest, typename NtkSource::node node,
+                        mockturtle::node_map<typename NtkDest::signal, NtkSource> &old_to_new)
+{
+  /* collect children */
+  std::vector<signal<NtkDest>> children;
+  ntk.foreach_fanin( node, [&]( auto child, auto ) {
+    const auto f = old_to_new[child];
+    if ( ntk.is_complemented( child ) )
+    {
+      children.push_back( dest.create_not( f ) );
+    }
+    else
+    {
+      children.push_back( f );
+    }
+  } );
+  return copy_gate(ntk, dest, node, children);
+}
+
 template<typename NtkSource, typename NtkDest, typename LeavesIterator>
 std::vector<signal<NtkDest>> cleanup_dangling( NtkSource const& ntk, NtkDest& dest, LeavesIterator begin, LeavesIterator end )
 {
@@ -85,120 +201,9 @@ std::vector<signal<NtkDest>> cleanup_dangling( NtkSource const& ntk, NtkDest& de
   topo_view topo{ntk};
   topo.foreach_node( [&]( auto node ) {
     if ( ntk.is_constant( node ) || ntk.is_ci( node ) )
-      return;
-
-    /* collect children */
-    std::vector<signal<NtkDest>> children;
-    ntk.foreach_fanin( node, [&]( auto child, auto ) {
-      const auto f = old_to_new[child];
-      if ( ntk.is_complemented( child ) )
-      {
-        children.push_back( dest.create_not( f ) );
-      }
-      else
-      {
-        children.push_back( f );
-      }
-    } );
-    if constexpr ( std::is_same_v<NtkSource, NtkDest> )
-    {
-      old_to_new[node] = dest.clone_node( ntk, node, children );
-    }
-    else
-    {
-      do
-      {
-        if constexpr ( has_is_and_v<NtkSource> )
-        {
-          static_assert( has_create_and_v<NtkDest>, "NtkDest cannot create AND gates" );
-          if ( ntk.is_and( node ) )
-          {
-            old_to_new[node] = dest.create_and( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_or_v<NtkSource> )
-        {
-          static_assert( has_create_or_v<NtkDest>, "NtkDest cannot create OR gates" );
-          if ( ntk.is_or( node ) )
-          {
-            old_to_new[node] = dest.create_or( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_xor_v<NtkSource> )
-        {
-          static_assert( has_create_xor_v<NtkDest>, "NtkDest cannot create XOR gates" );
-          if ( ntk.is_xor( node ) )
-          {
-            old_to_new[node] = dest.create_xor( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_maj_v<NtkSource> )
-        {
-          static_assert( has_create_maj_v<NtkDest>, "NtkDest cannot create MAJ gates" );
-          if ( ntk.is_maj( node ) )
-          {
-            old_to_new[node] = dest.create_maj( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_ite_v<NtkSource> )
-        {
-          static_assert( has_create_ite_v<NtkDest>, "NtkDest cannot create ITE gates" );
-          if ( ntk.is_ite( node ) )
-          {
-            old_to_new[node] = dest.create_ite( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_xor3_v<NtkSource> )
-        {
-          static_assert( has_create_xor3_v<NtkDest>, "NtkDest cannot create XOR3 gates" );
-          if ( ntk.is_xor3( node ) )
-          {
-            old_to_new[node] = dest.create_xor3( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_and_v<NtkSource> )
-        {
-          static_assert( has_create_nary_and_v<NtkDest>, "NtkDest cannot create n-ary AND gates" );
-          if ( ntk.is_nary_and( node ) )
-          {
-            old_to_new[node] = dest.create_nary_and( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_or_v<NtkSource> )
-        {
-          static_assert( has_create_nary_or_v<NtkDest>, "NtkDest cannot create n-ary OR gates" );
-          if ( ntk.is_nary_or( node ) )
-          {
-            old_to_new[node] = dest.create_nary_or( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_xor_v<NtkSource> )
-        {
-          static_assert( has_create_nary_xor_v<NtkDest>, "NtkDest cannot create n-ary XOR gates" );
-          if ( ntk.is_nary_xor( node ) )
-          {
-            old_to_new[node] = dest.create_nary_xor( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_function_v<NtkSource> )
-        {
-          static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
-          old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
-          break;
-        }
-        std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
-      } while ( false );
-    }
-  } );
+        return;
+    old_to_new[node] = copy_gate(ntk, dest, node, old_to_new);
+  });
 
   /* create outputs in same order */
   std::vector<signal<NtkDest>> fs;
@@ -280,44 +285,43 @@ template<class NtkSrc, class NtkDest = NtkSrc>
       old_to_new[n] = dest.get_constant( false );
       return;
     }
-    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
+    auto updated = dest.create_pi();
+    old_to_new[n] = updated;
+    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_set_name_v<NtkDest> )
     {
-      auto s = ntk.make_signal( n );
+      auto const s = ntk.make_signal( n );
       if ( ntk.has_name( s ) )
       {
-        old_to_new[n] = dest.create_pi( ntk.get_name( s ) );
+        dest.set_name(updated, ntk.get_name( s ) );
       }
-      else
+      if ( ntk.has_name( !s ) )
       {
-        old_to_new[n] = dest.create_pi();
+        dest.set_name(dest.create_not(updated), ntk.get_name( !s ) );
       }
-    }
-    else
-    {
-      old_to_new[n] = dest.create_pi();
     }
   } );
 
-  ntk.foreach_register( [&]( std::pair<typename NtkSrc::signal, typename NtkSrc::node> reg ) {
-    typename NtkSrc::node ro = reg.second;
-    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
+  if constexpr ( has_foreach_register_v<NtkSrc> && has_create_ro_v<NtkDest> )
   {
-      auto ros = ntk.make_signal( ro );
-      if ( ntk.has_name( ros ) )
+    ntk.foreach_register( [&]( std::pair<typename NtkSrc::signal, typename NtkSrc::node> reg ) {
+      typename NtkSrc::node ro = reg.second;
+      auto updated = dest.create_ro();
+      old_to_new[ro] = updated;
+      if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_set_name_v<NtkDest> )
       {
-        old_to_new[ro] = dest.create_ro( ntk.get_name( ros ) );
-  }
-      else
-      {
-        old_to_new[ro] = dest.create_ro();
+        auto const s = ntk.make_signal( ro );
+        if ( ntk.has_name( s ) )
+        {
+          dest.set_name(updated, ntk.get_name( s ) );
+        }
+        if ( ntk.has_name( !s ) )
+        {
+          dest.set_name(dest.create_not(updated), ntk.get_name( !s ) );
+        }
       }
-    }
-    else
-    {
-      old_to_new[ro] = dest.create_ro();
-    }
-    dest._storage->latch_information[dest.get_node(old_to_new[ro])] = ntk._storage->latch_information[ro];
-  } );
+      dest._storage->latch_information[dest.get_node(updated)] = ntk._storage->latch_information[ro];
+    } );
+  }
 
   old_to_new[ntk.get_constant( false )] = dest.get_constant( false );
 
@@ -329,121 +333,23 @@ template<class NtkSrc, class NtkDest = NtkSrc>
   /* foreach node in topological order */
   topo_view topo{ntk};
   topo.foreach_node( [&]( auto node ) {
-    if ( ntk.is_constant( node ) || ntk.is_ci( node ))
+    if ( ntk.is_constant( node ) || ntk.is_ci( node ) )
       return;
-
-    /* collect children */
-    std::vector<signal<NtkDest>> children;
-    ntk.foreach_fanin( node, [&]( auto child, auto ) {
-      const auto f = old_to_new[child];
-      if ( ntk.is_complemented( child ) )
-      {
-        children.push_back( dest.create_not( f ) );
-      }
-      else
-      {
-        children.push_back( f );
-      }
-    } );
-    if constexpr ( std::is_same_v<NtkSrc, NtkDest> )
+    auto updated = copy_gate(ntk, dest, node, old_to_new);
+    old_to_new[node] = updated;
+    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_set_name_v<NtkDest> )
     {
-      old_to_new[node] = dest.clone_node( ntk, node, children );
-    }
-    else
-    {
-      do
+      auto s = ntk.make_signal( node );
+      if ( ntk.has_name( s ) )
       {
-        if constexpr ( has_is_and_v<NtkSrc> )
-        {
-          static_assert( has_create_and_v<NtkDest>, "NtkDest cannot create AND gates" );
-          if ( ntk.is_and( node ) )
-          {
-            old_to_new[node] = dest.create_and( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_or_v<NtkSrc> )
-        {
-          static_assert( has_create_or_v<NtkDest>, "NtkDest cannot create OR gates" );
-          if ( ntk.is_or( node ) )
-          {
-            old_to_new[node] = dest.create_or( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_xor_v<NtkSrc> )
-        {
-          static_assert( has_create_xor_v<NtkDest>, "NtkDest cannot create XOR gates" );
-          if ( ntk.is_xor( node ) )
-          {
-            old_to_new[node] = dest.create_xor( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_maj_v<NtkSrc> )
-        {
-          static_assert( has_create_maj_v<NtkDest>, "NtkDest cannot create MAJ gates" );
-          if ( ntk.is_maj( node ) )
-          {
-            old_to_new[node] = dest.create_maj( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_ite_v<NtkSrc> )
-        {
-          static_assert( has_create_ite_v<NtkDest>, "NtkDest cannot create ITE gates" );
-          if ( ntk.is_ite( node ) )
-          {
-            old_to_new[node] = dest.create_ite( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_xor3_v<NtkSrc> )
-        {
-          static_assert( has_create_xor3_v<NtkDest>, "NtkDest cannot create XOR3 gates" );
-          if ( ntk.is_xor3( node ) )
-          {
-            old_to_new[node] = dest.create_xor3( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_and_v<NtkSrc> )
-        {
-          static_assert( has_create_nary_and_v<NtkDest>, "NtkDest cannot create n-ary AND gates" );
-          if ( ntk.is_nary_and( node ) )
-          {
-            old_to_new[node] = dest.create_nary_and( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_or_v<NtkSrc> )
-        {
-          static_assert( has_create_nary_or_v<NtkDest>, "NtkDest cannot create n-ary OR gates" );
-          if ( ntk.is_nary_or( node ) )
-          {
-            old_to_new[node] = dest.create_nary_or( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_xor_v<NtkSrc> )
-        {
-          static_assert( has_create_nary_xor_v<NtkDest>, "NtkDest cannot create n-ary XOR gates" );
-          if ( ntk.is_nary_xor( node ) )
-          {
-            old_to_new[node] = dest.create_nary_xor( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_function_v<NtkSrc> )
-        {
-          static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
-          old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
-          break;
-        }
-        std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
-      } while ( false );
+        dest.set_name(updated, ntk.get_name( s ) );
+      }
+      if ( ntk.has_name( !s ) )
+      {
+        dest.set_name(dest.create_not(updated), ntk.get_name( !s ) );
+      }
     }
-  } );
+  });
 
   ntk.foreach_po( [&]( auto po, auto index ) {
     if ( remove_redundant_POs && ( dest.is_pi( dest.get_node( po ) ) || dest.is_constant( dest.get_node( po ) ) ) ) {
@@ -451,311 +357,27 @@ template<class NtkSrc, class NtkDest = NtkSrc>
     }
     const auto f = old_to_new[po];
     typename NtkDest::signal g = ntk.is_complemented( po ) ? dest.create_not( old_to_new[po] ) : old_to_new[po];
-
-    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
-    {
-      if ( ntk.has_output_name( index ) )
-      {
-        dest.create_po( g, ntk.get_output_name( index ) );
-      }
-      else
-      {
-        dest.create_po( g );
-      }
-    }
-    else
-    {
-      dest.create_po( g );
-    }
+    auto const s = dest.create_po( g );
   } );
 
-  ntk.foreach_ri( [&]( auto ri, auto index ) {
-    typename NtkDest::signal g = ntk.is_complemented( ri ) ? dest.create_not( old_to_new[ri] ) : old_to_new[ri];
-
-    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
-    {
-      if ( ntk.has_output_name( index ) )
-      {
-        dest.create_ri( g, 0, ntk.get_output_name( index ) );
-      }
-      else
-      {
-        dest.create_ri( g );
-      }
-    }
-    else
-    {
-      dest.create_ri( g );
-    }
-  } );
-
-  return dest;
-}
-
-/*! \brief Cleans up dangling nodes.
- *
- * This method reconstructs a network and omits all dangling nodes.  The
- * network types of the source and destination network are the same.
- *
-   \verbatim embed:rst
-
-   .. note::
-
-      This method returns the cleaned up network as a return value.  It does
-      *not* modify the input network.
-   \endverbatim
- *
- * **Required network functions:**
- * - `get_node`
- * - `node_to_index`
- * - `get_constant`
- * - `create_pi`
- * - `create_po`
- * - `create_not`
- * - `is_complemented`
- * - `foreach_node`
- * - `foreach_pi`
- * - `foreach_po`
- * - `clone_node`
- * - `is_ci`
- * - `is_constant`
- */
-template<class NtkSrc, class NtkDest = NtkSrc>
-NtkDest cleanup_dangling_with_registers( NtkSrc const& ntk )
-{
-  static_assert( is_network_type_v<NtkSrc>, "NtkSrc is not a network type" );
-  static_assert( is_network_type_v<NtkDest>, "NtkDest is not a network type" );
-  static_assert( has_get_node_v<NtkSrc>, "NtkSrc does not implement the get_node method" );
-  static_assert( has_node_to_index_v<NtkSrc>, "NtkSrc does not implement the node_to_index method" );
-  static_assert( has_get_constant_v<NtkSrc>, "NtkSrc does not implement the get_constant method" );
-  static_assert( has_foreach_node_v<NtkSrc>, "NtkSrc does not implement the foreach_node method" );
-  static_assert( has_foreach_pi_v<NtkSrc>, "NtkSrc does not implement the foreach_pi method" );
-  static_assert( has_foreach_po_v<NtkSrc>, "NtkSrc does not implement the foreach_po method" );
-  static_assert( has_is_ci_v<NtkSrc>, "NtkSrc does not implement the is_ci method" );
-  static_assert( has_is_constant_v<NtkSrc>, "NtkSrc does not implement the is_constant method" );
-  static_assert( has_clone_node_v<NtkDest>, "NtkDest does not implement the clone_node method" );
-  static_assert( has_create_pi_v<NtkDest>, "NtkDest does not implement the create_pi method" );
-  static_assert( has_create_po_v<NtkDest>, "NtkDest does not implement the create_po method" );
-  static_assert( has_create_not_v<NtkDest>, "NtkDest does not implement the create_not method" );
-  static_assert( has_is_complemented_v<NtkSrc>, "NtkDest does not implement the is_complemented method" );
-
-  NtkDest dest;
-  if constexpr ( has_get_network_name_v<NtkSrc> && has_set_network_name_v<NtkDest> )
+  if constexpr ( has_foreach_ri_v<NtkSrc> && has_create_ri_v<NtkDest> )
   {
-    dest.set_network_name( ntk.get_network_name() );
-  }
-
-  node_map<signal<NtkDest>, NtkSrc> old_to_new( ntk );
-
-  std::vector<signal<NtkDest>> pis;
-  ntk.foreach_pi( [&]( auto n ) {
-    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
-    {
-      auto s = ntk.make_signal( n );
-      if ( ntk.has_name( s ) )
-      {
-        old_to_new[n] = dest.create_pi( ntk.get_name( s ) );
-      }
-      else
-      {
-        old_to_new[n] = dest.create_pi();
-      }
-    }
-    else
-    {
-      old_to_new[n] = dest.create_pi();
-    }
-  } );
-
-  ntk.foreach_register( [&]( std::pair<typename NtkSrc::signal, typename NtkSrc::node> reg ) {
-    typename NtkSrc::node ro = reg.second;
-    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
-    {
-      auto ros = ntk.make_signal( ro );
-      if ( ntk.has_name( ros ) )
-      {
-        old_to_new[ro] = dest.create_ro( ntk.get_name( ros ) );
-      }
-      else
-      {
-        old_to_new[ro] = dest.create_ro();
-      }
-    }
-    else
-    {
-      old_to_new[ro] = dest.create_ro();
-    }
-    dest._storage->latch_information[dest.get_node(old_to_new[ro])] = ntk._storage->latch_information[ro];
-  } );
-
-  old_to_new[ntk.get_constant( false )] = dest.get_constant( false );
-
-  if ( ntk.get_node( ntk.get_constant( true ) ) != ntk.get_node( ntk.get_constant( false ) ) )
-  {
-    old_to_new[ntk.get_constant( true )] = dest.get_constant( true );
-  }
-
-  /* foreach node in topological order */
-  topo_view topo{ntk};
-  topo.foreach_node( [&]( auto node ) {
-    if ( ntk.is_constant( node ) || ntk.is_ci( node ))
-      return;
-
-    /* collect children */
-    std::vector<signal<NtkDest>> children;
-    ntk.foreach_fanin( node, [&]( auto child, auto ) {
-      const auto f = old_to_new[child];
-      if ( ntk.is_complemented( child ) )
-      {
-        children.push_back( dest.create_not( f ) );
-      }
-      else
-      {
-        children.push_back( f );
-      }
+    ntk.foreach_ri( [&]( auto ri, auto index ) {
+      typename NtkDest::signal g = ntk.is_complemented( ri ) ? dest.create_not( old_to_new[ri] ) : old_to_new[ri];
+      auto const s = dest.create_ri( g, 0 );
     } );
-    if constexpr ( std::is_same_v<NtkSrc, NtkDest> )
-    {
-      old_to_new[node] = dest.clone_node( ntk, node, children );
-    }
-    else
-    {
-      do
-      {
-        if constexpr ( has_is_and_v<NtkSrc> )
-        {
-          static_assert( has_create_and_v<NtkDest>, "NtkDest cannot create AND gates" );
-          if ( ntk.is_and( node ) )
-          {
-            old_to_new[node] = dest.create_and( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_or_v<NtkSrc> )
-        {
-          static_assert( has_create_or_v<NtkDest>, "NtkDest cannot create OR gates" );
-          if ( ntk.is_or( node ) )
-          {
-            old_to_new[node] = dest.create_or( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_xor_v<NtkSrc> )
-        {
-          static_assert( has_create_xor_v<NtkDest>, "NtkDest cannot create XOR gates" );
-          if ( ntk.is_xor( node ) )
-          {
-            old_to_new[node] = dest.create_xor( children[0], children[1] );
-            break;
-          }
-        }
-        if constexpr ( has_is_maj_v<NtkSrc> )
-        {
-          static_assert( has_create_maj_v<NtkDest>, "NtkDest cannot create MAJ gates" );
-          if ( ntk.is_maj( node ) )
-          {
-            old_to_new[node] = dest.create_maj( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_ite_v<NtkSrc> )
-        {
-          static_assert( has_create_ite_v<NtkDest>, "NtkDest cannot create ITE gates" );
-          if ( ntk.is_ite( node ) )
-          {
-            old_to_new[node] = dest.create_ite( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_xor3_v<NtkSrc> )
-        {
-          static_assert( has_create_xor3_v<NtkDest>, "NtkDest cannot create XOR3 gates" );
-          if ( ntk.is_xor3( node ) )
-          {
-            old_to_new[node] = dest.create_xor3( children[0], children[1], children[2] );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_and_v<NtkSrc> )
-        {
-          static_assert( has_create_nary_and_v<NtkDest>, "NtkDest cannot create n-ary AND gates" );
-          if ( ntk.is_nary_and( node ) )
-          {
-            old_to_new[node] = dest.create_nary_and( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_or_v<NtkSrc> )
-        {
-          static_assert( has_create_nary_or_v<NtkDest>, "NtkDest cannot create n-ary OR gates" );
-          if ( ntk.is_nary_or( node ) )
-          {
-            old_to_new[node] = dest.create_nary_or( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_nary_xor_v<NtkSrc> )
-        {
-          static_assert( has_create_nary_xor_v<NtkDest>, "NtkDest cannot create n-ary XOR gates" );
-          if ( ntk.is_nary_xor( node ) )
-          {
-            old_to_new[node] = dest.create_nary_xor( children );
-            break;
-          }
-        }
-        if constexpr ( has_is_function_v<NtkSrc> )
-        {
-          static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
-          old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
-          break;
-        }
-        std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
-      } while ( false );
-    }
-  } );
+  }
 
-  ntk.foreach_po( [&]( auto po, auto index ) {
-    const auto f = old_to_new[po];
-    typename NtkDest::signal g = ntk.is_complemented( po ) ? dest.create_not( old_to_new[po] ) : old_to_new[po];
-
-    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
-    {
+  if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> && has_set_output_name_v<NtkDest> )
+  {
+    ntk.foreach_co( [&]( auto co, auto index ) {
+      (void) co;
       if ( ntk.has_output_name( index ) )
       {
-        dest.create_po( g, ntk.get_output_name( index ) );
+        dest.set_output_name( index, ntk.get_output_name( index ) );
       }
-      else
-      {
-        dest.create_po( g );
-      }
-    }
-    else
-    {
-      dest.create_po( g );
-    }
-  } );
-
-  ntk.foreach_ri( [&]( auto ri, auto index ) {
-    // typename NtkSrc::signal ri = reg.first;
-    // typename NtkSrc::node ro = reg.second;
-    typename NtkDest::signal g = ntk.is_complemented( ri ) ? dest.create_not( old_to_new[ri] ) : old_to_new[ri];
-
-    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
-    {
-      if ( ntk.has_output_name( index ) )
-      {
-        dest.create_ri( g, 0, ntk.get_output_name( index ) );
-      }
-      else
-      {
-        dest.create_ri( g );
-      }
-    }
-    else
-    {
-      dest.create_ri( g );
-    }
-  } );
+    });
+  }
 
   return dest;
 }
@@ -821,21 +443,14 @@ Ntk cleanup_luts( Ntk const& ntk )
 
   // PIs and constants
   ntk.foreach_pi( [&]( auto const& n ) {
+    old_to_new[n] = dest.create_pi();
     if constexpr ( has_has_name_v<Ntk> && has_get_name_v<Ntk>)
     {
       auto s = ntk.make_signal( n );
       if ( ntk.has_name( s ) )
       {
-        old_to_new[n] = dest.create_pi( ntk.get_name( s ) );
+        dest.set_name_pi( old_to_new[n], ntk.get_name( s ) );
       }
-      else
-      {
-        old_to_new[n] = dest.create_pi();
-      }
-    }
-    else
-    {
-      old_to_new[n] = dest.create_pi();
     }
   } );
   old_to_new[ntk.get_constant( false )] = dest.get_constant( false );
@@ -907,20 +522,13 @@ Ntk cleanup_luts( Ntk const& ntk )
   ntk.foreach_po( [&]( auto const& f, auto i ) {
     auto const& new_f = old_to_new[f];
     auto s = ntk.is_complemented( f ) ? dest.create_not( new_f ) : new_f;
+    auto po = dest.create_po( s );
     if constexpr ( has_has_output_name_v<Ntk> && has_get_output_name_v<Ntk> )
     {
       if ( ntk.has_output_name( i ) )
       {
-        dest.create_po( s, ntk.get_output_name( i ) );
+        dest.set_output_name( po, ntk.get_output_name( i ) );
       }
-      else
-      {
-        dest.create_po( s );
-      }
-    }
-    else
-    {
-      dest.create_po( s );
     }
   });
 

--- a/include/mockturtle/algorithms/cleanup.hpp
+++ b/include/mockturtle/algorithms/cleanup.hpp
@@ -84,7 +84,7 @@ std::vector<signal<NtkDest>> cleanup_dangling( NtkSource const& ntk, NtkDest& de
   /* foreach node in topological order */
   topo_view topo{ntk};
   topo.foreach_node( [&]( auto node ) {
-    if ( ntk.is_constant( node ) || ntk.is_pi( node ) )
+    if ( ntk.is_constant( node ) || ntk.is_ci( node ) )
       return;
 
     /* collect children */
@@ -268,20 +268,494 @@ template<class NtkSrc, class NtkDest = NtkSrc>
   static_assert( has_is_complemented_v<NtkSrc>, "NtkDest does not implement the is_complemented method" );
 
   NtkDest dest;
-  std::vector<signal<NtkDest>> pis;
+  if constexpr ( has_get_network_name_v<NtkSrc> && has_set_network_name_v<NtkDest> )
+  {
+    dest.set_network_name( ntk.get_network_name() );
+  }
+
+  node_map<signal<NtkDest>, NtkSrc> old_to_new( ntk );
+
   ntk.foreach_pi( [&]( auto n ) {
-    if ( remove_dangling_PIs && ntk.fanout_size( n ) == 0 )
-      pis.push_back( dest.get_constant( false ) );
+    if ( remove_dangling_PIs && ntk.fanout_size( n ) == 0 ) {
+      old_to_new[n] = dest.get_constant( false );
+      return;
+    }
+    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
+    {
+      auto s = ntk.make_signal( n );
+      if ( ntk.has_name( s ) )
+      {
+        old_to_new[n] = dest.create_pi( ntk.get_name( s ) );
+      }
+      else
+      {
+        old_to_new[n] = dest.create_pi();
+      }
+    }
     else
-      pis.push_back( dest.create_pi() );
+    {
+      old_to_new[n] = dest.create_pi();
+    }
   } );
 
-  for ( auto f : cleanup_dangling( ntk, dest, pis.begin(), pis.end() ) )
+  ntk.foreach_register( [&]( std::pair<typename NtkSrc::signal, typename NtkSrc::node> reg ) {
+    typename NtkSrc::node ro = reg.second;
+    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
   {
-    if ( remove_redundant_POs && ( dest.is_pi( dest.get_node( f ) ) || dest.is_constant( dest.get_node( f ) ) ) )
-      continue;
-    dest.create_po( f );
+      auto ros = ntk.make_signal( ro );
+      if ( ntk.has_name( ros ) )
+      {
+        old_to_new[ro] = dest.create_ro( ntk.get_name( ros ) );
   }
+      else
+      {
+        old_to_new[ro] = dest.create_ro();
+      }
+    }
+    else
+    {
+      old_to_new[ro] = dest.create_ro();
+    }
+    dest._storage->latch_information[dest.get_node(old_to_new[ro])] = ntk._storage->latch_information[ro];
+  } );
+
+  old_to_new[ntk.get_constant( false )] = dest.get_constant( false );
+
+  if ( ntk.get_node( ntk.get_constant( true ) ) != ntk.get_node( ntk.get_constant( false ) ) )
+  {
+    old_to_new[ntk.get_constant( true )] = dest.get_constant( true );
+  }
+
+  /* foreach node in topological order */
+  topo_view topo{ntk};
+  topo.foreach_node( [&]( auto node ) {
+    if ( ntk.is_constant( node ) || ntk.is_ci( node ))
+      return;
+
+    /* collect children */
+    std::vector<signal<NtkDest>> children;
+    ntk.foreach_fanin( node, [&]( auto child, auto ) {
+      const auto f = old_to_new[child];
+      if ( ntk.is_complemented( child ) )
+      {
+        children.push_back( dest.create_not( f ) );
+      }
+      else
+      {
+        children.push_back( f );
+      }
+    } );
+    if constexpr ( std::is_same_v<NtkSrc, NtkDest> )
+    {
+      old_to_new[node] = dest.clone_node( ntk, node, children );
+    }
+    else
+    {
+      do
+      {
+        if constexpr ( has_is_and_v<NtkSrc> )
+        {
+          static_assert( has_create_and_v<NtkDest>, "NtkDest cannot create AND gates" );
+          if ( ntk.is_and( node ) )
+          {
+            old_to_new[node] = dest.create_and( children[0], children[1] );
+            break;
+          }
+        }
+        if constexpr ( has_is_or_v<NtkSrc> )
+        {
+          static_assert( has_create_or_v<NtkDest>, "NtkDest cannot create OR gates" );
+          if ( ntk.is_or( node ) )
+          {
+            old_to_new[node] = dest.create_or( children[0], children[1] );
+            break;
+          }
+        }
+        if constexpr ( has_is_xor_v<NtkSrc> )
+        {
+          static_assert( has_create_xor_v<NtkDest>, "NtkDest cannot create XOR gates" );
+          if ( ntk.is_xor( node ) )
+          {
+            old_to_new[node] = dest.create_xor( children[0], children[1] );
+            break;
+          }
+        }
+        if constexpr ( has_is_maj_v<NtkSrc> )
+        {
+          static_assert( has_create_maj_v<NtkDest>, "NtkDest cannot create MAJ gates" );
+          if ( ntk.is_maj( node ) )
+          {
+            old_to_new[node] = dest.create_maj( children[0], children[1], children[2] );
+            break;
+          }
+        }
+        if constexpr ( has_is_ite_v<NtkSrc> )
+        {
+          static_assert( has_create_ite_v<NtkDest>, "NtkDest cannot create ITE gates" );
+          if ( ntk.is_ite( node ) )
+          {
+            old_to_new[node] = dest.create_ite( children[0], children[1], children[2] );
+            break;
+          }
+        }
+        if constexpr ( has_is_xor3_v<NtkSrc> )
+        {
+          static_assert( has_create_xor3_v<NtkDest>, "NtkDest cannot create XOR3 gates" );
+          if ( ntk.is_xor3( node ) )
+          {
+            old_to_new[node] = dest.create_xor3( children[0], children[1], children[2] );
+            break;
+          }
+        }
+        if constexpr ( has_is_nary_and_v<NtkSrc> )
+        {
+          static_assert( has_create_nary_and_v<NtkDest>, "NtkDest cannot create n-ary AND gates" );
+          if ( ntk.is_nary_and( node ) )
+          {
+            old_to_new[node] = dest.create_nary_and( children );
+            break;
+          }
+        }
+        if constexpr ( has_is_nary_or_v<NtkSrc> )
+        {
+          static_assert( has_create_nary_or_v<NtkDest>, "NtkDest cannot create n-ary OR gates" );
+          if ( ntk.is_nary_or( node ) )
+          {
+            old_to_new[node] = dest.create_nary_or( children );
+            break;
+          }
+        }
+        if constexpr ( has_is_nary_xor_v<NtkSrc> )
+        {
+          static_assert( has_create_nary_xor_v<NtkDest>, "NtkDest cannot create n-ary XOR gates" );
+          if ( ntk.is_nary_xor( node ) )
+          {
+            old_to_new[node] = dest.create_nary_xor( children );
+            break;
+          }
+        }
+        if constexpr ( has_is_function_v<NtkSrc> )
+        {
+          static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
+          old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
+          break;
+        }
+        std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
+      } while ( false );
+    }
+  } );
+
+  ntk.foreach_po( [&]( auto po, auto index ) {
+    if ( remove_redundant_POs && ( dest.is_pi( dest.get_node( po ) ) || dest.is_constant( dest.get_node( po ) ) ) ) {
+      return;
+    }
+    const auto f = old_to_new[po];
+    typename NtkDest::signal g = ntk.is_complemented( po ) ? dest.create_not( old_to_new[po] ) : old_to_new[po];
+
+    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
+    {
+      if ( ntk.has_output_name( index ) )
+      {
+        dest.create_po( g, ntk.get_output_name( index ) );
+      }
+      else
+      {
+        dest.create_po( g );
+      }
+    }
+    else
+    {
+      dest.create_po( g );
+    }
+  } );
+
+  ntk.foreach_ri( [&]( auto ri, auto index ) {
+    typename NtkDest::signal g = ntk.is_complemented( ri ) ? dest.create_not( old_to_new[ri] ) : old_to_new[ri];
+
+    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
+    {
+      if ( ntk.has_output_name( index ) )
+      {
+        dest.create_ri( g, 0, ntk.get_output_name( index ) );
+      }
+      else
+      {
+        dest.create_ri( g );
+      }
+    }
+    else
+    {
+      dest.create_ri( g );
+    }
+  } );
+
+  return dest;
+}
+
+/*! \brief Cleans up dangling nodes.
+ *
+ * This method reconstructs a network and omits all dangling nodes.  The
+ * network types of the source and destination network are the same.
+ *
+   \verbatim embed:rst
+
+   .. note::
+
+      This method returns the cleaned up network as a return value.  It does
+      *not* modify the input network.
+   \endverbatim
+ *
+ * **Required network functions:**
+ * - `get_node`
+ * - `node_to_index`
+ * - `get_constant`
+ * - `create_pi`
+ * - `create_po`
+ * - `create_not`
+ * - `is_complemented`
+ * - `foreach_node`
+ * - `foreach_pi`
+ * - `foreach_po`
+ * - `clone_node`
+ * - `is_ci`
+ * - `is_constant`
+ */
+template<class NtkSrc, class NtkDest = NtkSrc>
+NtkDest cleanup_dangling_with_registers( NtkSrc const& ntk )
+{
+  static_assert( is_network_type_v<NtkSrc>, "NtkSrc is not a network type" );
+  static_assert( is_network_type_v<NtkDest>, "NtkDest is not a network type" );
+  static_assert( has_get_node_v<NtkSrc>, "NtkSrc does not implement the get_node method" );
+  static_assert( has_node_to_index_v<NtkSrc>, "NtkSrc does not implement the node_to_index method" );
+  static_assert( has_get_constant_v<NtkSrc>, "NtkSrc does not implement the get_constant method" );
+  static_assert( has_foreach_node_v<NtkSrc>, "NtkSrc does not implement the foreach_node method" );
+  static_assert( has_foreach_pi_v<NtkSrc>, "NtkSrc does not implement the foreach_pi method" );
+  static_assert( has_foreach_po_v<NtkSrc>, "NtkSrc does not implement the foreach_po method" );
+  static_assert( has_is_ci_v<NtkSrc>, "NtkSrc does not implement the is_ci method" );
+  static_assert( has_is_constant_v<NtkSrc>, "NtkSrc does not implement the is_constant method" );
+  static_assert( has_clone_node_v<NtkDest>, "NtkDest does not implement the clone_node method" );
+  static_assert( has_create_pi_v<NtkDest>, "NtkDest does not implement the create_pi method" );
+  static_assert( has_create_po_v<NtkDest>, "NtkDest does not implement the create_po method" );
+  static_assert( has_create_not_v<NtkDest>, "NtkDest does not implement the create_not method" );
+  static_assert( has_is_complemented_v<NtkSrc>, "NtkDest does not implement the is_complemented method" );
+
+  NtkDest dest;
+  if constexpr ( has_get_network_name_v<NtkSrc> && has_set_network_name_v<NtkDest> )
+  {
+    dest.set_network_name( ntk.get_network_name() );
+  }
+
+  node_map<signal<NtkDest>, NtkSrc> old_to_new( ntk );
+
+  std::vector<signal<NtkDest>> pis;
+  ntk.foreach_pi( [&]( auto n ) {
+    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
+    {
+      auto s = ntk.make_signal( n );
+      if ( ntk.has_name( s ) )
+      {
+        old_to_new[n] = dest.create_pi( ntk.get_name( s ) );
+      }
+      else
+      {
+        old_to_new[n] = dest.create_pi();
+      }
+    }
+    else
+    {
+      old_to_new[n] = dest.create_pi();
+    }
+  } );
+
+  ntk.foreach_register( [&]( std::pair<typename NtkSrc::signal, typename NtkSrc::node> reg ) {
+    typename NtkSrc::node ro = reg.second;
+    if constexpr ( has_has_name_v<NtkSrc> && has_get_name_v<NtkSrc> && has_has_name_v<NtkDest> && has_get_name_v<NtkDest> )
+    {
+      auto ros = ntk.make_signal( ro );
+      if ( ntk.has_name( ros ) )
+      {
+        old_to_new[ro] = dest.create_ro( ntk.get_name( ros ) );
+      }
+      else
+      {
+        old_to_new[ro] = dest.create_ro();
+      }
+    }
+    else
+    {
+      old_to_new[ro] = dest.create_ro();
+    }
+    dest._storage->latch_information[dest.get_node(old_to_new[ro])] = ntk._storage->latch_information[ro];
+  } );
+
+  old_to_new[ntk.get_constant( false )] = dest.get_constant( false );
+
+  if ( ntk.get_node( ntk.get_constant( true ) ) != ntk.get_node( ntk.get_constant( false ) ) )
+  {
+    old_to_new[ntk.get_constant( true )] = dest.get_constant( true );
+  }
+
+  /* foreach node in topological order */
+  topo_view topo{ntk};
+  topo.foreach_node( [&]( auto node ) {
+    if ( ntk.is_constant( node ) || ntk.is_ci( node ))
+      return;
+
+    /* collect children */
+    std::vector<signal<NtkDest>> children;
+    ntk.foreach_fanin( node, [&]( auto child, auto ) {
+      const auto f = old_to_new[child];
+      if ( ntk.is_complemented( child ) )
+      {
+        children.push_back( dest.create_not( f ) );
+      }
+      else
+      {
+        children.push_back( f );
+      }
+    } );
+    if constexpr ( std::is_same_v<NtkSrc, NtkDest> )
+    {
+      old_to_new[node] = dest.clone_node( ntk, node, children );
+    }
+    else
+    {
+      do
+      {
+        if constexpr ( has_is_and_v<NtkSrc> )
+        {
+          static_assert( has_create_and_v<NtkDest>, "NtkDest cannot create AND gates" );
+          if ( ntk.is_and( node ) )
+          {
+            old_to_new[node] = dest.create_and( children[0], children[1] );
+            break;
+          }
+        }
+        if constexpr ( has_is_or_v<NtkSrc> )
+        {
+          static_assert( has_create_or_v<NtkDest>, "NtkDest cannot create OR gates" );
+          if ( ntk.is_or( node ) )
+          {
+            old_to_new[node] = dest.create_or( children[0], children[1] );
+            break;
+          }
+        }
+        if constexpr ( has_is_xor_v<NtkSrc> )
+        {
+          static_assert( has_create_xor_v<NtkDest>, "NtkDest cannot create XOR gates" );
+          if ( ntk.is_xor( node ) )
+          {
+            old_to_new[node] = dest.create_xor( children[0], children[1] );
+            break;
+          }
+        }
+        if constexpr ( has_is_maj_v<NtkSrc> )
+        {
+          static_assert( has_create_maj_v<NtkDest>, "NtkDest cannot create MAJ gates" );
+          if ( ntk.is_maj( node ) )
+          {
+            old_to_new[node] = dest.create_maj( children[0], children[1], children[2] );
+            break;
+          }
+        }
+        if constexpr ( has_is_ite_v<NtkSrc> )
+        {
+          static_assert( has_create_ite_v<NtkDest>, "NtkDest cannot create ITE gates" );
+          if ( ntk.is_ite( node ) )
+          {
+            old_to_new[node] = dest.create_ite( children[0], children[1], children[2] );
+            break;
+          }
+        }
+        if constexpr ( has_is_xor3_v<NtkSrc> )
+        {
+          static_assert( has_create_xor3_v<NtkDest>, "NtkDest cannot create XOR3 gates" );
+          if ( ntk.is_xor3( node ) )
+          {
+            old_to_new[node] = dest.create_xor3( children[0], children[1], children[2] );
+            break;
+          }
+        }
+        if constexpr ( has_is_nary_and_v<NtkSrc> )
+        {
+          static_assert( has_create_nary_and_v<NtkDest>, "NtkDest cannot create n-ary AND gates" );
+          if ( ntk.is_nary_and( node ) )
+          {
+            old_to_new[node] = dest.create_nary_and( children );
+            break;
+          }
+        }
+        if constexpr ( has_is_nary_or_v<NtkSrc> )
+        {
+          static_assert( has_create_nary_or_v<NtkDest>, "NtkDest cannot create n-ary OR gates" );
+          if ( ntk.is_nary_or( node ) )
+          {
+            old_to_new[node] = dest.create_nary_or( children );
+            break;
+          }
+        }
+        if constexpr ( has_is_nary_xor_v<NtkSrc> )
+        {
+          static_assert( has_create_nary_xor_v<NtkDest>, "NtkDest cannot create n-ary XOR gates" );
+          if ( ntk.is_nary_xor( node ) )
+          {
+            old_to_new[node] = dest.create_nary_xor( children );
+            break;
+          }
+        }
+        if constexpr ( has_is_function_v<NtkSrc> )
+        {
+          static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
+          old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
+          break;
+        }
+        std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
+      } while ( false );
+    }
+  } );
+
+  ntk.foreach_po( [&]( auto po, auto index ) {
+    const auto f = old_to_new[po];
+    typename NtkDest::signal g = ntk.is_complemented( po ) ? dest.create_not( old_to_new[po] ) : old_to_new[po];
+
+    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
+    {
+      if ( ntk.has_output_name( index ) )
+      {
+        dest.create_po( g, ntk.get_output_name( index ) );
+      }
+      else
+      {
+        dest.create_po( g );
+      }
+    }
+    else
+    {
+      dest.create_po( g );
+    }
+  } );
+
+  ntk.foreach_ri( [&]( auto ri, auto index ) {
+    // typename NtkSrc::signal ri = reg.first;
+    // typename NtkSrc::node ro = reg.second;
+    typename NtkDest::signal g = ntk.is_complemented( ri ) ? dest.create_not( old_to_new[ri] ) : old_to_new[ri];
+
+    if constexpr ( has_has_output_name_v<NtkSrc> && has_get_output_name_v<NtkSrc> )
+    {
+      if ( ntk.has_output_name( index ) )
+      {
+        dest.create_ri( g, 0, ntk.get_output_name( index ) );
+      }
+      else
+      {
+        dest.create_ri( g );
+      }
+    }
+    else
+    {
+      dest.create_ri( g );
+    }
+  } );
 
   return dest;
 }
@@ -318,7 +792,7 @@ template<class NtkSrc, class NtkDest = NtkSrc>
  * - `node_function`
  */
 template<class Ntk>
-[[nodiscard]] Ntk cleanup_luts( Ntk const& ntk )
+Ntk cleanup_luts( Ntk const& ntk )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
@@ -338,11 +812,31 @@ template<class Ntk>
   static_assert( has_node_function_v<Ntk>, "Ntk does not implement the node_function method" );
 
   Ntk dest;
+  if constexpr ( has_get_network_name_v<Ntk> && has_set_network_name_v<Ntk> )
+  {
+    dest.set_network_name( ntk.get_network_name() );
+  }
+
   node_map<signal<Ntk>, Ntk> old_to_new( ntk );
 
   // PIs and constants
   ntk.foreach_pi( [&]( auto const& n ) {
-    old_to_new[n] = dest.create_pi();
+    if constexpr ( has_has_name_v<Ntk> && has_get_name_v<Ntk>)
+    {
+      auto s = ntk.make_signal( n );
+      if ( ntk.has_name( s ) )
+      {
+        old_to_new[n] = dest.create_pi( ntk.get_name( s ) );
+      }
+      else
+      {
+        old_to_new[n] = dest.create_pi();
+      }
+    }
+    else
+    {
+      old_to_new[n] = dest.create_pi();
+    }
   } );
   old_to_new[ntk.get_constant( false )] = dest.get_constant( false );
   if ( ntk.get_node( ntk.get_constant( true ) ) != ntk.get_node( ntk.get_constant( false ) ) )
@@ -410,9 +904,24 @@ template<class Ntk>
   } );
 
   // POs
-  ntk.foreach_po( [&]( auto const& f ) {
+  ntk.foreach_po( [&]( auto const& f, auto i ) {
     auto const& new_f = old_to_new[f];
-    dest.create_po( ntk.is_complemented( f ) ? dest.create_not( new_f ) : new_f );
+    auto s = ntk.is_complemented( f ) ? dest.create_not( new_f ) : new_f;
+    if constexpr ( has_has_output_name_v<Ntk> && has_get_output_name_v<Ntk> )
+    {
+      if ( ntk.has_output_name( i ) )
+      {
+        dest.create_po( s, ntk.get_output_name( i ) );
+      }
+      else
+      {
+        dest.create_po( s );
+      }
+    }
+    else
+    {
+      dest.create_po( s );
+    }
   });
 
   return dest;

--- a/include/mockturtle/io/write_dot.hpp
+++ b/include/mockturtle/io/write_dot.hpp
@@ -68,7 +68,7 @@ public: /* callbacks */
     {
       return "box";
     }
-    else if ( ntk.is_pi( n ) )
+    else if ( ntk.is_ci( n ) )
     {
       return "triangle";
     }
@@ -306,7 +306,7 @@ public:
  *
  * **Required network functions:**
  * - is_constant
- * - is_pi
+ * - is_ci
  * - foreach_node
  * - foreach_fanin
  * - foreach_po
@@ -319,7 +319,7 @@ void write_dot( Ntk const& ntk, std::ostream& os, Drawer const& drawer = {} )
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
-  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
   static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
   static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
@@ -334,7 +334,7 @@ void write_dot( Ntk const& ntk, std::ostream& os, Drawer const& drawer = {} )
                           drawer.node_label( ntk, n ),
                           drawer.node_shape( ntk, n ),
                           drawer.node_fillcolor( ntk, n ) );
-    if ( !ntk.is_constant( n ) && !ntk.is_pi( n ) )
+    if ( !ntk.is_constant( n ) && !ntk.is_ci( n ) )
     {
       ntk.foreach_fanin( n, [&]( auto const& f ) {
         if ( !drawer.draw_signal( ntk, n, f ) )
@@ -382,7 +382,7 @@ void write_dot( Ntk const& ntk, std::ostream& os, Drawer const& drawer = {} )
  *
  * **Required network functions:**
  * - is_constant
- * - is_pi
+ * - is_ci
  * - foreach_node
  * - foreach_fanin
  * - foreach_po

--- a/include/mockturtle/networks/abstract_xag.hpp
+++ b/include/mockturtle/networks/abstract_xag.hpp
@@ -217,6 +217,11 @@ public:
     return n > 0 && _storage->nodes[n].fanin_size == 0u;
   }
 
+  bool is_ci( node const& n ) const
+  {
+      return is_pi( n );
+  }
+
   bool constant_value( node const& n ) const
   {
     (void)n;

--- a/include/mockturtle/views/depth_view.hpp
+++ b/include/mockturtle/views/depth_view.hpp
@@ -255,7 +255,7 @@ private:
     {
       return _levels[n] = 0;
     }
-    if ( this->is_pi( n ) )
+    if ( this->is_ci( n ) )
     {
       assert( !_ps.pi_cost || _cost_fn( *this, n ) >= 1 );
       return _levels[n] = _ps.pi_cost ? _cost_fn( *this, n ) - 1 : 0;
@@ -277,7 +277,7 @@ private:
   void compute_levels()
   {
     _depth = 0;
-    this->foreach_po( [&]( auto const& f ) {
+    this->foreach_co( [&]( auto const& f ) {
       auto clevel = compute_levels( this->get_node( f ) );
       if ( _ps.count_complements && this->is_complemented( f ) )
       {
@@ -286,7 +286,7 @@ private:
       _depth = std::max( _depth, clevel );
     } );
 
-    this->foreach_po( [&]( auto const& f ) {
+    this->foreach_co( [&]( auto const& f ) {
       const auto n = this->get_node( f );
       if ( _levels[n] == _depth )
       {
@@ -298,7 +298,7 @@ private:
   void set_critical_path( node const& n )
   {
     _crit_path[n] = true;
-    if ( !this->is_constant( n ) && !( _ps.pi_cost && this->is_pi( n ) ) )
+    if ( !this->is_constant( n ) && !( _ps.pi_cost && this->is_ci( n ) ) )
     {
       const auto lvl = _levels[n];
       this->foreach_fanin( n, [&]( auto const& f ) {

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -62,19 +62,10 @@ public:
 
   names_view<Ntk>& operator=( names_view<Ntk> const& named_ntk )
   {
-    std::map<signal, std::string> new_signal_names;
-    std::vector<signal> current_pis;
-    Ntk::foreach_pi( [this, &current_pis]( auto const& n ) {
-      current_pis.emplace_back( Ntk::make_signal( n ) );
-    } );
-    named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
-      if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
-        new_signal_names[named_ntk.make_signal( n )] = it->second;
-    } );
-
     Ntk::operator=( named_ntk );
-    _signal_names = new_signal_names;
+    _signal_names = named_ntk._signal_names;
     _network_name = named_ntk._network_name;
+    _output_names = named_ntk._output_names;
     return *this;
   }
 
@@ -88,14 +79,24 @@ public:
     return s;
   }
 
-  void create_po( signal const& s, std::string const& name = {} )
+  uint32_t create_pi( signal const& s, std::string const& name = {} )
   {
-    const auto index = Ntk::num_pos();
-    Ntk::create_po( s, name );
+    const auto index = Ntk::create_pi( s, name );
     if ( !name.empty() )
     {
       set_output_name( index, name );
     }
+    return index;
+  }
+
+  uint32_t create_po( signal const& s, std::string const& name = {} )
+  {
+    const auto index = Ntk::create_po( s, name );
+    if ( !name.empty() )
+    {
+      set_output_name( index, name );
+    }
+    return index;
   }
 
   template<typename StrType = const char*>

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -45,17 +45,17 @@ void test_create_names_view()
   CHECK( !named_ntk.has_name( b ) );
   CHECK( !named_ntk.has_name( c ) );
   CHECK( !named_ntk.has_output_name( 0 ) );
-  
+
   named_ntk.set_name( a, "a" );
   named_ntk.set_name( b, "b" );
   named_ntk.set_name( c, "c" );
   named_ntk.set_output_name( 0, "f" );
-  
+
   CHECK( named_ntk.has_name( a ) );
   CHECK( named_ntk.has_name( b ) );
   CHECK( named_ntk.has_name( c ) );
   CHECK( named_ntk.has_output_name( 0 ) );
-  
+
   CHECK( named_ntk.get_name( a ) == "a" );
   CHECK( named_ntk.get_name( b ) == "b" );
   CHECK( named_ntk.get_name( c ) == "c" );
@@ -83,7 +83,7 @@ void test_copy_names_view()
   auto const f = ntk.create_and( t1, t2 );
   ntk.create_po( f );
 
-  names_view<Ntk> named_ntk;
+  names_view<Ntk> named_ntk(ntk);
   named_ntk.set_name( a, "a" );
   named_ntk.set_name( b, "b" );
   named_ntk.set_name( c, "c" );
@@ -113,4 +113,35 @@ TEST_CASE( "copy names", "[names_view]" )
   test_copy_names_view<xag_network>();
   test_copy_names_view<xmg_network>();
   test_copy_names_view<klut_network>();
+}
+
+TEST_CASE( "register names", "[names_view]" )
+{
+  names_view<aig_network> ntk;
+  ntk.set_network_name( "network" );
+  const auto pi = ntk.create_pi();
+  ntk.set_name(pi, "pi");
+  const auto ro = ntk.create_ro();
+  ntk.set_name(ro, "ro");
+  const auto gate = ntk.create_and( pi, ro );
+  ntk.set_name(gate, "gate");
+  const uint32_t ri = ntk.create_ri( gate, 1 );
+  ntk._storage->latch_information[ntk.get_node(ro)].control = "s";
+  ntk._storage->latch_information[ntk.get_node(ro)].init = 1;
+  ntk._storage->latch_information[ntk.get_node(ro)].type = "t";
+  ntk.set_output_name(ri, "ri");
+  const uint32_t po = ntk.create_po( ntk.create_not( gate ) );
+  ntk.set_output_name(po, "po");
+
+  CHECK( ntk.has_name( pi ) );
+  CHECK( ntk.get_name( pi ) == "pi" );
+  CHECK( ntk.has_name( ro ) );
+  CHECK( ntk.get_name( ro ) == "ro" );
+  CHECK( ntk.has_name( gate ) );
+  CHECK( ntk.get_name( gate ) == "gate" );
+  CHECK( ntk.get_network_name() == "network" );
+  CHECK( ntk.has_output_name( ri ) );
+  CHECK( ntk.get_output_name( ri ) == "ri" );
+  CHECK( ntk.has_output_name( po ) );
+  CHECK( ntk.get_output_name( po ) == "po" );
 }


### PR DESCRIPTION
This fixes several instances where only check is being made for PI, ignoring the other CI cases. Cleanup fails to handle registers at all. The two cleanup_dangling functions are split into separate copies for backwards compatibility.