### PR TITLE
Write verilog with binding and names

### DIFF
--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -1777,6 +1777,36 @@ template<class Ntk>
 inline constexpr bool has_foreach_cell_fanin_v = has_foreach_cell_fanin<Ntk>::value;
 #pragma endregion
 
+#pragma region has_has_binding
+template<class Ntk, class = void>
+struct has_has_binding : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_has_binding<Ntk, std::void_t<decltype( std::declval<Ntk>().has_binding( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_has_binding_v = has_has_binding<Ntk>::value;
+#pragma endregion
+
+#pragma region has_get_binding_index
+template<class Ntk, class = void>
+struct has_get_binding_index : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_get_binding_index<Ntk, std::void_t<decltype( std::declval<Ntk>().get_binding_index( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_get_binding_index_v = has_get_binding_index<Ntk>::value;
+#pragma endregion
+
 #pragma region has_clear_values
 template<class Ntk, class = void>
 struct has_clear_values : std::false_type

--- a/include/mockturtle/views/binding_view.hpp
+++ b/include/mockturtle/views/binding_view.hpp
@@ -82,7 +82,7 @@ namespace mockturtle
       res.report_gates_usage();
 
       // write the mapped network in verilog
-      write_verilog( res, "file.v" );
+      write_verilog_with_binding( res, "file.v" );
    \endverbatim
  */
 template<class Ntk>
@@ -149,17 +149,17 @@ public:
     _bindings.erase( n );
   }
 
-  const gate& get_binding( node const& n) const
+  const gate& get_binding( node const& n ) const
   {
     return _library[_bindings[n]];
   }
 
-  bool has_binding( node const& n) const
+  bool has_binding( node const& n ) const
   {
     return _bindings.has( n );
   }
 
-  unsigned int get_binding_index( node const& n) const
+  unsigned int get_binding_index( node const& n ) const
   {
     return _bindings[n];
   }

--- a/test/io/write_verilog.cpp
+++ b/test/io/write_verilog.cpp
@@ -212,7 +212,7 @@ TEST_CASE( "write mapped network into Verilog file", "[write_verilog]" )
   klut.add_binding( klut.get_node( f2 ), 2 );
 
   std::ostringstream out;
-  write_verilog( klut, out );
+  write_verilog_with_binding( klut, out );
 
   CHECK( out.str() == "module top( x0 , x1 , x2 , y0 , y1 , y2 , y3 );\n"
                       "  input x0 , x1 , x2 ;\n"
@@ -265,7 +265,7 @@ TEST_CASE( "write mapped network with multiple driven POs and register names int
   write_verilog_params ps;
   ps.input_names = {{"ref", 1u}, {"data", 2u}};
   ps.output_names = {{"y", 4u}};
-  write_verilog( klut, out, ps );
+  write_verilog_with_binding( klut, out, ps );
 
   CHECK( out.str() == "module top( ref , data , y );\n"
                       "  input [0:0] ref ;\n"


### PR DESCRIPTION
- Change the specialized version of `write_verilog` with `binding_view` into `write_verilog_with_binding` to correctly support PI/PO names.
- Make `write_verilog_params::module_name` an optional and use network's name when network has a non-empty name and this parameter is not specified.