### PR TITLE
Remove the "name" argument in PI/PO creation interfaces

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Change Log
 v0.4 (not yet released)
 -----------------------
 
+* Network interface:
+    - Remove the "name" argument in `create_pi`, `create_po`, `create_ri`, and `create_ro`. Names should be set using the `names_view` APIs. `#559 <https://github.com/lsils/mockturtle/pull/559>`_
 
 v0.3 (July 12, 2022)
 --------------------

--- a/docs/utils/util_functions.rst
+++ b/docs/utils/util_functions.rst
@@ -9,3 +9,14 @@ Manipulate windows with network data types
 .. doxygenfunction:: mockturtle::clone_subnetwork( Ntk const&, std::vector<typename Ntk::node> const&, std::vector<typename Ntk::signal> const&, std::vector<typename Ntk::node> const&, SubNtk& )
 
 .. doxygenfunction:: mockturtle::insert_ntk( Ntk&, BeginIter, EndIter, SubNtk const&, Fn&& )
+
+Restore network and PI/PO names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Header:** ``mockturtle/utils/name_utils.hpp``
+
+.. doxygenfunction:: mockturtle::restore_network_name( const NtkSrc& ntk_src, NtkDest& ntk_dest )
+
+.. doxygenfunction:: mockturtle::restore_names( const NtkSrc& ntk_src, NtkDest& ntk_dest, node_map<signal<NtkDest>, NtkSrc>& old2new )
+
+.. doxygenfunction:: mockturtle::restore_pio_names_by_order( const NtkSrc& ntk_src, NtkDest& ntk_dest )

--- a/include/mockturtle/interface.hpp
+++ b/include/mockturtle/interface.hpp
@@ -132,10 +132,8 @@ public:
    *
    * Each created primary input is stored in a node and contributes to the size
    * of the network.
-   *
-   * \param name Optional name for the input
    */
-  signal create_pi( std::string const& name = std::string() );
+  signal create_pi();
 
   /*! \brief Creates a primary output in the network.
    *
@@ -145,9 +143,8 @@ public:
    * point to the same signal.
    *
    * \param s Signal that drives the created primary output
-   * \param name Optional name for the output
    */
-  void create_po( signal const& s, std::string const& name = std::string() );
+  void create_po( signal const& s );
 
   /*! \brief Creates a register output in the network.
    *
@@ -162,10 +159,8 @@ public:
    * pairs; they are associated to each other by index, i.e., the
    * first created register output corresponds to the first created
    * register input, etc.
-   *
-   * \param name Optional name for the register output
    */
-  signal create_ro( std::string const& name = std::string() );
+  signal create_ro();
 
   /*! \brief Creates a register input in the network.
    *
@@ -184,10 +179,10 @@ public:
    * first created register output corresponds to the first created
    * register input, etc.
    *
-   * \param s Signal that drives the created primary output
-   * \param name Optional name for the output
+   * \param s Signal that drives the created register input
+   * \param reset Reset value
    */
-  void create_ri( signal const& s, std::string const& name = std::string() );
+  void create_ri( signal const& s, int8_t reset );
 
   /*! \brief Checks whether the network is combinational.
    *

--- a/include/mockturtle/io/bench_reader.hpp
+++ b/include/mockturtle/io/bench_reader.hpp
@@ -85,17 +85,25 @@ public:
   {
     for ( auto const& o : outputs )
     {
-      _ntk.create_po( signals.at( o ), o );
+      _ntk.create_po( signals[o] );
     }
   }
 
   void on_input( const std::string& name ) const override
   {
-    signals[name] = _ntk.create_pi( name );
+    signals[name] = _ntk.create_pi();
+    if constexpr ( has_set_name_v<Ntk> )
+    {
+      _ntk.set_name( signals[name], name );
+    }
   }
 
   void on_output( const std::string& name ) const override
   {
+    if constexpr ( has_set_output_name_v<Ntk> )
+    {
+      _ntk.set_output_name( outputs.size(), name );
+    }
     outputs.emplace_back( name );
   }
 

--- a/include/mockturtle/io/blif_reader.hpp
+++ b/include/mockturtle/io/blif_reader.hpp
@@ -85,7 +85,7 @@ public:
   {
     for ( auto const& o : outputs )
     {
-      ntk_.create_po( signals[o], o );
+      ntk_.create_po( signals[o] );
     }
 
     for ( auto const& latch : latches )
@@ -110,7 +110,7 @@ public:
 
   virtual void on_input( const std::string& name ) const override
   {
-    signals[name] = ntk_.create_pi( name );
+    signals[name] = ntk_.create_pi();
     if constexpr ( has_set_name_v<Ntk> )
     {
       ntk_.set_name( signals[name], name );
@@ -128,7 +128,7 @@ public:
 
   virtual void on_latch( const std::string& input, const std::string& output, const std::optional<latch_type>& l_type, const std::optional<std::string>& control, const std::optional<latch_init_value>& reset ) const override
   {
-    signals[output] = ntk_.create_ro( output );
+    signals[output] = ntk_.create_ro();
     if constexpr ( has_set_name_v<Ntk> && has_set_output_name_v<Ntk> )
     {
       ntk_.set_name( signals[output], output );

--- a/include/mockturtle/io/verilog_reader.hpp
+++ b/include/mockturtle/io/verilog_reader.hpp
@@ -116,7 +116,7 @@ public:
     {
       if ( size.empty() )
       {
-        signals_[name] = ntk_.create_pi( name );
+        signals_[name] = ntk_.create_pi();
         input_names_.emplace_back( name, 1u );
         if constexpr ( has_set_name_v<Ntk> )
         {
@@ -130,7 +130,7 @@ public:
         for ( auto i = 0u; i < length; ++i )
         {
           const auto sname = fmt::format( "{}[{}]", name, i );
-          word.push_back( ntk_.create_pi( sname ) );
+          word.push_back( ntk_.create_pi() );
           signals_[sname] = word.back();
           if constexpr ( has_set_name_v<Ntk> )
           {
@@ -399,7 +399,7 @@ public:
 
     for ( auto const& o : outputs_ )
     {
-      ntk_.create_po( signals_[o], o );
+      ntk_.create_po( signals_[o] );
     }
 
     if constexpr ( has_set_output_name_v<Ntk> )

--- a/include/mockturtle/networks/abstract_xag.hpp
+++ b/include/mockturtle/networks/abstract_xag.hpp
@@ -180,20 +180,16 @@ public:
     return {0, value};
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index = static_cast<uint32_t>( _storage->nodes.size() );
     _storage->nodes.emplace_back();
     _storage->inputs.emplace_back( index );
     return {index, 0};
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].fanout_size++;
     auto const po_index = static_cast<uint32_t>( _storage->outputs.size() );

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -204,10 +204,8 @@ public:
     return {0, static_cast<uint64_t>( value ? 1 : 0 )};
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = _storage->inputs.size();
@@ -216,10 +214,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f)
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const po_index = _storage->outputs.size();
@@ -228,10 +224,8 @@ public:
     return static_cast<uint32_t>( po_index );
   }
 
-  signal create_ro( std::string const& name = std::string() )
+  signal create_ro()
   {
-    (void)name;
-
     auto const index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = _storage->inputs.size();
@@ -239,10 +233,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_ri( signal const& f, int8_t reset = 0, std::string const& name = std::string() )
+  uint32_t create_ri( signal const& f, int8_t reset = 0 )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const ri_index = _storage->outputs.size();

--- a/include/mockturtle/networks/aqfp.hpp
+++ b/include/mockturtle/networks/aqfp.hpp
@@ -182,10 +182,8 @@ public:
     return { 0, static_cast<uint64_t>( value ? 1 : 0 ) };
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children.resize( 3u );
@@ -195,10 +193,8 @@ public:
     return { index, 0 };
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const po_index = static_cast<uint32_t>( _storage->outputs.size() );
@@ -207,10 +203,8 @@ public:
     return po_index;
   }
 
-  signal create_ro( std::string const& name = std::string() )
+  signal create_ro()
   {
-    (void)name;
-
     auto const index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children.resize( 3u );
@@ -219,10 +213,8 @@ public:
     return { index, 0 };
   }
 
-  uint32_t create_ri( signal const& f, int8_t reset = 0, std::string const& name = std::string() )
+  uint32_t create_ri( signal const& f, int8_t reset = 0 )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const ri_index = static_cast<uint32_t>( _storage->outputs.size() );

--- a/include/mockturtle/networks/cover.hpp
+++ b/include/mockturtle/networks/cover.hpp
@@ -199,10 +199,8 @@ public:
     return value ? 1 : 0;
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index_node = _storage->nodes.size();
     std::vector<kitty::cube> cube_I{ kitty::cube( "1" ) };
     const auto index_covers = _storage->data.insert( std::make_pair( cube_I, true ) );
@@ -218,10 +216,8 @@ public:
     return index_node;
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f].data[0].h1++;
 
@@ -231,10 +227,8 @@ public:
 
     return po_index;
   }
-  signal create_ro( std::string const& name = std::string() )
+  signal create_ro()
   {
-    (void)name;
-
     auto const index = static_cast<uint32_t>( _storage->nodes.size() );
     _storage->nodes.emplace_back();
     _storage->inputs.emplace_back( index );
@@ -242,10 +236,8 @@ public:
     return index;
   }
 
-  uint32_t create_ri( signal const& f, int8_t reset = 0, std::string const& name = std::string() )
+  uint32_t create_ri( signal const& f, int8_t reset = 0 )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f].data[0].h1++;
     auto const ri_index = static_cast<uint32_t>( _storage->outputs.size() );

--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -174,10 +174,8 @@ public:
     return value ? 1 : 0;
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index = _storage->nodes.size();
     _storage->nodes.emplace_back();
     _storage->inputs.emplace_back( index );
@@ -186,10 +184,8 @@ public:
     return index;
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f].data[0].h1++;
 
@@ -199,10 +195,8 @@ public:
     return po_index;
   }
 
-  signal create_ro( std::string const& name = std::string() )
+  signal create_ro()
   {
-    (void)name;
-
     auto const index = static_cast<uint32_t>( _storage->nodes.size() );
     _storage->nodes.emplace_back();
     _storage->inputs.emplace_back( index );
@@ -210,10 +204,8 @@ public:
     return index;
   }
 
-  uint32_t create_ri( signal const& f, int8_t reset = 0, std::string const& name = std::string() )
+  uint32_t create_ri( signal const& f, int8_t reset = 0 )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f].data[0].h1++;
     auto const ri_index = static_cast<uint32_t>( _storage->outputs.size() );

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -188,10 +188,8 @@ public:
     return {0, static_cast<uint64_t>( value ? 1 : 0 )};
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = node.children[2].data = _storage->inputs.size();
@@ -200,10 +198,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const po_index = static_cast<uint32_t>( _storage->outputs.size() );
@@ -212,10 +208,8 @@ public:
     return po_index;
   }
 
-  signal create_ro( std::string const& name = std::string() )
+  signal create_ro()
   {
-    (void)name;
-
     auto const index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = node.children[2].data = _storage->inputs.size();
@@ -223,10 +217,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_ri( signal const& f, int8_t reset = 0, std::string const& name = std::string() )
+  uint32_t create_ri( signal const& f, int8_t reset = 0 )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const ri_index = static_cast<uint32_t>( _storage->outputs.size() );

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -203,10 +203,8 @@ public:
     return {0, static_cast<uint64_t>( value ? 1 : 0 )};
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = _storage->inputs.size();
@@ -215,10 +213,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const po_index = static_cast<uint32_t>( _storage->outputs.size() );
@@ -227,10 +223,8 @@ public:
     return po_index;
   }
 
-  signal create_ro( std::string const& name = std::string() )
+  signal create_ro()
   {
-    (void)name;
-
     auto const index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = _storage->inputs.size();
@@ -238,10 +232,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_ri( signal const& f, int8_t reset = 0, std::string const& name = std::string() )
+  uint32_t create_ri( signal const& f, int8_t reset = 0 )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const ri_index = static_cast<uint32_t>( _storage->outputs.size() );

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -187,10 +187,8 @@ public:
     return {0, static_cast<size_t>( value ? 1 : 0 )};
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    (void)name;
-
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = node.children[2].data = _storage->inputs.size();
@@ -199,10 +197,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
 
@@ -213,10 +209,8 @@ public:
     return po_index; 
   }
 
-  signal create_ro( std::string const& name = std::string() )
+  signal create_ro()
   {
-    (void)name;
-
     auto const index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = node.children[2].data = _storage->inputs.size();
@@ -224,10 +218,8 @@ public:
     return {index, 0};
   }
 
-  uint32_t create_ri( signal const& f, int8_t reset = 0, std::string const& name = std::string() )
+  uint32_t create_ri( signal const& f, int8_t reset = 0 )
   {
-    (void)name;
-
     /* increase ref-count to children */
     _storage->nodes[f.index].data[0].h1++;
     auto const ri_index = static_cast<uint32_t>( _storage->outputs.size() );

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -133,7 +133,7 @@ struct has_create_pi : std::false_type
 };
 
 template<class Ntk>
-struct has_create_pi<Ntk, std::void_t<decltype( std::declval<Ntk>().create_pi( std::string() ) )>> : std::true_type
+struct has_create_pi<Ntk, std::void_t<decltype( std::declval<Ntk>().create_pi() )>> : std::true_type
 {
 };
 
@@ -148,7 +148,7 @@ struct has_create_po : std::false_type
 };
 
 template<class Ntk>
-struct has_create_po<Ntk, std::void_t<decltype( std::declval<Ntk>().create_po( std::declval<signal<Ntk>>(), std::string() ) )>> : std::true_type
+struct has_create_po<Ntk, std::void_t<decltype( std::declval<Ntk>().create_po( std::declval<signal<Ntk>>() ) )>> : std::true_type
 {
 };
 
@@ -163,7 +163,7 @@ struct has_create_ro : std::false_type
 };
 
 template<class Ntk>
-struct has_create_ro<Ntk, std::void_t<decltype( std::declval<Ntk>().create_ro( std::string() ) )>> : std::true_type
+struct has_create_ro<Ntk, std::void_t<decltype( std::declval<Ntk>().create_ro() )>> : std::true_type
 {
 };
 
@@ -178,7 +178,7 @@ struct has_create_ri : std::false_type
 };
 
 template<class Ntk>
-struct has_create_ri<Ntk, std::void_t<decltype( std::declval<Ntk>().create_ri( std::declval<signal<Ntk>>(), int8_t(), std::string() ) )>> : std::true_type
+struct has_create_ri<Ntk, std::void_t<decltype( std::declval<Ntk>().create_ri( std::declval<signal<Ntk>>(), int8_t() ) )>> : std::true_type
 {
 };
 

--- a/include/mockturtle/views/cnf_view.hpp
+++ b/include/mockturtle/views/cnf_view.hpp
@@ -284,9 +284,9 @@ public:
     }
   }
 
-  signal create_pi( std::string const& name = std::string() )
+  signal create_pi()
   {
-    const auto f = Ntk::create_pi( name );
+    const auto f = Ntk::create_pi();
 
     const auto v = solver_.add_variable();
 

--- a/include/mockturtle/views/fanout_limit_view.hpp
+++ b/include/mockturtle/views/fanout_limit_view.hpp
@@ -60,15 +60,15 @@ public:
     assert( ps.fanout_limit > 0u );
   }
 
-  uint32_t create_po( signal const& f, std::string const& name = std::string() )
+  uint32_t create_po( signal const& f )
   {
     if ( Ntk::is_maj( Ntk::get_node( f ) ) && Ntk::fanout_size( Ntk::get_node( f ) ) + 1 > ps.fanout_limit )
     {
-      return Ntk::create_po( replicate_node( f ), name );
+      return Ntk::create_po( replicate_node( f ) );
     }
     else
     {
-      return Ntk::create_po( f, name );
+      return Ntk::create_po( f );
     }
   }
 

--- a/include/mockturtle/views/immutable_view.hpp
+++ b/include/mockturtle/views/immutable_view.hpp
@@ -62,8 +62,10 @@ public:
   {
   }
 
-  signal create_pi( std::string const& name = {} ) = delete;
-  void create_po( signal const& s, std::string const& name = {} ) = delete;
+  signal create_pi() = delete;
+  void create_po( signal const& s ) = delete;
+  signal create_ro() = delete;
+  void create_ri( signal const& s, int8_t reset = 0 ) = delete;
   signal create_buf( signal const& f ) = delete;
   signal create_not( signal const& f ) = delete;
   signal create_and( signal const& f, signal const& g ) = delete;

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -80,7 +80,7 @@ public:
 
   signal create_pi( std::string const& name = {} )
   {
-    const auto s = Ntk::create_pi( name );
+    const auto s = Ntk::create_pi();
     if ( !name.empty() )
     {
       set_name( s, name );
@@ -91,7 +91,7 @@ public:
   void create_po( signal const& s, std::string const& name = {} )
   {
     const auto index = Ntk::num_pos();
-    Ntk::create_po( s, name );
+    Ntk::create_po( s );
     if ( !name.empty() )
     {
       set_output_name( index, name );

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -1,5 +1,5 @@
 /* mockturtle: C++ logic network library
- * Copyright (C) 2018-2021  EPFL
+ * Copyright (C) 2018-2022  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -78,6 +78,10 @@ public:
     return *this;
   }
 
+  /*! \brief Creates a primary input and set its name.
+   *
+   * \param name Name of the created primary input
+   */
   signal create_pi( std::string const& name = {} )
   {
     const auto s = Ntk::create_pi();
@@ -88,6 +92,10 @@ public:
     return s;
   }
 
+  /*! \brief Creates a primary output and set its name.
+   *
+   * \param name Name of the created primary output
+   */
   void create_po( signal const& s, std::string const& name = {} )
   {
     const auto index = Ntk::num_pos();
@@ -98,42 +106,90 @@ public:
     }
   }
 
+  /*! \brief Sets network name.
+   *
+   * \param name Name of the network
+   */
   template<typename StrType = const char*>
   void set_network_name( StrType name ) noexcept
   {
     _network_name = name;
   }
 
+  /*! \brief Gets network name.
+   */
   std::string get_network_name() const noexcept
   {
     return _network_name;
   }
 
+  /*! \brief Checks if a signal has a name.
+   *
+   * Note that complemented signals may have different names.
+   *
+   * \param s Signal to be checked
+   * \return Whether the signal has a name in record
+   */
   bool has_name( signal const& s ) const
   {
     return ( _signal_names.find( s ) != _signal_names.end() );
   }
 
+  /*! \brief Sets the name for a signal.
+   *
+   * Note that names are set separately for complemented signals.
+   *
+   * \param s Signal to be set a name
+   * \param name Name of the signal
+   */
   void set_name( signal const& s, std::string const& name )
   {
     _signal_names[s] = name;
   }
 
+  /*! \brief Gets signal name.
+   *
+   * Note that complemented signals may have different names.
+   *
+   * \param s Signal to be queried
+   * \return Name of the signal
+   */
   std::string get_name( signal const& s ) const
   {
     return _signal_names.at( s );
   }
 
+  /*! \brief Checks if a primary output has a name.
+   *
+   * \param index Index of the primary output to be checked
+   * \return Whether the primary output has a name in record
+   */
   bool has_output_name( uint32_t index ) const
   {
     return ( _output_names.find( index ) != _output_names.end() );
   }
 
+  /*! \brief Sets the name for a primary output.
+   *
+   * Note that even if two primary outputs are driven by
+   * the same signal, they may have different names.
+   *
+   * \param index Index of the primary output to set a name
+   * \param name Name of the primary output
+   */
   void set_output_name( uint32_t index, std::string const& name )
   {
     _output_names[index] = name;
   }
 
+  /*! \brief Gets the name of a primary output.
+   *
+   * Note that even if two primary outputs are driven by
+   * the same signal, they may have different names.
+   *
+   * \param index Index of the primary output to be queried
+   * \return Name of the primary output
+   */
   std::string get_output_name( uint32_t index ) const
   {
     return _output_names.at( index );

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -94,6 +94,7 @@ public:
 
   /*! \brief Creates a primary output and set its name.
    *
+   * \param s Signal that drives the created primary output
    * \param name Name of the created primary output
    */
   void create_po( signal const& s, std::string const& name = {} )
@@ -117,6 +118,8 @@ public:
   }
 
   /*! \brief Gets network name.
+   *
+   * \return Network name
    */
   std::string get_network_name() const noexcept
   {

--- a/test/generators/modular_arithmetic.cpp
+++ b/test/generators/modular_arithmetic.cpp
@@ -374,6 +374,6 @@ TEST_CASE( "10-bit constant multiplication by 661", "[modular_arithmetic]" )
   for ( auto i = 0u; i < 100u; ++i )
   {
     const auto v = dist( gen );
-    CHECK( to_int( simulate<bool>( xag, input_word_simulator( v ) ) ) == ( ( 661 * v ) % 1024 ) );
+    CHECK( to_int( simulate<bool>( xag, input_word_simulator( v ) ) ) == uint64_t( ( 661 * v ) % 1024 ) );
   }
 }


### PR DESCRIPTION
Finally addresses the proposal mentioned in #468.
The API functions `create_pi`, `create_po`, `create_ri` and `create_ro` do not accept a name string anymore.
Signal names should always be set using `names_view`, either using `set_name` and `set_output_name`, or passing the name in `create_pi` and `create_po`.