### PR TITLE
Additions to crossed network types

### DIFF
--- a/include/mockturtle/algorithms/cleanup.hpp
+++ b/include/mockturtle/algorithms/cleanup.hpp
@@ -576,7 +576,7 @@ template<class NtkSrc, class NtkDest = NtkSrc>
   detail::clone_inputs( ntk, dest, cis, remove_dangling_PIs );
 
   node_map<signal<NtkDest>, NtkSrc> old_to_new( ntk );
-  if constexpr ( std::is_same_v<typename NtkSrc::base_type, crossed_klut_network> )
+  if constexpr ( is_crossed_network_type_v<NtkSrc> )
   {
     detail::cleanup_dangling_with_crossings_impl( ntk, dest, cis.begin(), cis.end(), old_to_new );
   }

--- a/include/mockturtle/algorithms/cleanup.hpp
+++ b/include/mockturtle/algorithms/cleanup.hpp
@@ -34,10 +34,10 @@
 
 #pragma once
 
+#include "../networks/crossed.hpp"
 #include "../traits.hpp"
 #include "../utils/node_map.hpp"
 #include "../views/topo_view.hpp"
-#include "../networks/crossed.hpp"
 
 #include <kitty/operations.hpp>
 
@@ -190,6 +190,24 @@ void cleanup_dangling_impl( NtkSrc const& ntk, NtkDest& dest, LeavesIterator beg
           static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
           old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
           break;
+        }
+        if constexpr ( has_is_not_v<NtkSrc> )
+        {
+          static_assert( has_create_not_v<NtkDest>, "NtkDest cannot create NOT gates" );
+          if ( ntk.is_not( node ) )
+          {
+            old_to_new[node] = dest.create_not( children[0] );
+            break;
+          }
+        }
+        if constexpr ( has_is_buf_v<NtkSrc> )
+        {
+          static_assert( has_create_buf_v<NtkDest>, "NtkDest cannot create buffer gates" );
+          if ( ntk.is_buf( node ) )
+          {
+            old_to_new[node] = dest.create_buf( children[0] );
+            break;
+          }
         }
         std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
       } while ( false );

--- a/include/mockturtle/algorithms/cleanup.hpp
+++ b/include/mockturtle/algorithms/cleanup.hpp
@@ -185,12 +185,6 @@ void cleanup_dangling_impl( NtkSrc const& ntk, NtkDest& dest, LeavesIterator beg
             break;
           }
         }
-        if constexpr ( has_is_function_v<NtkSrc> )
-        {
-          static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
-          old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
-          break;
-        }
         if constexpr ( has_is_not_v<NtkSrc> )
         {
           static_assert( has_create_not_v<NtkDest>, "NtkDest cannot create NOT gates" );
@@ -202,12 +196,18 @@ void cleanup_dangling_impl( NtkSrc const& ntk, NtkDest& dest, LeavesIterator beg
         }
         if constexpr ( has_is_buf_v<NtkSrc> )
         {
-          static_assert( has_create_buf_v<NtkDest>, "NtkDest cannot create buffer gates" );
+          static_assert( has_create_buf_v<NtkDest>, "NtkDest cannot create buffers" );
           if ( ntk.is_buf( node ) )
           {
             old_to_new[node] = dest.create_buf( children[0] );
             break;
           }
+        }
+        if constexpr ( has_is_function_v<NtkSrc> )
+        {
+          static_assert( has_create_node_v<NtkDest>, "NtkDest cannot create arbitrary function gates" );
+          old_to_new[node] = dest.create_node( children, ntk.node_function( node ) );
+          break;
         }
         std::cerr << "[e] something went wrong, could not copy node " << ntk.node_to_index( node ) << "\n";
       } while ( false );

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -30,6 +30,7 @@
   \author Heinz Riener
   \author Mathias Soeken
   \author Siang-Yun (Sonia) Lee
+  \author Marcel Walter
 */
 
 #pragma once
@@ -399,7 +400,7 @@ public:
       int64_t j = 0;
       for ( int64_t i = empty_slots.size() - 1; i >= 0; --i )
       {
-        while ( empty_slots[j] >= num_patterns - 1 && j <= i )
+        while ( j <= i && empty_slots[j] >= num_patterns - 1 )
         {
           if ( empty_slots[j] == num_patterns - 1 )
           {
@@ -537,10 +538,29 @@ node_map<SimulationType, Ntk> simulate_nodes( Ntk const& ntk, Simulator const& s
   } );
 
   ntk.foreach_gate( [&]( auto const& n ) {
+    // skip crossings
+    if constexpr ( has_is_crossing_v<Ntk> )
+    {
+      if ( ntk.is_crossing( n ) )
+      {
+        return;
+      }
+    }
+
     std::vector<SimulationType> fanin_values( ntk.fanin_size( n ) );
-    ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
+
+    const auto fanin_fun = [&]( auto const& f, auto i ) {
       fanin_values[i] = node_to_value[f];
-    } );
+    };
+
+    if constexpr ( is_crossed_network_type_v<Ntk> )
+    {
+      ntk.foreach_fanin_ignore_crossings( n, fanin_fun );
+    }
+    else
+    {
+      ntk.foreach_fanin( n, fanin_fun );
+    }
     node_to_value[n] = ntk.compute( n, fanin_values.begin(), fanin_values.end() );
   } );
 
@@ -587,12 +607,30 @@ void simulate_nodes_with_node_map( Ntk const& ntk, Container& node_to_value, Sim
 
   /* gates */
   ntk.foreach_gate( [&]( auto const& n ) {
+    // skip crossings
+    if constexpr ( has_is_crossing_v<Ntk> )
+    {
+      if ( ntk.is_crossing( n ) )
+      {
+        return;
+      }
+    }
+
     if ( !node_to_value.has( n ) )
     {
       std::vector<SimulationType> fanin_values( ntk.fanin_size( n ) );
-      ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
+      const auto fanin_fun = [&]( auto const& f, auto i ) {
         fanin_values[i] = node_to_value[ntk.get_node( f )];
-      } );
+      };
+
+      if constexpr ( is_crossed_network_type_v<Ntk> )
+      {
+        ntk.foreach_fanin_ignore_crossings( n, fanin_fun );
+      }
+      else
+      {
+        ntk.foreach_fanin( n, fanin_fun );
+      }
 
       node_to_value[n] = ntk.compute( n, fanin_values.begin(), fanin_values.end() );
     }
@@ -655,7 +693,7 @@ template<class Ntk, class Simulator, class Container>
 void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
-  ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
+  const auto fanin_fun = [&]( auto const& f, auto i ) {
     if ( !node_to_value.has( ntk.get_node( f ) ) )
     {
       simulate_fanin_cone( ntk, ntk.get_node( f ), node_to_value, sim );
@@ -665,7 +703,17 @@ void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container
       re_simulate_fanin_cone( ntk, ntk.get_node( f ), node_to_value, sim );
     }
     fanin_values[i] = node_to_value[ntk.get_node( f )];
-  } );
+  };
+
+  if constexpr ( is_crossed_network_type_v<Ntk> )
+  {
+    ntk.foreach_fanin_ignore_crossings( n, fanin_fun );
+  }
+  else
+  {
+    ntk.foreach_fanin( n, fanin_fun );
+  }
+
   node_to_value[n] = ntk.compute( n, fanin_values.begin(), fanin_values.end() );
 }
 
@@ -673,7 +721,8 @@ template<class Ntk, class Simulator, class Container>
 void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
-  ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
+
+  const auto fanin_fun = [&]( auto const& f, auto i ) {
     if ( !node_to_value.has( ntk.get_node( f ) ) )
     {
       simulate_fanin_cone( ntk, ntk.get_node( f ), node_to_value, sim );
@@ -683,7 +732,17 @@ void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Contai
       re_simulate_fanin_cone( ntk, ntk.get_node( f ), node_to_value, sim );
     }
     fanin_values[i] = node_to_value[ntk.get_node( f )];
-  } );
+  };
+
+  if constexpr ( is_crossed_network_type_v<Ntk> )
+  {
+
+    ntk.foreach_fanin_ignore_crossings( n, fanin_fun );
+  }
+  else
+  {
+    ntk.foreach_fanin( n, fanin_fun );
+  }
   ntk.compute( n, node_to_value[n], fanin_values.begin(), fanin_values.end() );
 }
 
@@ -862,12 +921,30 @@ std::vector<kitty::static_truth_table<NumPIs>> simulate_buffered( Ntk const& ntk
     node_to_value[n] = sim.compute_pi( i );
   } );
   ntk.foreach_node( [&]( auto const& n ) {
+    // skip crossings
+    if constexpr ( has_is_crossing_v<Ntk> )
+    {
+      if ( ntk.is_crossing( n ) )
+      {
+        return;
+      }
+    }
+
     if ( ntk.fanin_size( n ) > 0 )
     {
       std::vector<kitty::static_truth_table<NumPIs>> fanin_values( ntk.fanin_size( n ) );
-      ntk.foreach_fanin( n, [&]( auto const& f, auto i ) {
+      const auto fanin_fun = [&]( auto const& f, auto i ) {
         fanin_values[i] = node_to_value[f];
-      } );
+      };
+
+      if constexpr ( is_crossed_network_type_v<Ntk> )
+      {
+        ntk.foreach_fanin_ignore_crossings( n, fanin_fun );
+      }
+      else
+      {
+        ntk.foreach_fanin( n, fanin_fun );
+      }
       node_to_value[n] = ntk.compute( n, fanin_values.begin(), fanin_values.end() );
     }
   } );

--- a/include/mockturtle/algorithms/simulation.hpp
+++ b/include/mockturtle/algorithms/simulation.hpp
@@ -548,8 +548,7 @@ node_map<SimulationType, Ntk> simulate_nodes( Ntk const& ntk, Simulator const& s
     }
 
     std::vector<SimulationType> fanin_values( ntk.fanin_size( n ) );
-
-    const auto fanin_fun = [&]( auto const& f, auto i ) {
+    auto const fanin_fun = [&]( auto const& f, auto i ) {
       fanin_values[i] = node_to_value[f];
     };
 
@@ -619,7 +618,7 @@ void simulate_nodes_with_node_map( Ntk const& ntk, Container& node_to_value, Sim
     if ( !node_to_value.has( n ) )
     {
       std::vector<SimulationType> fanin_values( ntk.fanin_size( n ) );
-      const auto fanin_fun = [&]( auto const& f, auto i ) {
+      auto const fanin_fun = [&]( auto const& f, auto i ) {
         fanin_values[i] = node_to_value[ntk.get_node( f )];
       };
 
@@ -693,7 +692,7 @@ template<class Ntk, class Simulator, class Container>
 void simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
-  const auto fanin_fun = [&]( auto const& f, auto i ) {
+  auto const fanin_fun = [&]( auto const& f, auto i ) {
     if ( !node_to_value.has( ntk.get_node( f ) ) )
     {
       simulate_fanin_cone( ntk, ntk.get_node( f ), node_to_value, sim );
@@ -721,8 +720,7 @@ template<class Ntk, class Simulator, class Container>
 void re_simulate_fanin_cone( Ntk const& ntk, typename Ntk::node const& n, Container& node_to_value, Simulator const& sim )
 {
   std::vector<kitty::partial_truth_table> fanin_values( ntk.fanin_size( n ) );
-
-  const auto fanin_fun = [&]( auto const& f, auto i ) {
+  auto const fanin_fun = [&]( auto const& f, auto i ) {
     if ( !node_to_value.has( ntk.get_node( f ) ) )
     {
       simulate_fanin_cone( ntk, ntk.get_node( f ), node_to_value, sim );
@@ -881,7 +879,7 @@ std::vector<SimulationType> simulate( Ntk const& ntk, Simulator const& sim = Sim
   static_assert( has_is_complemented_v<Ntk>, "Ntk does not implement the is_complemented function" );
   static_assert( has_compute_v<Ntk, SimulationType>, "Ntk does not implement the compute function for SimulationType" );
 
-  const auto node_to_value = simulate_nodes<SimulationType, Ntk, Simulator>( ntk, sim );
+  auto const node_to_value = simulate_nodes<SimulationType, Ntk, Simulator>( ntk, sim );
 
   std::vector<SimulationType> po_values( ntk.num_pos() );
   ntk.foreach_po( [&]( auto const& f, auto i ) {
@@ -933,7 +931,7 @@ std::vector<kitty::static_truth_table<NumPIs>> simulate_buffered( Ntk const& ntk
     if ( ntk.fanin_size( n ) > 0 )
     {
       std::vector<kitty::static_truth_table<NumPIs>> fanin_values( ntk.fanin_size( n ) );
-      const auto fanin_fun = [&]( auto const& f, auto i ) {
+      auto const fanin_fun = [&]( auto const& f, auto i ) {
         fanin_values[i] = node_to_value[f];
       };
 

--- a/include/mockturtle/io/write_dot.hpp
+++ b/include/mockturtle/io/write_dot.hpp
@@ -29,6 +29,7 @@
 
   \author Heinz Riener
   \author Mathias Soeken
+  \author Marcel Walter
 */
 
 #pragma once
@@ -204,6 +205,22 @@ public:
       }
     }
 
+    if constexpr ( has_is_buf_v<Ntk> )
+    {
+      if ( ntk.is_buf( n ) && !ntk.is_ci( n ) )
+      {
+        return "BUF";
+      }
+    }
+
+    if constexpr ( has_is_crossing_v<Ntk> )
+    {
+      if ( ntk.is_crossing( n ) )
+      {
+        return "CROSS";
+      }
+    }
+
     return default_dot_drawer<Ntk>::node_label( ntk, n );
   }
 
@@ -280,6 +297,22 @@ public:
       if ( ntk.is_nary_xor( n ) )
       {
         return "lightskyblue";
+      }
+    }
+
+    if constexpr ( has_is_buf_v<Ntk> )
+    {
+      if ( ntk.is_buf( n ) && !ntk.is_ci( n ) )
+      {
+        return "palegoldenrod";
+      }
+    }
+
+    if constexpr ( has_is_crossing_v<Ntk> )
+    {
+      if ( ntk.is_crossing( n ) )
+      {
+        return "palegoldenrod";
       }
     }
 

--- a/include/mockturtle/networks/crossed.hpp
+++ b/include/mockturtle/networks/crossed.hpp
@@ -66,6 +66,8 @@ public:
   static constexpr auto min_fanin_size = 1;
   static constexpr auto max_fanin_size = 32;
 
+  static constexpr bool is_crossed_network_type = true;
+
   using base_type = crossed_klut_network;
   using storage = std::shared_ptr<crossed_klut_storage>;
   using node = uint64_t;

--- a/include/mockturtle/networks/crossed.hpp
+++ b/include/mockturtle/networks/crossed.hpp
@@ -376,24 +376,24 @@ public:
   node insert_crossing( signal const& in1, signal const& in2, node const& out1, node const& out2 )
   {
     uint32_t fanin_index1 = std::numeric_limits<uint32_t>::max();
-    foreach_fanin( out1, [&]( auto const& f, auto i ){
-        if ( f == in1 )
-        {
-          fanin_index1 = i;
-          return false;
-        }
-        return true;
+    foreach_fanin( out1, [&]( auto const& f, auto i ) {
+      if ( f == in1 )
+      {
+        fanin_index1 = i;
+        return false;
+      }
+      return true;
     } );
     assert( fanin_index1 != std::numeric_limits<uint32_t>::max() );
 
     uint32_t fanin_index2 = std::numeric_limits<uint32_t>::max();
-    foreach_fanin( out2, [&]( auto const& f, auto i ){
-        if ( f == in2 )
-        {
-          fanin_index2 = i;
-          return false;
-        }
-        return true;
+    foreach_fanin( out2, [&]( auto const& f, auto i ) {
+      if ( f == in2 )
+      {
+        fanin_index2 = i;
+        return false;
+      }
+      return true;
     } );
     assert( fanin_index2 != std::numeric_limits<uint32_t>::max() );
 
@@ -402,8 +402,8 @@ public:
     _storage->nodes[out2].children[fanin_index2] = fout2;
 
     /* decrease ref-count to children (was increased in `create_crossing`) */
-    _storage->nodes[in1.index].data[0].h1++;
-    _storage->nodes[in2.index].data[0].h1++;
+    _storage->nodes[in1.index].data[0].h1--;
+    _storage->nodes[in2.index].data[0].h1--;
 
     return get_node( fout1 );
   }

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -602,6 +602,36 @@ template<class Ntk>
 inline constexpr bool has_create_crossing_v = has_create_crossing<Ntk>::value;
 #pragma endregion
 
+#pragma region has_insert_crossing
+template<class Ntk, class = void>
+struct has_insert_crossing : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_insert_crossing<Ntk, std::void_t<decltype( std::declval<Ntk>().insert_crossing( std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>(), std::declval<node<Ntk>>(), std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_insert_crossing_v = has_insert_crossing<Ntk>::value;
+#pragma endregion
+
+#pragma region has_merge_into_crossing
+template<class Ntk, class = void>
+struct has_merge_into_crossing : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_merge_into_crossing<Ntk, std::void_t<decltype( std::declval<Ntk>().merge_into_crossing( std::declval<node<Ntk>>(), std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_merge_into_crossing_v = has_merge_into_crossing<Ntk>::value;
+#pragma endregion
+
 #pragma region has_clone_node
 template<class Ntk, class = void>
 struct has_clone_node : std::false_type

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -92,6 +92,21 @@ template<class Ntk>
 inline constexpr bool is_buffered_network_type_v = is_buffered_network_type<Ntk>::value;
 #pragma endregion
 
+#pragma region is_crossed_network_type
+template<class Ntk, class = void>
+struct is_crossed_network_type : std::false_type
+{
+};
+
+template<class Ntk>
+struct is_crossed_network_type<Ntk, std::enable_if_t<Ntk::is_crossed_network_type, std::void_t<decltype( Ntk::is_crossed_network_type )>>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool is_crossed_network_type_v = is_crossed_network_type<Ntk>::value;
+#pragma endregion
+
 #pragma region has_clone
 template<class Ntk, class = void>
 struct has_clone : std::false_type

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -992,6 +992,21 @@ template<class Ntk>
 inline constexpr bool has_is_buf_v = has_is_buf<Ntk>::value;
 #pragma endregion
 
+#pragma region has_is_not
+template<class Ntk, class = void>
+struct has_is_not : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_not<Ntk, std::void_t<decltype( std::declval<Ntk>().is_not( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_not_v = has_is_not<Ntk>::value;
+#pragma endregion
+
 #pragma region has_is_and
 template<class Ntk, class = void>
 struct has_is_and : std::false_type

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -587,6 +587,21 @@ template<class Ntk>
 inline constexpr bool has_create_cover_node_v = has_create_cover_node<Ntk>::value;
 #pragma endregion
 
+#pragma region has_create_crossing
+template<class Ntk, class = void>
+struct has_create_crossing : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_create_crossing<Ntk, std::void_t<decltype( std::declval<Ntk>().create_crossing( std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_create_crossing_v = has_create_crossing<Ntk>::value;
+#pragma endregion
+
 #pragma region has_clone_node
 template<class Ntk, class = void>
 struct has_clone_node : std::false_type
@@ -1005,6 +1020,21 @@ struct has_is_not<Ntk, std::void_t<decltype( std::declval<Ntk>().is_not( std::de
 
 template<class Ntk>
 inline constexpr bool has_is_not_v = has_is_not<Ntk>::value;
+#pragma endregion
+
+#pragma region has_is_crossing
+template<class Ntk, class = void>
+struct has_is_crossing : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_is_crossing<Ntk, std::void_t<decltype( std::declval<Ntk>().is_crossing( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_is_crossing_v = has_is_crossing<Ntk>::value;
 #pragma endregion
 
 #pragma region has_is_and

--- a/test/networks/buffered.cpp
+++ b/test/networks/buffered.cpp
@@ -14,6 +14,7 @@ void test_buffered_network()
 
   CHECK( has_create_buf_v<Ntk> );
   CHECK( has_is_buf_v<Ntk> );
+  CHECK( has_is_not_v<Ntk> );
 
   auto x1 = ntk.create_pi();
   auto x2 = ntk.create_pi();
@@ -31,6 +32,7 @@ void test_buffered_network()
   /* properties */
   CHECK( ntk.is_pi( ntk.get_node( x1 ) ) );
   CHECK( !ntk.is_buf( ntk.get_node( x1 ) ) );
+  CHECK( !ntk.is_not( ntk.get_node( x1 ) ) );
   CHECK( !ntk.is_ci( ntk.get_node( b1 ) ) );
   CHECK( ntk.is_buf( ntk.get_node( b1 ) ) );
 

--- a/test/networks/buffered.cpp
+++ b/test/networks/buffered.cpp
@@ -76,9 +76,11 @@ TEST_CASE( "buffered networks", "[buffered]" )
 
 TEST_CASE( "is_buffered_network_type", "[buffered]" )
 {
-  CHECK( is_buffered_network_type_v<buffered_aig_network> == true );
-  CHECK( is_buffered_network_type_v<buffered_mig_network> == true );
+  CHECK( is_buffered_network_type_v<buffered_aig_network> );
+  CHECK( is_buffered_network_type_v<buffered_mig_network> );
+  CHECK( is_buffered_network_type_v<buffered_crossed_klut_network> );
 
-  CHECK( is_buffered_network_type_v<aig_network> == false );
-  CHECK( is_buffered_network_type_v<mig_network> == false );
+  CHECK( !is_buffered_network_type_v<aig_network> );
+  CHECK( !is_buffered_network_type_v<mig_network> );
+  CHECK( !is_buffered_network_type_v<klut_network> );
 }

--- a/test/networks/crossed.cpp
+++ b/test/networks/crossed.cpp
@@ -1,10 +1,19 @@
 #include <catch.hpp>
 
+#include <mockturtle/algorithms/cleanup.hpp>
 #include <mockturtle/networks/crossed.hpp>
 #include <mockturtle/networks/klut.hpp>
-#include <mockturtle/algorithms/cleanup.hpp>
 
 using namespace mockturtle;
+
+TEST_CASE( "type traits", "[crossed]" )
+{
+  CHECK( !has_create_crossing_v<klut_network> );
+  CHECK( !has_is_crossing_v<klut_network> );
+
+  CHECK( has_create_crossing_v<crossed_klut_network> );
+  CHECK( has_is_crossing_v<crossed_klut_network> );
+}
 
 TEST_CASE( "insert crossings in reversed topological order, then cleanup (topo-sort)", "[crossed]" )
 {
@@ -27,8 +36,8 @@ TEST_CASE( "insert crossings in reversed topological order, then cleanup (topo-s
 
   crossed = cleanup_dangling( crossed );
 
-  crossed.foreach_po( [&]( auto const& po ){
-    crossed.foreach_fanin_ignore_crossings( crossed.get_node( po ), [&]( auto const& f, auto i ){
+  crossed.foreach_po( [&]( auto const& po ) {
+    crossed.foreach_fanin_ignore_crossings( crossed.get_node( po ), [&]( auto const& f, auto i ) {
       if ( i == 0 )
         CHECK( f == x1 );
       else
@@ -55,8 +64,8 @@ TEST_CASE( "create crossings in topological order", "[crossed]" )
   crossed.create_po( n7 );
   crossed.create_po( n8 );
 
-  crossed.foreach_po( [&]( auto const& po ){
-    crossed.foreach_fanin_ignore_crossings( crossed.get_node( po ), [&]( auto const& f, auto i ){
+  crossed.foreach_po( [&]( auto const& po ) {
+    crossed.foreach_fanin_ignore_crossings( crossed.get_node( po ), [&]( auto const& f, auto i ) {
       if ( i == 0 )
         CHECK( f == x1 );
       else

--- a/test/networks/crossed.cpp
+++ b/test/networks/crossed.cpp
@@ -9,14 +9,17 @@ using namespace mockturtle;
 
 TEST_CASE( "type traits", "[crossed]" )
 {
+  CHECK( !is_crossed_network_type_v<klut_network> );
   CHECK( !has_create_crossing_v<klut_network> );
   CHECK( !has_insert_crossing_v<klut_network> );
   CHECK( !has_is_crossing_v<klut_network> );
   CHECK( !has_merge_into_crossing_v<klut_network> );
 
+  CHECK( is_crossed_network_type_v<crossed_klut_network> );
   CHECK( has_create_crossing_v<crossed_klut_network> );
   CHECK( has_insert_crossing_v<crossed_klut_network> );
   CHECK( has_is_crossing_v<crossed_klut_network> );
+  CHECK( is_crossed_network_type_v<buffered_crossed_klut_network> );
   CHECK( !has_merge_into_crossing_v<crossed_klut_network> );
   CHECK( has_merge_into_crossing_v<buffered_crossed_klut_network> );
 }

--- a/test/networks/crossed.cpp
+++ b/test/networks/crossed.cpp
@@ -1,6 +1,7 @@
 #include <catch.hpp>
 
 #include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/networks/buffered.hpp>
 #include <mockturtle/networks/crossed.hpp>
 #include <mockturtle/networks/klut.hpp>
 
@@ -9,10 +10,15 @@ using namespace mockturtle;
 TEST_CASE( "type traits", "[crossed]" )
 {
   CHECK( !has_create_crossing_v<klut_network> );
+  CHECK( !has_insert_crossing_v<klut_network> );
   CHECK( !has_is_crossing_v<klut_network> );
+  CHECK( !has_merge_into_crossing_v<klut_network> );
 
   CHECK( has_create_crossing_v<crossed_klut_network> );
+  CHECK( has_insert_crossing_v<crossed_klut_network> );
   CHECK( has_is_crossing_v<crossed_klut_network> );
+  CHECK( !has_merge_into_crossing_v<crossed_klut_network> );
+  CHECK( has_merge_into_crossing_v<buffered_crossed_klut_network> );
 }
 
 TEST_CASE( "insert crossings in reversed topological order, then cleanup (topo-sort)", "[crossed]" )
@@ -91,4 +97,38 @@ TEST_CASE( "transform from klut to crossed_klut", "[crossed]" )
 
   crossed_klut_network crossed = cleanup_dangling<klut_network, crossed_klut_network>( klut );
   CHECK( klut.size() == crossed.size() );
+}
+
+TEST_CASE( "merge buffers into a crossing cell", "[crossed]" )
+{
+  buffered_crossed_klut_network klut;
+
+  auto const x1 = klut.create_pi();
+  auto const x2 = klut.create_pi();
+
+  auto const w1 = klut.create_buf( x1 );
+  auto const w2 = klut.create_buf( x2 );
+  auto const w3 = klut.create_buf( w1 );
+  auto const w4 = klut.create_buf( w2 );
+
+  auto const a1 = klut.create_and( w3, w4 );
+
+  klut.create_po( a1 );
+
+  auto const cx = klut.merge_into_crossing( klut.get_node( w1 ), klut.get_node( w2 ) );
+
+  CHECK( klut.is_crossing( cx ) );
+
+  klut.foreach_fanin( cx, [&]( auto const& f, auto i ) {
+    if ( i == 0 )
+      CHECK( f == x1 );
+    else
+      CHECK( f == x2 );
+  } );
+
+  CHECK( klut.size() == 10 );
+
+  klut = cleanup_dangling( klut );
+
+  CHECK( klut.size() == 8 );
 }


### PR DESCRIPTION
This PR adds to the functionality of crossed network types. In particular, it

- adds a new function `merge_into_crossing` to `crossed_klut_network` that merges two buffer nodes into a crossing cell
- adds new traits `is_crossed_network_type`, `has_create_crossing`, `has_insert_crossing`, `has_merge_into_crossing`
- updates the DOT drawers to support buffer nodes and crossing cells
- updates the simulation interface to support crossing cells
- fixes (?) a potential reference-counting bug in `crossed_klut_network`