### PR TITLE
Algebraic methods for AIGs and XAGs

### DIFF
--- a/docs/algorithms/aig_balancing.rst
+++ b/docs/algorithms/aig_balancing.rst
@@ -1,0 +1,15 @@
+AIG balancing
+---------
+
+**Header:** ``mockturtle/algorithms/aig_balancing.hpp``
+
+Parameters
+~~~~~~~~~~
+
+.. doxygenstruct:: mockturtle::aig_balancing_params
+   :members:
+
+Algorithm
+~~~~~~~~~
+
+.. doxygenfunction:: mockturtle::aig_balance

--- a/docs/algorithms/index_restructuring.rst
+++ b/docs/algorithms/index_restructuring.rst
@@ -27,5 +27,6 @@ Logic restructuring and optimization
    xmg_optimization
    functional_reduction
    refactoring
+   aig_balancing
    balancing
    cost_generic_resub

--- a/docs/algorithms/index_restructuring.rst
+++ b/docs/algorithms/index_restructuring.rst
@@ -15,6 +15,7 @@ Logic restructuring and optimization
    :caption: Rewriting and resubstitution
 
    cut_rewriting
+   xag_algebraic_rewriting
    mig_algebraic_rewriting
    resubstitution
 

--- a/docs/algorithms/xag_algebraic_rewriting.rst
+++ b/docs/algorithms/xag_algebraic_rewriting.rst
@@ -1,0 +1,15 @@
+XAG algebraic rewriting
+-----------------------
+
+**Header:** ``mockturtle/algorithms/xag_algebraic_rewriting.hpp``
+
+Parameters
+~~~~~~~~~~
+
+.. doxygenstruct:: mockturtle::xag_algebraic_depth_rewriting_params
+   :members:
+
+Algorithm
+~~~~~~~~~
+
+.. doxygenfunction:: mockturtle::xag_algebraic_depth_rewriting

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,13 +11,13 @@ v0.4 (not yet released)
 * Network implementations:
     - Remove sequential interfaces from all networks (`aig_network`, `xag_network`, `mig_network`, `xmg_network`, `klut_network`, `cover_network`, `aqfp_network`). Add the `sequential` extension to combinational networks. `#564 <https://github.com/lsils/mockturtle/pull/564>`_
     - Move `trav_id` from the custom storage data (e.g. `aig_storage_data`) to the common `storage`. Remove `num_pis` and `num_pos` as they are only needed for sequential network. Remove custom storage data when not needed (`aig_storage_data`, `xag_storage_data`, `mig_storage_data`, `xmg_storage_data`). Remove latch information from the common `storage`. `#564 <https://github.com/lsils/mockturtle/pull/564>`_
-    - Add access methods to check if a node is present in the network given its immediate fanin (e.g. `has_and` in `aig_network`)
+    - Add access methods to check if a node is present in the network given its immediate fanin (e.g., `has_and` in `aig_network`) `#580 <https://github.com/lsils/mockturtle/pull/580>`_
 * Algorithms:
-    - AIG balancing (`aig_balance`)
+    - AIG balancing (`aig_balance`) `#580 <https://github.com/lsils/mockturtle/pull/580>`_
     - Cost-generic resubstitution (`cost_generic_resub`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Cost aware resynthesis solver (`cost_resyn`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Resynthesis based on SOP factoring (`sop_factoring`) `#579 <https://github.com/lsils/mockturtle/pull/579>`_
-    - XAG algebraic depth rewriting (`xag_algebraic_rewriting`)
+    - XAG algebraic depth rewriting (`xag_algebraic_depth_rewriting`) `#580 <https://github.com/lsils/mockturtle/pull/580>`_
 * Views:
     - Add cost view to evaluate costs in the network and to maintain contexts (`cost_view`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
 * Properties:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ v0.4 (not yet released)
     - Remove sequential interfaces from all networks (`aig_network`, `xag_network`, `mig_network`, `xmg_network`, `klut_network`, `cover_network`, `aqfp_network`). Add the `sequential` extension to combinational networks. `#564 <https://github.com/lsils/mockturtle/pull/564>`_
     - Move `trav_id` from the custom storage data (e.g. `aig_storage_data`) to the common `storage`. Remove `num_pis` and `num_pos` as they are only needed for sequential network. Remove custom storage data when not needed (`aig_storage_data`, `xag_storage_data`, `mig_storage_data`, `xmg_storage_data`). Remove latch information from the common `storage`. `#564 <https://github.com/lsils/mockturtle/pull/564>`_
 * Algorithms:
+    - AIG balancing (`aig_balance`)
     - Cost-generic resubstitution (`cost_generic_resub`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Cost aware resynthesis solver (`cost_resyn`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Resynthesis based on SOP factoring (`sop_factoring`) `#579 <https://github.com/lsils/mockturtle/pull/579>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ v0.4 (not yet released)
 * Network implementations:
     - Remove sequential interfaces from all networks (`aig_network`, `xag_network`, `mig_network`, `xmg_network`, `klut_network`, `cover_network`, `aqfp_network`). Add the `sequential` extension to combinational networks. `#564 <https://github.com/lsils/mockturtle/pull/564>`_
     - Move `trav_id` from the custom storage data (e.g. `aig_storage_data`) to the common `storage`. Remove `num_pis` and `num_pos` as they are only needed for sequential network. Remove custom storage data when not needed (`aig_storage_data`, `xag_storage_data`, `mig_storage_data`, `xmg_storage_data`). Remove latch information from the common `storage`. `#564 <https://github.com/lsils/mockturtle/pull/564>`_
+    - Add access methods to check if a node is present in the network given its immediate fanin (e.g. `has_and` in `aig_network`)
 * Algorithms:
     - AIG balancing (`aig_balance`)
     - Cost-generic resubstitution (`cost_generic_resub`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,12 +15,13 @@ v0.4 (not yet released)
     - Cost-generic resubstitution (`cost_generic_resub`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Cost aware resynthesis solver (`cost_resyn`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Resynthesis based on SOP factoring (`sop_factoring`) `#579 <https://github.com/lsils/mockturtle/pull/579>`_
+    - XAG algebraic depth rewriting (`xag_algebraic_rewriting`)
 * Views:
     - Add cost view to evaluate costs in the network and to maintain contexts (`cost_view`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
 * Properties:
     - Cost functions based on the factored form literals count (`factored_literal_cost`) `#579 <https://github.com/lsils/mockturtle/pull/579>`_
 * Utils:
-    - Add recursive cost function class to customize cost in resubstitution algorithm (`recurisve_cost_function`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
+    - Add recursive cost function class to customize cost in resubstitution algorithm (`recursive_cost_function`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Sum-of-products factoring utilities `#579 <https://github.com/lsils/mockturtle/pull/579>`_
 
 v0.3 (July 12, 2022)

--- a/include/mockturtle/algorithms/aig_balancing.hpp
+++ b/include/mockturtle/algorithms/aig_balancing.hpp
@@ -411,6 +411,7 @@ void aig_balance( Ntk& ntk, aig_balancing_params const& ps = {} )
   static_assert( has_create_po_v<Ntk>, "Ntk does not implement the create_po method" );
   static_assert( has_create_not_v<Ntk>, "Ntk does not implement the create_not method" );
   static_assert( has_is_complemented_v<Ntk>, "Ntk does not implement the is_complemented method" );
+  static_assert( has_has_and_v<Ntk>, "Ntk does not implement the has_and method" );
 
   fanout_view<Ntk> f_ntk{ ntk };
   depth_view<fanout_view<Ntk>> d_ntk{ f_ntk };

--- a/include/mockturtle/algorithms/aig_balancing.hpp
+++ b/include/mockturtle/algorithms/aig_balancing.hpp
@@ -1,0 +1,424 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2022  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file aig_balancing.hpp
+  \brief Balances the AIG to reduce the depth
+
+  \author Alessandro Tempia Calvino
+*/
+
+#pragma once
+
+#include <vector>
+#include <random>
+#include <algorithm>
+
+#include "cleanup.hpp"
+#include "../networks/aig.hpp"
+#include "../traits.hpp"
+#include "../views/depth_view.hpp"
+#include "../views/fanout_view.hpp"
+
+namespace mockturtle
+{
+
+struct aig_balancing_params
+{
+  /*! \brief Minimizes the number of levels. */
+  bool minimize_levels{ true };
+};
+
+namespace detail
+{
+
+template<class Ntk>
+class aig_balance_impl
+{
+public:
+  static constexpr size_t storage_init_size = 30;
+  using node = typename Ntk::node;
+  using signal = typename Ntk::signal;
+  using storage_t = std::vector<std::vector<signal>>;
+
+public:
+  aig_balance_impl( Ntk& ntk, aig_balancing_params const& ps )
+      : ntk( ntk ), ps( ps ),storage( storage_init_size )
+  {
+  }
+
+  void run()
+  {
+    ntk.clear_values();
+
+    for ( auto i = 0; i < storage_init_size; ++i )
+      storage[i].reserve( 10 );
+
+    /* balance every CO */
+    ntk.foreach_co( [&]( auto const& f ) {
+      balance_rec( ntk.get_node( f ), 0 );
+    } );
+  }
+
+private:
+  signal balance_rec( node const& n, uint32_t level )
+  {
+    if ( ntk.is_ci( n ) )
+      return ntk.make_signal( n );
+
+    /* node has been replaced in a previous recursion */
+    if ( ntk.is_dead( n ) || ntk.value( n ) > 0 )
+    {
+      return ntk.make_signal( find_substituted_node( n ) );
+    }
+
+    if ( level >= storage.size() )
+    {
+      storage.emplace_back( std::vector<signal>() );
+      storage.back().reserve( 10 );
+    }
+
+    /* collect leaves of the AND tree */
+    collect_leaves( n, storage[level] );
+
+    if ( storage[level].size() == 0 )
+    {
+      ntk.substitute_node( n, ntk.get_constant( false ) );
+      return ntk.get_constant( false );
+    }
+
+    /* recur over the leaves */
+    for ( auto& f : storage[level] )
+    {
+      signal new_signal = balance_rec( ntk.get_node( f ), level + 1 );
+      f = new_signal ^ ntk.is_complemented( f );
+    }
+
+    assert( storage[level].size() > 1 );
+
+    /* sort by decreasing level */
+    std::sort( storage[level].begin(), storage[level].end(), [this]( auto const& a, auto const& b ) {
+      return ntk.level( ntk.get_node( a ) ) > ntk.level( ntk.get_node( b ) );
+    } );
+
+    /* mark TFI cone of n */
+    ntk.incr_trav_id();
+    mark_tfi( ntk.make_signal( n ), true );
+
+    /* generate the AND tree */
+    while ( storage[level].size() > 1 )
+    {
+      /* explore multiple possibilities to find logic sharing */
+      if ( ps.minimize_levels )
+        pick_nodes( storage[level], find_left_most_at_level( storage[level] ) );
+      else
+        pick_nodes_area( storage[level] );
+
+      /* pop the two selected nodes to create the new AND gate */
+      signal child1 = storage[level].back();
+      storage[level].pop_back();
+      signal child2 = storage[level].back();
+      storage[level].pop_back();
+      signal new_sig = ntk.create_and( child1, child2 );
+
+      /* update level for AND node */
+      update_level( ntk.get_node( new_sig ) );
+
+      /* insert the new node back */
+      insert_node_sorted( storage[level], new_sig );
+    }
+
+    signal root = storage[level][0];
+
+    /* replace if new */
+    if ( n != ntk.get_node( root ) )
+    {
+      ntk.substitute_node( n, root );
+    }
+
+    /* remember the substitution and the new node as already balanced */
+    ntk.set_value( n, ntk.node_to_index( ntk.get_node( root ) ) );
+    ntk.set_value( ntk.get_node( root ), ntk.node_to_index( ntk.get_node( root ) ) );
+
+    /* clean leaves storage */
+    storage[level].clear();
+
+    return root;
+  }
+
+  void collect_leaves( node const& n, std::vector<signal>& leaves )
+  {
+    ntk.incr_trav_id();
+
+    int ret = collect_leaves_rec( ntk.make_signal( n ), leaves, true );
+
+    /* check for constant false */
+    if ( ret < 0 )
+    {
+      leaves.clear();
+    }
+  }
+
+  int collect_leaves_rec( signal const& f, std::vector<signal>& leaves, bool is_root )
+  {
+    node n = ntk.get_node( f );
+
+    /* check if already visited */
+    if ( ntk.visited( n ) == ntk.trav_id() )
+    {
+      for ( signal const& s : leaves )
+      {
+        if ( ntk.get_node( s ) != n )
+          continue;
+
+        if ( s == f )
+          return 1;   /* same polarity: duplicate */
+        else
+          return -1;  /* opposite polarity: const0 */
+      }
+
+      return 0;
+    }
+
+    /* set as leaf if signal is complemented or is a CI or has a multiple fanout */
+    if ( !is_root && ( ntk.is_complemented( f ) || ntk.is_ci( n ) || ntk.fanout_size( n ) > 1 ) )
+    {
+      leaves.push_back( f );
+      ntk.set_visited( n, ntk.trav_id() );
+      return 0;
+    }
+
+    int ret = 0;
+    ntk.foreach_fanin( n, [&]( auto const& child ) {
+      ret |= collect_leaves_rec( child, leaves, false );
+    } );
+
+    return ret;
+  }
+
+  size_t find_left_most_at_level( std::vector<signal> const& leaves )
+  {
+    size_t pointer = leaves.size() - 1;
+    uint32_t current_level = ntk.level( ntk.get_node( leaves[leaves.size() - 2] ) );
+
+    while ( pointer > 0 )
+    {
+      if ( ntk.level( ntk.get_node( leaves[pointer - 1] ) ) > current_level )
+        break;
+
+      --pointer;
+    }
+
+    assert( ntk.level( ntk.get_node( leaves[pointer] ) ) == current_level );
+    return pointer;
+  }
+
+  void pick_nodes( std::vector<signal>& leaves, size_t left_most )
+  {
+    size_t right_most = leaves.size() - 2;
+
+    if ( ntk.level( ntk.get_node( leaves[leaves.size() - 1] ) ) == ntk.level( ntk.get_node( leaves[leaves.size() - 2] ) ) )
+      right_most = left_most;
+
+    for ( size_t right_pointer = leaves.size() - 1; right_pointer > right_most; --right_pointer )
+    {
+      assert( left_most < right_pointer );
+
+      size_t left_pointer = right_pointer;
+      while ( left_pointer-- > left_most )
+      {
+        /* select if node exists */
+        std::optional<node> pnode = ntk.has_and( leaves[right_pointer], leaves[left_pointer] );
+        if ( pnode.has_value() )
+        {
+          /* already present in TFI */
+          if ( ntk.visited( *pnode ) == ntk.trav_id() )
+          {
+            continue;
+          }
+
+          if ( leaves[right_pointer] != leaves[leaves.size() - 1] )
+            std::swap( leaves[right_pointer], leaves[leaves.size() - 1] );
+          if ( leaves[left_pointer] != leaves[leaves.size() - 2] )
+            std::swap( leaves[left_pointer], leaves[leaves.size() - 2] );
+          break;
+        }
+      }
+    }
+  }
+
+  void pick_nodes_area( std::vector<signal>& leaves )
+  {
+    for ( size_t right_pointer = leaves.size() - 1; right_pointer > 0; --right_pointer )
+    {
+      size_t left_pointer = right_pointer;
+      while ( left_pointer-- > 0 )
+      {
+        /* select if node exists */
+        std::optional<node> pnode = ntk.has_and( leaves[right_pointer], leaves[left_pointer] );
+        if ( pnode.has_value() )
+        {
+          /* already present in TFI */
+          if ( ntk.visited( *pnode ) == ntk.trav_id() )
+          {
+            continue;
+          }
+
+          if ( leaves[right_pointer] != leaves[leaves.size() - 1] )
+            std::swap( leaves[right_pointer], leaves[leaves.size() - 1] );
+          if ( leaves[left_pointer] != leaves[leaves.size() - 2] )
+            std::swap( leaves[left_pointer], leaves[leaves.size() - 2] );
+          break;
+        }
+      }
+    }
+  }
+
+  void insert_node_sorted( std::vector<signal>& leaves, signal const& f )
+  {
+    node n = ntk.get_node( f );
+
+    /* check uniqueness */
+    for ( auto const& s : leaves )
+    {
+      if ( s == f )
+        return;
+    }
+
+    leaves.push_back( f );
+    for ( size_t i = leaves.size() - 1; i > 0; --i )
+    {
+      auto& s2 = leaves[i - 1];
+
+      if ( ntk.level( ntk.get_node( s2 ) ) < ntk.level( n ) )
+      {
+        std::swap( s2, leaves[i] );
+      }
+      else
+      {
+        break;
+      }
+    }
+  }
+
+  void update_level( node const& n )
+  {
+    uint32_t l = 0;
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      l = std::max( l, ntk.level( ntk.get_node( f ) ) );
+    } );
+
+    ntk.set_level( n, l + 1 );
+  }
+
+  node find_substituted_node( node n )
+  {
+    while ( ntk.is_dead( n ) )
+      n = ntk.index_to_node( ntk.value( n ) );
+    
+    return n;
+  }
+
+  void mark_tfi( signal const& f, bool is_root )
+  {
+    node n = ntk.get_node( f );
+
+    /* check if already visited */
+    if ( ntk.visited( n ) == ntk.trav_id() )
+      return;
+
+    ntk.set_visited( n, ntk.trav_id() );
+
+    /* set as leaf if signal is complemented or is a CI or has a multiple fanout */
+    if ( !is_root && ( ntk.is_complemented( f ) || ntk.is_ci( n ) || ntk.fanout_size( n ) > 1 ) )
+    {
+      return;
+    }
+
+    ntk.foreach_fanin( n, [&]( auto const& child ) {
+      mark_tfi( child, false );
+    } );
+  }
+
+private:
+  Ntk& ntk;
+  aig_balancing_params const& ps;
+
+  storage_t storage;
+};
+
+} /* namespace detail */
+
+/*! \brief AIG balancing.
+ *
+ * This method balance the AIG to reduce the
+ * depth. Level minimization can be turned off.
+ * In this case, balancing tries to reconstruct
+ * AND trees such that logic sharing is maximized.
+ *
+ * **Required network functions:**
+ * - `get_node`
+ * - `node_to_index`
+ * - `get_constant`
+ * - `create_pi`
+ * - `create_po`
+ * - `create_not`
+ * - `is_complemented`
+ * - `foreach_node`
+ * - `foreach_pi`
+ * - `foreach_po`
+ * - `clone_node`
+ * - `is_pi`
+ * - `is_constant`
+ * - `has_and`
+ */
+template<class Ntk>
+void aig_balance( Ntk& ntk, aig_balancing_params const& ps = {} )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+  static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
+  static_assert( has_get_constant_v<Ntk>, "Ntk does not implement the get_constant method" );
+  static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+  static_assert( has_foreach_pi_v<Ntk>, "Ntk does not implement the foreach_pi method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
+  static_assert( has_clone_node_v<Ntk>, "Ntk does not implement the clone_node method" );
+  static_assert( has_create_pi_v<Ntk>, "Ntk does not implement the create_pi method" );
+  static_assert( has_create_po_v<Ntk>, "Ntk does not implement the create_po method" );
+  static_assert( has_create_not_v<Ntk>, "Ntk does not implement the create_not method" );
+  static_assert( has_is_complemented_v<Ntk>, "Ntk does not implement the is_complemented method" );
+
+  fanout_view<Ntk> f_ntk{ ntk };
+  depth_view<fanout_view<Ntk>> d_ntk{ f_ntk };
+
+  detail::aig_balance_impl p( d_ntk, ps );
+  p.run();
+
+  ntk = cleanup_dangling( ntk );
+}
+
+} /* namespace mockturtle */

--- a/include/mockturtle/algorithms/xag_algebraic_rewriting.hpp
+++ b/include/mockturtle/algorithms/xag_algebraic_rewriting.hpp
@@ -1,0 +1,565 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2021  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file xag_algebraic_rewriting.hpp
+  \brief xag algebraric rewriting
+
+  \author Alessandro Tempia Calvino
+*/
+
+#pragma once
+
+#include <iostream>
+#include <optional>
+
+#include "../views/fanout_view.hpp"
+#include "../views/topo_view.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Parameters for xag_algebraic_depth_rewriting.
+ *
+ * The data structure `xag_algebraic_depth_rewriting_params` holds configurable
+ * parameters with default arguments for `xag_algebraic_depth_rewriting`.
+ */
+struct xag_algebraic_depth_rewriting_params
+{
+  /*! \brief Rewriting strategy. */
+  enum strategy_t
+  {
+    /*! \brief DFS rewriting strategy.
+     *
+     * Applies depth rewriting once to all output cones whose drivers have
+     * maximum levels
+     */
+    dfs,
+    /*! \brief Aggressive rewriting strategy.
+     *
+     * Applies depth reduction multiple times until the number of nodes, which
+     * cannot be rewritten, matches the number of nodes, in the current
+     * network; or the new network size is larger than the initial size w.r.t.
+     * to an `overhead`.
+     */
+    aggressive,
+    /*! \brief Selective rewriting strategy.
+     *
+     * Like `aggressive`, but only applies rewriting to nodes on critical paths
+     * and without `overhead`.
+     */
+    selective
+  } strategy = dfs;
+
+  /*! \brief Overhead factor in aggressive rewriting strategy.
+   *
+   * When comparing to the initial size in aggressive depth rewriting, also the
+   * number of dangling nodes are taken into account.
+   */
+  float overhead{ 2.0f };
+
+  /*! \brief Allow area increase while optimizing depth. */
+  bool allow_area_increase{ true };
+
+  /*! \brief Try rules that are rarely applied. */
+  bool allow_rare_rules{ false };
+};
+
+namespace detail
+{
+
+template<class Ntk>
+class xag_algebraic_depth_rewriting_impl
+{
+public:
+  xag_algebraic_depth_rewriting_impl( Ntk& ntk, xag_algebraic_depth_rewriting_params const& ps )
+      : ntk( ntk ), ps( ps )
+  {
+  }
+
+  void run()
+  {
+    switch ( ps.strategy )
+    {
+    case xag_algebraic_depth_rewriting_params::dfs:
+      run_dfs();
+      break;
+    case xag_algebraic_depth_rewriting_params::selective:
+      run_selective();
+      break;
+    case xag_algebraic_depth_rewriting_params::aggressive:
+      run_aggressive();
+      break;
+    }
+  }
+
+private:
+  void run_dfs()
+  {
+    ntk.foreach_po( [this]( auto po ) {
+      const auto driver = ntk.get_node( po );
+      if ( ntk.level( driver ) < ntk.depth() )
+        return;
+      topo_view topo{ ntk, po };
+      topo.foreach_node( [&]( auto n ) {
+        bool res = reduce_depth_and_associativity( n );
+        res |= reduce_depth_xor_associativity( n );
+
+        if ( ps.allow_area_increase && !res )
+        {
+          reduce_depth_and_or_distributivity( n );
+
+          reduce_depth_and_xor_distributivity( n );
+        }
+
+        if ( ps.allow_rare_rules && !res )
+          res = reduce_depth_and_distributity( n );
+
+        return true;
+      } );
+    } );
+  }
+
+  void run_selective()
+  {
+    uint32_t counter{ 0 };
+    while ( true )
+    {
+      mark_critical_paths();
+
+      topo_view topo{ ntk };
+      topo.foreach_node( [this, &counter]( auto n ) {
+        if ( ntk.fanout_size( n ) == 0 || ntk.value( n ) == 0 )
+          return;
+
+        bool res = reduce_depth_and_associativity( n );
+        res |= reduce_depth_xor_associativity( n );
+
+        if ( ps.allow_area_increase && !res )
+        {
+          reduce_depth_and_or_distributivity( n );
+
+          reduce_depth_and_xor_distributivity( n );
+        }
+
+        if ( ps.allow_rare_rules && !res )
+          res = reduce_depth_and_distributity( n );
+
+        if ( res )
+        {
+          mark_critical_paths();
+        }
+        else
+        {
+          ++counter;
+        }
+      } );
+
+      if ( counter > ntk.size() )
+        break;
+    }
+  }
+
+  void run_aggressive()
+  {
+    uint32_t counter{ 0 }, init_size{ ntk.size() };
+    while ( true )
+    {
+      topo_view topo{ ntk };
+      topo.foreach_node( [this, &counter]( auto n ) {
+        if ( ntk.fanout_size( n ) == 0 )
+          return;
+
+        bool res = reduce_depth_and_associativity( n );
+        res |= reduce_depth_xor_associativity( n );
+
+        if ( ps.allow_area_increase && !res )
+        {
+          reduce_depth_and_or_distributivity( n );
+
+          reduce_depth_and_xor_distributivity( n );
+        }
+
+        if ( ps.allow_rare_rules && !res )
+          res = reduce_depth_and_distributity( n );
+
+        if ( !res )
+        {
+          ++counter;
+        }
+      } );
+
+      if ( ntk.size() > ps.overhead * init_size )
+        break;
+      if ( counter > ntk.size() )
+        break;
+    }
+  }
+
+private:
+  /* AND associativity */
+  bool reduce_depth_and_associativity( node<Ntk> const& n )
+  {
+    if ( !ntk.is_and( n ) )
+      return false;
+
+    if ( ntk.level( n ) == 0 )
+      return false;
+
+    /* get children of top node, ordered by node level (ascending) */
+    const auto ocs = ordered_children( n );
+
+    if ( !ntk.is_and( ntk.get_node( ocs[1] ) ) || ntk.is_complemented( ocs[1] ) )
+      return false;
+
+    /* depth of second child must be (significantly) higher than depth of first child */
+    if ( ntk.level( ntk.get_node( ocs[1] ) ) <= ntk.level( ntk.get_node( ocs[0] ) ) + 1 )
+      return false;
+
+    /* child must have single fanout, if no area overhead is allowed */
+    if ( !ps.allow_area_increase && ntk.fanout_size( ntk.get_node( ocs[1] ) ) != 1 )
+      return false;
+
+    /* get children of second child */
+    auto ocs1 = ordered_children( ntk.get_node( ocs[1] ) );
+
+    /* depth of second grand-child must be higher than depth of first grand-child */
+    if ( ntk.level( ntk.get_node( ocs1[1] ) ) == ntk.level( ntk.get_node( ocs1[0] ) ) )
+      return false;
+
+    auto opt = ntk.create_and( ocs1[1], ntk.create_and( ocs[0], ocs1[0] ) );
+    ntk.substitute_node( n, opt );
+    ntk.update_levels();
+
+    return true;
+  }
+
+  /* XOR associativity */
+  bool reduce_depth_xor_associativity( node<Ntk> const& n )
+  {
+    if ( !ntk.is_xor( n ) )
+      return false;
+
+    if ( ntk.level( n ) == 0 )
+      return false;
+
+    /* get children of top node, ordered by node level (ascending) */
+    const auto ocs = ordered_children( n );
+
+    if ( !ntk.is_xor( ntk.get_node( ocs[1] ) ) )
+      return false;
+
+    /* depth of second child must be (significantly) higher than depth of first child */
+    if ( ntk.level( ntk.get_node( ocs[1] ) ) <= ntk.level( ntk.get_node( ocs[0] ) ) + 1 )
+      return false;
+
+    /* child must have single fanout, if no area overhead is allowed */
+    if ( !ps.allow_area_increase && ntk.fanout_size( ntk.get_node( ocs[1] ) ) != 1 )
+      return false;
+
+    /* get children of last child */
+    auto ocs1 = ordered_children( ntk.get_node( ocs[1] ) );
+
+    /* depth of second grand-child must be higher than depth of first grand-child */
+    if ( ntk.level( ntk.get_node( ocs1[1] ) ) == ntk.level( ntk.get_node( ocs1[0] ) ) )
+      return false;
+
+    auto opt = ntk.create_xor( ocs1[1], ntk.create_xor( ocs[0], ocs1[0] ) );
+
+    if ( ntk.is_complemented( ocs[1] ) )
+      opt = !opt;
+
+    ntk.substitute_node( n, opt );
+    ntk.update_levels();
+
+    return true;
+  }
+
+  /* AND distributivity */
+  bool reduce_depth_and_distributity( node<Ntk> const& n )
+  {
+    if ( !ntk.is_and( n ) )
+      return false;
+
+    if ( ntk.level( n ) == 0 )
+      return false;
+
+    /* get children of top node, ordered by node level (ascending) */
+    const auto ocs = ordered_children( n );
+
+    if ( !ntk.is_and( ntk.get_node( ocs[0] ) ) || !ntk.is_complemented( ocs[0] ) )
+      return false;
+
+    if ( !ntk.is_and( ntk.get_node( ocs[1] ) ) || !ntk.is_complemented( ocs[1] ) )
+      return false;
+
+    /* children must have single fanout, if no area overhead is allowed */
+    if ( !ps.allow_area_increase && ( ntk.fanout_size( ntk.get_node( ocs[0] ) ) != 1 || ntk.fanout_size( ntk.get_node( ocs[1] ) ) != 1 ) )
+      return false;
+
+    /* get children of first child */
+    auto ocs0 = ordered_children( ntk.get_node( ocs[0] ) );
+
+    /* get children of second child */
+    auto ocs1 = ordered_children( ntk.get_node( ocs[1] ) );
+
+    /* find common support */
+    bool critical_common = false;
+    signal<Ntk> common, x, y;
+    if ( ocs0[0] == ocs1[0] )
+    {
+      common = ocs0[0];
+      x = ocs0[1];
+      y = ocs1[1];
+    }
+    else if ( ocs0[0] == ocs1[1] )
+    {
+      common = ocs0[0];
+      x = ocs0[1];
+      y = ocs1[0];
+    }
+    else if ( ocs0[1] == ocs1[0] )
+    {
+      common = ocs0[1];
+      x = ocs0[0];
+      y = ocs1[1];
+    }
+    else if ( ocs0[1] == ocs1[1] )
+    {
+      common = ocs0[1];
+      x = ocs0[0];
+      y = ocs1[0];
+      critical_common = true;
+    }
+    else
+    {
+      return false;
+    }
+
+    /* common signal is not critical, children must have single fanout, to not increase the area */
+    if ( !critical_common && ( ntk.fanout_size( ntk.get_node( ocs[0] ) ) != 1 || ntk.fanout_size( ntk.get_node( ocs[1] ) ) != 1 ) )
+      return false;
+
+    auto opt = !ntk.create_and( common, !ntk.create_and( !x, !y ) );
+    ntk.substitute_node( n, opt );
+    ntk.update_levels();
+
+    return true;
+  }
+
+  /* AND-OR distributivity */
+  bool reduce_depth_and_or_distributivity( node<Ntk> const& n )
+  {
+    if ( !ntk.is_and( n ) )
+      return false;
+
+    if ( ntk.level( n ) < 3 )
+      return false;
+
+    /* get children of top node, ordered by node level (ascending) */
+    const auto ocs = ordered_children( n );
+
+    if ( !ntk.is_and( ntk.get_node( ocs[1] ) ) || !ntk.is_complemented( ocs[1] ) )
+      return false;
+
+    /* depth of second child must be significantly higher than depth of first child */
+    if ( ntk.level( ntk.get_node( ocs[1] ) ) <= ntk.level( ntk.get_node( ocs[0] ) ) + 2 )
+      return false;
+
+    /* get children of last child */
+    auto ocs1 = ordered_children( ntk.get_node( ocs[1] ) );
+
+    if ( !ntk.is_and( ntk.get_node( ocs1[1] ) ) || !ntk.is_complemented( ocs1[1] ) )
+      return false;
+
+    /* depth of second grand-child must be higher than depth of first grand-child */
+    if ( ntk.level( ntk.get_node( ocs1[1] ) ) == ntk.level( ntk.get_node( ocs1[0] ) ) )
+      return false;
+
+    /* get children of last grand-child */
+    auto ocs11 = ordered_children( ntk.get_node( ocs1[1] ) );
+
+    /* depth of second grand-grand-child must be higher than depth of first grand-grand-child */
+    if ( ntk.level( ntk.get_node( ocs11[1] ) ) == ntk.level( ntk.get_node( ocs11[0] ) ) )
+      return false;
+
+    auto opt = !ntk.create_and( !ntk.create_and( ocs[0], !ocs1[0] ), !ntk.create_and( ntk.create_and( ocs[0], ocs11[0] ), ocs11[1] ) );
+    ntk.substitute_node( n, opt );
+    ntk.update_levels();
+
+    return true;
+  }
+
+  /* AND-XOR distributivity */
+  bool reduce_depth_and_xor_distributivity( node<Ntk> const& n )
+  {
+    if ( !ntk.is_and( n ) )
+      return false;
+
+    if ( ntk.level( n ) < 3 )
+      return false;
+
+    /* get children of top node, ordered by node level (ascending) */
+    const auto ocs = ordered_children( n );
+
+    if ( !ntk.is_xor( ntk.get_node( ocs[1] ) ) )
+      return false;
+
+    /* depth of second child must be significantly higher than depth of first child */
+    if ( ntk.level( ntk.get_node( ocs[1] ) ) <= ntk.level( ntk.get_node( ocs[0] ) ) + 2 )
+      return false;
+
+    /* get children of last child */
+    auto ocs1 = ordered_children( ntk.get_node( ocs[1] ) );
+
+    if ( !ntk.is_and( ntk.get_node( ocs1[1] ) ) )
+      return false;
+
+    /* depth of second grand-child must be higher than depth of first grand-child */
+    if ( ntk.level( ntk.get_node( ocs1[1] ) ) == ntk.level( ntk.get_node( ocs1[0] ) ) )
+      return false;
+
+    /* get children of last grand-child */
+    auto ocs11 = ordered_children( ntk.get_node( ocs1[1] ) );
+
+    /* depth of second grand-grand-child must be higher than depth of first grand-grand-child */
+    if ( ntk.level( ntk.get_node( ocs11[1] ) ) == ntk.level( ntk.get_node( ocs11[0] ) ) )
+      return false;
+
+    /* if XOR is complemented, complement first grand-child */
+    if ( ntk.is_complemented( ocs[1] ) != ntk.is_complemented( ocs1[1] ) )
+    {
+      ocs1[0] = !ocs1[0];
+    }
+
+    auto opt = ntk.create_xor( ntk.create_and( ocs[0], ocs1[0] ), ntk.create_and( ntk.create_and( ocs[0], ocs11[0] ), ocs11[1] ) );
+    ntk.substitute_node( n, opt );
+    ntk.update_levels();
+
+    return true;
+  }
+
+  inline std::array<signal<Ntk>, 2> ordered_children( node<Ntk> const& n ) const
+  {
+    std::array<signal<Ntk>, 2> children;
+    ntk.foreach_fanin( n, [&children]( auto const& f, auto i ) {
+      children[i] = f;
+    } );
+    if ( ntk.level( ntk.get_node( children[0] ) ) > ntk.level( ntk.get_node( children[1] ) ) )
+    {
+      std::swap( children[0], children[1] );
+    }
+    return children;
+  }
+
+  void mark_critical_path( node<Ntk> const& n )
+  {
+    if ( ntk.is_pi( n ) || ntk.is_constant( n ) || ntk.value( n ) )
+      return;
+
+    const auto level = ntk.level( n );
+    ntk.set_value( n, 1 );
+    ntk.foreach_fanin( n, [this, level]( auto const& f ) {
+      if ( ntk.level( ntk.get_node( f ) ) == level - 1 )
+      {
+        mark_critical_path( ntk.get_node( f ) );
+      }
+    } );
+  }
+
+  void mark_critical_paths()
+  {
+    ntk.clear_values();
+    ntk.foreach_po( [this]( auto const& f ) {
+      if ( ntk.level( ntk.get_node( f ) ) == ntk.depth() )
+      {
+        mark_critical_path( ntk.get_node( f ) );
+      }
+    } );
+  }
+
+private:
+  Ntk& ntk;
+  xag_algebraic_depth_rewriting_params const& ps;
+};
+
+} // namespace detail
+
+/*! \brief XAG algebraic depth rewriting.
+ *
+ * This algorithm tries to rewrite a network with AND/XOR gates for depth
+ * optimization using the associativity and distributivity rule in
+ * AND-XOR logic.  It can be applied to networks other than XAGs, but
+ * only considers pairs of nodes which both implement the AND
+ * function and the XOR function.
+ *
+ * **Required network functions:**
+ * - `get_node`
+ * - `level`
+ * - `update_levels`
+ * - `create_and`
+ * - `create_xor`
+ * - `substitute_node`
+ * - `foreach_node`
+ * - `foreach_po`
+ * - `foreach_fanin`
+ * - `is_and`
+ * - `is_xor`
+ * - `clear_values`
+ * - `set_value`
+ * - `value`
+ * - `fanout_size`
+ *
+   \verbatim embed:rst
+
+  .. note::
+
+   \endverbatim
+ */
+template<class Ntk>
+void xag_algebraic_depth_rewriting( Ntk& ntk, xag_algebraic_depth_rewriting_params const& ps = {} )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+  static_assert( has_level_v<Ntk>, "Ntk does not implement the level method" );
+  static_assert( has_create_and_v<Ntk>, "Ntk does not implement the create_maj method" );
+  static_assert( has_create_xor_v<Ntk>, "Ntk does not implement the create_maj method" );
+  static_assert( has_substitute_node_v<Ntk>, "Ntk does not implement the substitute_node method" );
+  static_assert( has_update_levels_v<Ntk>, "Ntk does not implement the update_levels method" );
+  static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin method" );
+  static_assert( has_is_and_v<Ntk>, "Ntk does not implement the is_and method" );
+  static_assert( has_is_xor_v<Ntk>, "Ntk does not implement the is_xor method" );
+  static_assert( has_clear_values_v<Ntk>, "Ntk does not implement the clear_values method" );
+  static_assert( has_set_value_v<Ntk>, "Ntk does not implement the set_value method" );
+  static_assert( has_value_v<Ntk>, "Ntk does not implement the value method" );
+  static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
+
+  detail::xag_algebraic_depth_rewriting_impl<Ntk> p( ntk, ps );
+  p.run();
+}
+
+} /* namespace mockturtle */

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -27,6 +27,7 @@
   \file aig.hpp
   \brief AIG logic network implementation
 
+  \author Alessandro Tempia Calvino
   \author Bruno Schmitt
   \author Hanyu Wang
   \author Heinz Riener
@@ -404,6 +405,41 @@ public:
     (void)source;
     assert( children.size() == 2u );
     return create_and( children[0u], children[1u] );
+  }
+#pragma endregion
+
+#pragma region Has node
+  std::optional<node> has_and( signal a, signal b )
+  {
+    /* order inputs */
+    if ( a.index > b.index )
+    {
+      std::swap( a, b );
+    }
+
+    /* trivial cases */
+    if ( a.index == b.index )
+    {
+      return ( a.complement == b.complement ) ? a.index : 0;
+    }
+    else if ( a.index == 0 )
+    {
+      return a.complement ? b.index : 0;
+    }
+
+    storage::element_type::node_type node;
+    node.children[0] = a;
+    node.children[1] = b;
+
+    /* structural hashing */
+    const auto it = _storage->hash.find( node );
+    if ( it != _storage->hash.end() )
+    {
+      assert( !is_dead( it->second ) );
+      return it->second;
+    }
+
+    return {};
   }
 #pragma endregion
 

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -27,6 +27,7 @@
   \file mig.hpp
   \brief MIG logic network implementation
 
+  \author Alessandro Tempia Calvino
   \author Bruno Schmitt
   \author Eleonora Testa
   \author Hanyu Wang
@@ -405,6 +406,63 @@ public:
     (void)source;
     assert( children.size() == 3u );
     return create_maj( children[0u], children[1u], children[2u] );
+  }
+#pragma endregion
+
+#pragma region Has node
+  std::optional<node> has_maj( signal a, signal b, signal c )
+  {
+    /* order inputs */
+    if ( a.index > b.index )
+    {
+      std::swap( a, b );
+      if ( b.index > c.index )
+        std::swap( b, c );
+      if ( a.index > b.index )
+        std::swap( a, b );
+    }
+    else
+    {
+      if ( b.index > c.index )
+        std::swap( b, c );
+      if ( a.index > b.index )
+        std::swap( a, b );
+    }
+
+    /* trivial cases */
+    if ( a.index == b.index )
+    {
+      return ( a.complement == b.complement ) ? get_node( a ) : get_node( c );
+    }
+    else if ( b.index == c.index )
+    {
+      return ( b.complement == c.complement ) ? get_node( b ) : get_node( a );
+    }
+
+    /*  complemented edges minimization */
+    if ( static_cast<unsigned>( a.complement ) + static_cast<unsigned>( b.complement ) +
+             static_cast<unsigned>( c.complement ) >=
+         2u )
+    {
+      a.complement = !a.complement;
+      b.complement = !b.complement;
+      c.complement = !c.complement;
+    }
+
+    storage::element_type::node_type node;
+    node.children[0] = a;
+    node.children[1] = b;
+    node.children[2] = c;
+
+    /* structural hashing */
+    const auto it = _storage->hash.find( node );
+    if ( it != _storage->hash.end() )
+    {
+      assert( !is_dead( it->second ) );
+      return it->second;
+    }
+
+    return {};
   }
 #pragma endregion
 

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -27,6 +27,7 @@
   \file xag.hpp
   \brief Xor-And Graph (XAG) logic network implementation
 
+  \author Alessandro Tempia Calvino
   \author Bruno Schmitt
   \author Eleonora Testa
   \author Hanyu Wang
@@ -427,6 +428,76 @@ public:
     {
       return create_xor( children[0u], children[1u] );
     }
+  }
+#pragma endregion
+
+#pragma region Has node
+  std::optional<node> has_and( signal a, signal b )
+  {
+    /* order inputs */
+    if ( a.index > b.index )
+    {
+      std::swap( a, b );
+    }
+
+    /* trivial cases */
+    if ( a.index == b.index )
+    {
+      return ( a.complement == b.complement ) ? a.index : 0;
+    }
+    else if ( a.index == 0 )
+    {
+      return a.complement ? b.index : 0;
+    }
+
+    storage::element_type::node_type node;
+    node.children[0] = a;
+    node.children[1] = b;
+
+    /* structural hashing */
+    const auto it = _storage->hash.find( node );
+    if ( it != _storage->hash.end() )
+    {
+      assert( !is_dead( it->second ) );
+      return it->second;
+    }
+
+    return {};
+  }
+
+  std::optional<node> has_xor( signal a, signal b )
+  {
+    /* order inputs */
+    if ( a.index < b.index )
+    {
+      std::swap( a, b );
+    }
+
+    /* trivial cases */
+    if ( a.index == b.index )
+    {
+      return 0;
+    }
+    else if ( b.index == 0 )
+    {
+      return get_node( a );
+    }
+
+    a.complement = b.complement = false;
+
+    storage::element_type::node_type node;
+    node.children[0] = a;
+    node.children[1] = b;
+
+    /* structural hashing */
+    const auto it = _storage->hash.find( node );
+    if ( it != _storage->hash.end() )
+    {
+      assert( !is_dead( it->second ) );
+      return it->second;
+    }
+
+    return {};
   }
 #pragma endregion
 

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -27,6 +27,7 @@
   \file xmg.hpp
   \brief XMG logic network implementation
 
+  \author Alessandro Tempia Calvino
   \author Bruno Schmitt
   \author Hanyu Wang
   \author Heinz Riener
@@ -469,6 +470,105 @@ public:
     {
       return create_xor3( children[0u], children[1u], children[2u] );
     }
+  }
+#pragma endregion
+
+#pragma region Has node
+  std::optional<node> has_maj( signal a, signal b, signal c )
+  {
+    /* order inputs */
+    if ( a.index > b.index )
+    {
+      std::swap( a, b );
+    }
+    if ( b.index > c.index )
+    {
+      std::swap( b, c );
+    }
+    if ( a.index > b.index )
+    {
+      std::swap( a, b );
+    }
+
+    /* trivial cases */
+    if ( a.index == b.index )
+    {
+      return ( a.complement == b.complement ) ? get_node( a ) : get_node( c );
+    }
+    else if ( b.index == c.index )
+    {
+      return ( b.complement == c.complement ) ? get_node( b ) : get_node( a );
+    }
+
+    /*  complemented edges minimization */
+    if ( static_cast<unsigned>( a.complement ) + static_cast<unsigned>( b.complement ) +
+             static_cast<unsigned>( c.complement ) >=
+         2u )
+    {
+      a.complement = !a.complement;
+      b.complement = !b.complement;
+      c.complement = !c.complement;
+    }
+
+    storage::element_type::node_type node;
+    node.children[0] = a;
+    node.children[1] = b;
+    node.children[2] = c;
+
+    /* structural hashing */
+    const auto it = _storage->hash.find( node );
+    if ( it != _storage->hash.end() )
+    {
+      assert( !is_dead( it->second ) );
+      return it->second;
+    }
+
+    return {};
+  }
+
+  std::optional<node> has_xor3( signal a, signal b, signal c )
+  {
+    /* order inputs */
+    if ( a.index < b.index )
+    {
+      std::swap( a, b );
+    }
+    if ( b.index < c.index )
+    {
+      std::swap( b, c );
+    }
+    if ( a.index < b.index )
+    {
+      std::swap( a, b );
+    }
+
+    /* trivial cases */
+    if ( a.index == b.index )
+    {
+      return get_node( c );
+    }
+    else if ( b.index == c.index )
+    {
+      return get_node( a );
+    }
+
+    /* propagate complement edges */
+    a.complement = b.complement = c.complement = false;
+
+    storage::element_type::node_type node;
+    node.children[0] = a;
+    node.children[1] = b;
+    node.children[2] = c;
+
+    /* structural hashing */
+    const auto it = _storage->hash.find( node );
+    if ( it != _storage->hash.end() )
+    {
+      assert( !is_dead( it->second ) );
+      return it->second;
+    }
+
+    return {};
   }
 #pragma endregion
 

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -27,6 +27,7 @@
   \file traits.hpp
   \brief Type traits and checkers for the network interface
 
+  \author Alessandro Tempia Calvino
   \author Andrea Costamagna
   \author Bruno Schmitt
   \author Hanyu Wang
@@ -593,6 +594,66 @@ struct has_clone_node<Ntk, std::void_t<decltype( std::declval<Ntk>().clone_node(
 
 template<class Ntk>
 inline constexpr bool has_clone_node_v = has_clone_node<Ntk>::value;
+#pragma endregion
+
+#pragma region has_has_and
+template<class Ntk, class = void>
+struct has_has_and : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_has_and<Ntk, std::void_t<decltype( std::declval<Ntk>().has_and( std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_has_and_v = has_has_and<Ntk>::value;
+#pragma endregion
+
+#pragma region has_has_xor
+template<class Ntk, class = void>
+struct has_has_xor : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_has_xor<Ntk, std::void_t<decltype( std::declval<Ntk>().has_xor( std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_has_xor_v = has_has_xor<Ntk>::value;
+#pragma endregion
+
+#pragma region has_has_maj
+template<class Ntk, class = void>
+struct has_has_maj : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_has_maj<Ntk, std::void_t<decltype( std::declval<Ntk>().has_maj( std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_has_maj_v = has_has_maj<Ntk>::value;
+#pragma endregion
+
+#pragma region has_has_xor3
+template<class Ntk, class = void>
+struct has_has_xor3 : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_has_xor3<Ntk, std::void_t<decltype( std::declval<Ntk>().has_xor3( std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>(), std::declval<signal<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_has_xor3_v = has_has_xor3<Ntk>::value;
 #pragma endregion
 
 #pragma region has_substitute_node

--- a/test/algorithms/aig_balancing.cpp
+++ b/test/algorithms/aig_balancing.cpp
@@ -1,0 +1,98 @@
+#include <catch.hpp>
+
+#include <algorithm>
+#include <vector>
+
+#include <mockturtle/algorithms/aig_balancing.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/views/depth_view.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "Balancing AND chain in AIG", "[aig_balancing]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+  const auto d = aig.create_pi();
+
+  aig.create_po( aig.create_and( a, aig.create_and( b, aig.create_and( c, d ) ) ) );
+
+  CHECK( depth_view{ aig }.depth() == 3u );
+
+  aig_balance( aig );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+}
+
+TEST_CASE( "Balance AND finding structural hashing", "[aig_balancing]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+  const auto d = aig.create_pi();
+
+  const auto f1 = aig.create_and( a, b );
+  const auto f2 = aig.create_and( f1, c );
+  const auto f3 = aig.create_and( b, c );
+  const auto f4 = aig.create_and( f3, d );
+
+  aig.create_po( f2 );
+  aig.create_po( f4 );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 4u );
+
+  aig_balancing_params ps;
+  ps.minimize_levels = false;
+  aig_balance( aig, ps );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 3u );
+}
+
+TEST_CASE( "Balance AND tree that is constant 0", "[aig_balancing]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+
+  const auto f1 = aig.create_and( a, b );
+  const auto f2 = aig.create_and( !a, c );
+  const auto f3 = aig.create_and( f1, f2 );
+
+  aig.create_po( f3 );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 3u );
+
+  aig_balance( aig );
+
+  CHECK( depth_view{ aig }.depth() == 0u );
+  CHECK( aig.num_gates() == 0u );
+}
+
+TEST_CASE( "Balance AND tree that has redundant leaves", "[aig_balancing]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+
+  const auto f1 = aig.create_and( a, b );
+  const auto f2 = aig.create_and( a, c );
+  const auto f3 = aig.create_and( f1, f2 );
+
+  aig.create_po( f3 );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 3u );
+
+  aig_balance( aig );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 2u );
+}

--- a/test/algorithms/xag_algebraic_rewriting.cpp
+++ b/test/algorithms/xag_algebraic_rewriting.cpp
@@ -1,0 +1,139 @@
+#include <catch.hpp>
+
+#include <mockturtle/algorithms/xag_algebraic_rewriting.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/traits.hpp>
+#include <mockturtle/views/depth_view.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "xag depth optimization with and associativity", "[xag_algebraic_rewriting]" )
+{
+  xag_network xag;
+
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+  const auto d = xag.create_pi();
+
+  const auto f1 = xag.create_and( a, b );
+  const auto f2 = xag.create_and( f1, c );
+  const auto f3 = xag.create_and( f2, d );
+
+  xag.create_po( f3 );
+
+  depth_view depth_xag{ xag };
+
+  CHECK( depth_xag.depth() == 3 );
+
+  xag_algebraic_depth_rewriting( depth_xag );
+
+  CHECK( depth_xag.depth() == 2 );
+}
+
+TEST_CASE( "xag depth optimization with xor associativity", "[xag_algebraic_rewriting]" )
+{
+  xag_network xag;
+
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+  const auto d = xag.create_pi();
+
+  const auto f1 = xag.create_xor( a, b );
+  const auto f2 = xag.create_xor( f1, c );
+  const auto f3 = xag.create_xor( f2, d );
+
+  xag.create_po( f3 );
+
+  depth_view depth_xag{ xag };
+
+  CHECK( depth_xag.depth() == 3 );
+
+  xag_algebraic_depth_rewriting( depth_xag );
+
+  CHECK( depth_xag.depth() == 2 );
+}
+
+TEST_CASE( "xag depth optimization with rare distributivity", "[xag_algebraic_rewriting]" )
+{
+  xag_network xag;
+
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+
+  const auto f1 = xag.create_and( a, b );
+  const auto f2 = xag.create_and( a, c );
+  const auto f3 = xag.create_or( f1, f2 );
+
+  xag.create_po( f3 );
+
+  depth_view depth_xag{ xag };
+
+  CHECK( depth_xag.depth() == 2 );
+  CHECK( depth_xag.num_gates() == 3 );
+
+  xag_algebraic_depth_rewriting_params ps;
+  ps.allow_rare_rules = true;
+  xag_algebraic_depth_rewriting( depth_xag, ps );
+
+  CHECK( depth_xag.depth() == 2 );
+  CHECK( depth_xag.num_gates() == 2 );
+}
+
+TEST_CASE( "xag depth optimization with and-or distributivity", "[xag_algebraic_rewriting]" )
+{
+  xag_network xag;
+
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+  const auto d = xag.create_pi();
+  const auto e = xag.create_pi();
+
+  const auto f1 = xag.create_xor( a, b );
+  const auto f2 = xag.create_and( f1, c );
+  const auto f3 = xag.create_or( f2, d );
+  const auto f4 = xag.create_and( f3, e );
+
+  xag.create_po( f4 );
+
+  depth_view depth_xag{ xag };
+
+  CHECK( depth_xag.depth() == 4 );
+  CHECK( depth_xag.num_gates() == 4 );
+
+  xag_algebraic_depth_rewriting( depth_xag );
+
+  CHECK( depth_xag.depth() == 3 );
+  CHECK( depth_xag.num_gates() == 5 );
+}
+
+TEST_CASE( "xag depth optimization with and-xor distributivity", "[xag_algebraic_rewriting]" )
+{
+  xag_network xag;
+
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+  const auto d = xag.create_pi();
+  const auto e = xag.create_pi();
+
+  const auto f1 = xag.create_xor( a, b );
+  const auto f2 = xag.create_and( f1, c );
+  const auto f3 = xag.create_xor( f2, d );
+  const auto f4 = xag.create_and( f3, e );
+
+  xag.create_po( f4 );
+
+  depth_view depth_xag{ xag };
+
+  CHECK( depth_xag.depth() == 4 );
+  CHECK( depth_xag.num_gates() == 4 );
+
+  xag_algebraic_depth_rewriting( depth_xag );
+
+  CHECK( depth_xag.depth() == 3 );
+  CHECK( depth_xag.num_gates() == 5 );
+}

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -292,6 +292,30 @@ TEST_CASE( "structural properties of an AIG", "[aig]" )
   CHECK( aig.fanout_size( aig.get_node( f2 ) ) == 1 );
 }
 
+TEST_CASE( "check has_and in AIG", "[aig]" )
+{
+  aig_network aig;
+  auto const x1 = aig.create_pi();
+  auto const x2 = aig.create_pi();
+  auto const x3 = aig.create_pi();
+
+  auto const n4 = aig.create_and( !x1, x2 );
+  auto const n5 = aig.create_and( x1, n4 );
+  auto const n6 = aig.create_and( x3, n5 );
+  auto const n7 = aig.create_and( n4, x2 );
+  auto const n8 = aig.create_and( !n5, !n7 );
+  auto const n9 = aig.create_and( !n8, n4 );
+
+  aig.create_po( n6 );
+  aig.create_po( n9 );
+
+  CHECK( aig.has_and( !x1, x2 ).has_value() == true );
+  CHECK( *aig.has_and( !x1, x2 ) == aig.get_node( n4 ) );
+  CHECK( aig.has_and( !x1, x3 ).has_value() == false );
+  CHECK( aig.has_and( !n7, !n5 ).has_value() == true );
+  CHECK( *aig.has_and( !n7, !n5 ) == aig.get_node( n8 ) );
+}
+
 TEST_CASE( "node and signal iteration in an AIG", "[aig]" )
 {
   aig_network aig;

--- a/test/networks/mig.cpp
+++ b/test/networks/mig.cpp
@@ -321,6 +321,25 @@ TEST_CASE( "structural properties of an MIG", "[mig]" )
   CHECK( mig.fanout_size( mig.get_node( f2 ) ) == 1 );
 }
 
+TEST_CASE( "check has_maj in MIG", "[mig]" )
+{
+  mig_network mig;
+
+  auto a = mig.create_pi();
+  auto b = mig.create_pi();
+  auto c = mig.create_pi();
+  auto d = mig.create_pi();
+
+  auto f = mig.create_maj( a, b, c );
+  auto g = mig.create_maj( a, c, d );
+
+  CHECK( mig.has_maj( a, b, c ).has_value() == true );
+  CHECK( *mig.has_maj( a, b, c ) == mig.get_node( f ) );
+  CHECK( mig.has_maj( a, b, d ).has_value() == false );
+  CHECK( mig.has_maj( !a, !c, !d ).has_value() == true );
+  CHECK( *mig.has_maj( !a, !c, !d ) == mig.get_node( g ) );
+}
+
 TEST_CASE( "node and signal iteration in an MIG", "[mig]" )
 {
   mig_network mig;

--- a/test/networks/xag.cpp
+++ b/test/networks/xag.cpp
@@ -615,6 +615,36 @@ TEST_CASE( "visited values in xags", "[xag]" )
   } );
 }
 
+TEST_CASE( "check has_and and has_xor in XAG", "[xag]" )
+{
+  xag_network xag;
+  auto const x1 = xag.create_pi();
+  auto const x2 = xag.create_pi();
+  auto const x3 = xag.create_pi();
+
+  auto const n4 = xag.create_and( !x1, x2 );
+  auto const n5 = xag.create_and( x1, n4 );
+  auto const n6 = xag.create_xor( x3, n5 );
+  auto const n7 = xag.create_and( n4, x2 );
+  auto const n8 = xag.create_and( !n5, !n7 );
+  auto const n9 = xag.create_xor( !n8, n4 );
+
+  xag.create_po( n6 );
+  xag.create_po( n9 );
+
+  CHECK( xag.has_and( !x1, x2 ).has_value() == true );
+  CHECK( *xag.has_and( !x1, x2 ) == xag.get_node( n4 ) );
+  CHECK( xag.has_xor( !x1, x2 ).has_value() == false );
+  CHECK( xag.has_and( !x1, x3 ).has_value() == false );
+  CHECK( xag.has_xor( !x1, x3 ).has_value() == false );
+  CHECK( xag.has_xor( n5, x3 ).has_value() == true );
+  CHECK( *xag.has_xor( n5, x3 ) == xag.get_node( n6 ) );
+  CHECK( xag.has_xor( !n5, !x3 ).has_value() == true );
+  CHECK( *xag.has_xor( !n5, !x3 ) == xag.get_node( n6 ) );
+  CHECK( xag.has_and( !n7, !n5 ).has_value() == true );
+  CHECK( *xag.has_and( !n7, !n5 ) == xag.get_node( n8 ) );
+}
+
 TEST_CASE( "simulate some special functions in XAGs", "[xag]" )
 {
   xag_network xag;

--- a/test/networks/xmg.cpp
+++ b/test/networks/xmg.cpp
@@ -242,6 +242,30 @@ TEST_CASE( "hash nodes in xmg network", "[xmg]" )
   CHECK( xmg.get_node( f1 ) == xmg.get_node( g1 ) );
 }
 
+TEST_CASE( "check has_maj and has_xor3 in xmg", "[xmg]" )
+{
+  xmg_network xmg;
+
+  auto a = xmg.create_pi();
+  auto b = xmg.create_pi();
+  auto c = xmg.create_pi();
+  auto d = xmg.create_pi();
+
+  auto f = xmg.create_maj( a, b, c );
+  auto g = xmg.create_maj( a, c, d );
+  auto p = xmg.create_xor3( a, c, d );
+
+  CHECK( xmg.has_maj( a, b, c ).has_value() == true );
+  CHECK( *xmg.has_maj( a, b, c ) == xmg.get_node( f ) );
+  CHECK( xmg.has_maj( a, b, d ).has_value() == false );
+  CHECK( xmg.has_maj( !a, !c, !d ).has_value() == true );
+  CHECK( *xmg.has_maj( !a, !c, !d ) == xmg.get_node( g ) );
+  CHECK( xmg.has_xor3( !a, !c, d ).has_value() == true );
+  CHECK( *xmg.has_xor3( !a, !c, d ) == xmg.get_node( p ) );
+  CHECK( xmg.has_xor3( a, !c, !d ).has_value() == true );
+  CHECK( *xmg.has_xor3( a, !c, !d ) == xmg.get_node( p ) );
+}
+
 TEST_CASE( "clone a XMG network", "[xmg]" )
 {
   CHECK( has_clone_v<xmg_network> );


### PR DESCRIPTION
This PR adds:
- AIG balancing
- XAG algebraic depth reduction (rules based on AND-associativity, XOR-associativity, AND-distributivity,  AND-OR-distributivity,  AND-XOR-distributivity)
- Methods to check if a node is present in the network given its immediate fanin (e.g., `has_and(f1, f2)` in `aig_network`).
   An example of the usage can be found in `aig_balance` in this PR