### PR TITLE
LUT maper updates

### DIFF
--- a/include/mockturtle/algorithms/lut_mapper.hpp
+++ b/include/mockturtle/algorithms/lut_mapper.hpp
@@ -827,7 +827,7 @@ private:
   {
     for ( auto i = 0u; i < node_match.size(); ++i )
     {
-      node_match[i].required = UINT32_MAX - 1;
+      node_match[i].required = UINT32_MAX << 1;
     }
 
     /* return in case of area_oriented_mapping */

--- a/include/mockturtle/algorithms/lut_mapper.hpp
+++ b/include/mockturtle/algorithms/lut_mapper.hpp
@@ -827,7 +827,7 @@ private:
   {
     for ( auto i = 0u; i < node_match.size(); ++i )
     {
-      node_match[i].required = UINT32_MAX << 1;
+      node_match[i].required = UINT32_MAX >> 1;
     }
 
     /* return in case of area_oriented_mapping */

--- a/include/mockturtle/algorithms/lut_mapper.hpp
+++ b/include/mockturtle/algorithms/lut_mapper.hpp
@@ -79,11 +79,14 @@ struct lut_map_params
    */
   cut_enumeration_params cut_enumeration_ps{};
 
+  /*! \brief Do area-oriented mapping. */
+  bool area_oriented_mapping{ false };
+
   /*! \brief Required depth for depth relaxation. */
   uint32_t required_delay{ 0u };
 
-  /*! \brief Do area-oriented mapping. */
-  bool area_oriented_mapping{ false };
+  /*! \brief Required depth relaxation ratio (%). */
+  uint32_t relax_required{ 0u };
 
   /*! \brief Recompute cuts at each step. */
   bool recompute_cuts{ true };
@@ -824,7 +827,7 @@ private:
   {
     for ( auto i = 0u; i < node_match.size(); ++i )
     {
-      node_match[i].required = UINT32_MAX;
+      node_match[i].required = UINT32_MAX - 1;
     }
 
     /* return in case of area_oriented_mapping */
@@ -832,6 +835,12 @@ private:
       return;
 
     uint32_t required = delay;
+
+    /* relax delay constraints */
+    if ( ps.required_delay == 0.0f && ps.relax_required > 0.0f )
+    {
+      required *= ( 100.0 + ps.relax_required ) / 100.0;
+    }
 
     if ( ps.required_delay != 0 )
     {

--- a/test/algorithms/lut_mapper.cpp
+++ b/test/algorithms/lut_mapper.cpp
@@ -159,6 +159,33 @@ TEST_CASE( "LUT map of 64-LUT network", "[lut_mapper]" )
   CHECK( mapped_aig.num_cells() == 114 );
 }
 
+TEST_CASE( "LUT map of 64-LUT network delay relaxed", "[lut_mapper]" )
+{
+  aig_network aig;
+
+  std::vector<aig_network::signal> a( 64 ), b( 64 );
+  std::generate( a.begin(), a.end(), [&aig]() { return aig.create_pi(); } );
+  std::generate( b.begin(), b.end(), [&aig]() { return aig.create_pi(); } );
+  auto carry = aig.get_constant( false );
+
+  carry_ripple_adder_inplace( aig, a, b, carry );
+
+  std::for_each( a.begin(), a.end(), [&]( auto f ) { aig.create_po( f ); } );
+  aig.create_po( carry );
+
+  mapping_view<aig_network, false> mapped_aig{ aig };
+
+  lut_map_params ps;
+  ps.area_oriented_mapping = false;
+  ps.relax_required = 1000;
+  ps.recompute_cuts = true;
+  ps.remove_dominated_cuts = false;
+  ps.edge_optimization = false;
+  lut_map<decltype( mapped_aig ), false>( mapped_aig, ps );
+
+  CHECK( mapped_aig.num_cells() == 114 );
+}
+
 TEST_CASE( "LUT map of 64-LUT network area", "[lut_mapper]" )
 {
   aig_network aig;


### PR DESCRIPTION
This PR updates the LUT mapper:
- Adding delay relaxation ratio: used for area-oriented mapping by mapping for delay first and then relaxing the required time