### PR TITLE
`rank_view` interface for logic networks

### DIFF
--- a/docs/views.rst
+++ b/docs/views.rst
@@ -28,6 +28,14 @@ algorithm.  Several views are implemented in mockturtle.
 .. doxygenclass:: mockturtle::depth_view
    :members:
 
+`rank_view`: Order nodes within each level
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Header:** ``mockturtle/views/rank_view.hpp``
+
+.. doxygenclass:: mockturtle::rank_view
+   :members:
+
 `mapping_view`: Add mapping interface methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/mockturtle/traits.hpp
+++ b/include/mockturtle/traits.hpp
@@ -977,6 +977,111 @@ template<class Ntk>
 inline constexpr bool has_update_levels_v = has_update_levels<Ntk>::value;
 #pragma endregion
 
+#pragma region has_rank_position
+template<class Ntk, class = void>
+struct has_rank_position : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_rank_position<Ntk, std::void_t<decltype( std::declval<Ntk>().rank_position( std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_rank_position_v = has_rank_position<Ntk>::value;
+#pragma endregion
+
+#pragma region has_at_rank_position
+template<class Ntk, class = void>
+struct has_at_rank_position : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_at_rank_position<Ntk, std::void_t<decltype( std::declval<Ntk>().at_rank_position( std::declval<uint32_t>(), std::declval<uint32_t>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_at_rank_position_v = has_at_rank_position<Ntk>::value;
+#pragma endregion
+
+#pragma region has_width
+template<class Ntk, class = void>
+struct has_width : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_width<Ntk, std::void_t<decltype( std::declval<Ntk>().width() )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_width_v = has_width<Ntk>::value;
+#pragma endregion
+
+#pragma region has_swap
+template<class Ntk, class = void>
+struct has_swap : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_swap<Ntk, std::void_t<decltype( std::declval<Ntk>().swap( std::declval<node<Ntk>>(), std::declval<node<Ntk>>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_swap_v = has_swap<Ntk>::value;
+#pragma endregion
+
+#pragma region has_sort_rank
+template<class Ntk, class = void>
+struct has_sort_rank : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_sort_rank<Ntk, std::void_t<decltype( std::declval<Ntk>().sort_rank( std::declval<uint32_t>(), std::declval<void( node<Ntk>, node<Ntk> )>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_sort_rank_v = has_sort_rank<Ntk>::value;
+#pragma endregion
+
+#pragma region has_foreach_node_in_rank
+template<class Ntk, class = void>
+struct has_foreach_node_in_rank : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_foreach_node_in_rank<Ntk, std::void_t<decltype( std::declval<Ntk>().foreach_node_in_rank( std::declval<uint32_t>(), std::declval<void( node<Ntk>, uint32_t )>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_foreach_node_in_rank_v = has_foreach_node_in_rank<Ntk>::value;
+#pragma endregion
+
+#pragma region has_foreach_gate_in_rank
+template<class Ntk, class = void>
+struct has_foreach_gate_in_rank : std::false_type
+{
+};
+
+template<class Ntk>
+struct has_foreach_gate_in_rank<Ntk, std::void_t<decltype( std::declval<Ntk>().foreach_gate_in_rank( std::declval<uint32_t>(), std::declval<void( node<Ntk>, uint32_t )>() ) )>> : std::true_type
+{
+};
+
+template<class Ntk>
+inline constexpr bool has_foreach_gate_in_rank_v = has_foreach_gate_in_rank<Ntk>::value;
+#pragma endregion
+
 #pragma region has_update_mffcs
 template<class Ntk, class = void>
 struct has_update_mffcs : std::false_type

--- a/include/mockturtle/views/rank_view.hpp
+++ b/include/mockturtle/views/rank_view.hpp
@@ -24,10 +24,10 @@
  */
 
 /*!
-  \file rank_view.hpp
-  \brief Implements rank orders for a network
+ \file rank_view.hpp
+ \brief Implements rank orders for a network
 
-  \author Marcel Walter
+ \author Marcel Walter
 */
 
 #pragma once
@@ -35,31 +35,72 @@
 #include "../networks/detail/foreach.hpp"
 #include "../traits.hpp"
 #include "../utils/node_map.hpp"
+#include "depth_view.hpp"
 
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <functional>
+#include <utility>
 #include <vector>
 
 namespace mockturtle
 {
 
-template<class Ntk, bool has_rank_interface = false>
+/*! \brief Implements rank orders for a network.
+*
+* This view assigns manipulable relative orders to the nodes of each level.
+* A sequence of nodes in the same level is called a rank. The width
+* of a rank is thereby defined as the number of nodes in the rank. The width of
+* the network is equal to the width of the widest rank. This view implements
+* functions to retrieve the assigned node position within a rank (`rank_position`)
+* as well as to fetch the node in a certain rank at a certain position (`at_rank_position`).
+* The ranks are assigned at construction and can be manipulated by calling the `swap` function.
+*
+* This view also automatically inserts new nodes into their respective rank (at the end),
+* however, it does not update the information, when modifying or deleting nodes.
+*
+* **Required network functions:**
+* -  foreach_node
+* -  get_node
+* -  num_pis
+* -  is_ci
+* -  is_constant
+*
+* Example
+*
+  \verbatim embed:rst
+
+  .. code-block:: c++
+
+     // create network somehow
+     aig_network aig = ...;
+
+     // create a depth view on the network
+     depth_view aig_depth{aig};
+     // create a rank view on the depth view
+     rank_view aig_rank{aig_depth};
+
+     // print width
+     std::cout << "Width: " << aig_rank.width() << "\n";
+  \endverbatim
+*/
+template<class Ntk, bool has_rank_interface = has_rank_position_v<Ntk>&& has_at_rank_position_v<Ntk>&& has_swap_v<Ntk>&& has_width_v<Ntk>&& has_foreach_node_in_rank_v<Ntk>&& has_foreach_gate_in_rank_v<Ntk>>
 class rank_view
 {
 };
 
 template<class Ntk>
-class rank_view<Ntk, true> : public Ntk
+class rank_view<Ntk, true> : public depth_view<Ntk>
 {
 public:
-  rank_view( Ntk const& ntk ) : Ntk( ntk )
+  rank_view( Ntk const& ntk ) : depth_view<Ntk>( ntk )
   {
   }
 };
 
 template<class Ntk>
-class rank_view<Ntk, false> : public Ntk
+class rank_view<Ntk, false> : public depth_view<Ntk>
 {
 public:
   static constexpr bool is_topologically_sorted = true;
@@ -68,9 +109,16 @@ public:
   using signal = typename Ntk::signal;
 
   explicit rank_view()
-      : Ntk()
+      : depth_view<Ntk>(), rank_pos{ *this }, ranks{}, max_rank_width{ 0 }
   {
     static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+    static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+    static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+    static_assert( has_num_pis_v<Ntk>, "Ntk does not implement the num_pis method" );
+    static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
+    static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
+
+    add_event = Ntk::events().register_add_event( [this]( auto const& n ) { on_add( n ); } );
   }
 
   /*! \brief Standard constructor.
@@ -78,11 +126,238 @@ public:
    * \param ntk Base network
    */
   explicit rank_view( Ntk const& ntk )
-      : Ntk( ntk )
+      : depth_view<Ntk>{ ntk }, rank_pos{ ntk }, ranks{ this->depth() + 1 }, max_rank_width{ 0 }
   {
     static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+    static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+    static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+    static_assert( has_num_pis_v<Ntk>, "Ntk does not implement the num_pis method" );
+    static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
+    static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
+
+    init_ranks();
+
+    add_event = Ntk::events().register_add_event( [this]( auto const& n ) { on_add( n ); } );
   }
 
+  /*! \brief Copy constructor. */
+  rank_view( rank_view<Ntk, false> const& other )
+      : depth_view<Ntk>( other ), rank_pos{ other.rank_pos }, ranks{ other.ranks }, max_rank_width{ other.max_rank_width }
+  {
+    add_event = Ntk::events().register_add_event( [this]( auto const& n ) { on_add( n ); } );
+  }
+
+  rank_view<Ntk, false>& operator=( rank_view<Ntk, false> const& other )
+  {
+    /* delete the event of this network */
+    Ntk::events().release_add_event( add_event );
+
+    /* update the base class */
+    this->_storage = other._storage;
+    this->_events = other._events;
+
+    /* copy */
+    rank_pos = other.rank_pos;
+    ranks = other.ranks;
+    max_rank_width = other.max_rank_width;
+
+    /* register new event in the other network */
+    add_event = Ntk::events().register_add_event( [this]( auto const& n ) { on_add( n ); } );
+
+    return *this;
+  }
+
+  ~rank_view()
+  {
+    Ntk::events().release_add_event( add_event );
+  }
+
+  uint32_t rank_position( node const& n ) const noexcept
+  {
+    assert( !this->is_constant( n ) && "node must not be constant" );
+
+    return rank_pos[n];
+  }
+
+  node at_rank_position( uint32_t const level, uint32_t const pos ) const noexcept
+  {
+    assert( level < ranks.size() && "level must be less than the number of ranks" );
+    assert( pos < ranks[level].size() && "pos must be less than the number of nodes in rank" );
+
+    return ranks[level][pos];
+  }
+
+  uint32_t width() const noexcept
+  {
+    return max_rank_width;
+  }
+
+  void swap( node const& n1, node const& n2 ) noexcept
+  {
+    assert( this->level( n1 ) == this->level( n2 ) && "nodes must be in the same rank" );
+
+    auto& pos1 = rank_pos[n1];
+    auto& pos2 = rank_pos[n2];
+
+    std::swap( ranks[this->level( n1 )][pos1], ranks[this->level( n2 )][pos2] );
+    std::swap( pos1, pos2 );
+  }
+  /**
+   * \brief Sorts the given rank according to a comparator.
+   *
+   * @tparam Cmp Functor type that compares two nodes. It needs to fulfill the requirements of `Compare` (named C++ requirement).
+   * @param level The level of the rank to sort.
+   * @param cmp The comparator to use.
+   */
+  template<typename Cmp>
+  void sort_rank( uint32_t const level, Cmp const& cmp )
+  {
+    // level must be less than the number of ranks
+    if ( level < ranks.size() )
+    {
+      auto& rank = ranks[level];
+
+      std::sort( rank.begin(), rank.end(), cmp );
+      std::for_each( rank.cbegin(), rank.cend(), [this, i = 0u]( auto const& n ) mutable { rank_pos[n] = i++; } );
+    }
+  }
+  /**
+   * \brief Applies a given function to each node in the rank level in order.
+   *
+   * @tparam Fn Functor type.
+   * @param level The rank to apply fn to.
+   * @param fn The function to apply.
+   */
+  template<typename Fn>
+  void foreach_node_in_rank( uint32_t const level, Fn&& fn ) const
+  {
+    // level must be less than the number of ranks
+    if ( level < ranks.size() )
+    {
+      auto const& rank = ranks[level];
+
+      detail::foreach_element( rank.cbegin(), rank.cend(), std::forward<Fn>( fn ) );
+    }
+  }
+  /**
+   * \brief Applies a given function to each node in rank order.
+   *
+   * This function overrides the `foreach_node` method of the base class.
+   *
+   * @tparam Fn Functor type.
+   * @param fn The function to apply.
+   */
+  template<typename Fn>
+  void foreach_node( Fn&& fn ) const
+  {
+    for ( auto l = 0; l < ranks.size(); ++l )
+    {
+      foreach_node_in_rank( l, std::forward<Fn>( fn ) );
+    }
+  }
+  /**
+   * \brief Applies a given function to each gate in the rank level in order.
+   *
+   * @tparam Fn Functor type.
+   * @param level The rank to apply fn to.
+   * @param fn The function to apply.
+   */
+  template<typename Fn>
+  void foreach_gate_in_rank( uint32_t const level, Fn&& fn ) const
+  {
+    // level must be less than the number of ranks
+    if ( level < ranks.size() )
+    {
+      auto const& rank = ranks[level];
+
+      detail::foreach_element_if(
+          rank.cbegin(), rank.cend(), [this]( auto const& n ) { return !this->is_ci( n ); }, std::forward<Fn>( fn ) );
+    }
+  }
+  /**
+   * \brief Applies a given function to each gate in rank order.
+   *
+   * This function overrides the `foreach_gate` method of the base class.
+   *
+   * @tparam Fn Functor type.
+   * @param fn The function to apply.
+   */
+  template<typename Fn>
+  void foreach_gate( Fn&& fn ) const
+  {
+    for ( auto l = 0; l < ranks.size(); ++l )
+    {
+      foreach_gate_in_rank( l, std::forward<Fn>( fn ) );
+    }
+  }
+  /**
+   * \brief Applies a given function to each PI in rank order.
+   *
+   * This function overrides the `foreach_pi` method of the base class.
+   *
+   * @tparam Fn Functor type.
+   * @param fn The function to apply.
+   */
+  template<typename Fn>
+  void foreach_pi( Fn&& fn ) const
+  {
+    std::vector<node> pis{};
+    pis.reserve( this->num_pis() );
+
+    depth_view<Ntk>::foreach_pi( [&pis]( auto const& pi ) { pis.push_back( pi ); } );
+    std::sort( pis.begin(), pis.end(), [this]( auto const& n1, auto const& n2 ) { return rank_pos[n1] < rank_pos[n2]; } );
+    detail::foreach_element( pis.cbegin(), pis.cend(), std::forward<Fn>( fn ) );
+  }
+  /**
+   * Overrides the base class method to also call the add_event on create_pi().
+   *
+   * @note This can (and in fact will) lead to issues if Ntk already calls add_event functions on create_pi()!
+   *
+   * @return Newly created PI signal.
+   */
+  signal create_pi()
+  {
+    auto const n = depth_view<Ntk>::create_pi();
+    this->resize_levels();
+    on_add( this->get_node( n ) );
+    return n;
+  }
+
+private:
+  node_map<uint32_t, Ntk> rank_pos;
+  std::vector<std::vector<node>> ranks;
+  uint32_t max_rank_width;
+
+  std::shared_ptr<typename network_events<Ntk>::add_event_type> add_event;
+
+  void insert_in_rank( node const& n ) noexcept
+  {
+    auto& rank = ranks[this->level( n )];
+    rank_pos[n] = rank.size();
+    rank.push_back( n );
+    max_rank_width = std::max( max_rank_width, static_cast<uint32_t>( rank.size() ) );
+  }
+
+  void on_add( node const& n ) noexcept
+  {
+    if ( this->level( n ) >= ranks.size() )
+    {
+      // add sufficient ranks to store the new node
+      ranks.insert( ranks.end(), this->level( n ) - ranks.size() + 1, {} );
+    }
+    rank_pos.resize();
+
+    insert_in_rank( n );
+  }
+
+  void init_ranks() noexcept
+  {
+    depth_view<Ntk>::foreach_node( [this]( auto const& n ) {
+     if (!this->is_constant(n))
+     {
+       insert_in_rank(n);
+     } } );
+  }
 };
 
 template<class T>

--- a/test/views/rank_view.cpp
+++ b/test/views/rank_view.cpp
@@ -1,0 +1,337 @@
+#include <catch.hpp>
+
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/buffered.hpp>
+#include <mockturtle/networks/cover.hpp>
+#include <mockturtle/networks/crossed.hpp>
+#include <mockturtle/networks/klut.hpp>
+#include <mockturtle/networks/mig.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/networks/xmg.hpp>
+#include <mockturtle/traits.hpp>
+#include <mockturtle/views/rank_view.hpp>
+
+#include <functional>
+#include <memory>
+
+using namespace mockturtle;
+
+TEMPLATE_TEST_CASE( "traits", "[rank_view]", aig_network, mig_network, xag_network, xmg_network, klut_network, cover_network, buffered_aig_network, buffered_mig_network, crossed_klut_network, buffered_crossed_klut_network )
+{
+  CHECK( is_network_type_v<TestType> );
+  CHECK( !has_rank_position_v<TestType> );
+  CHECK( !has_at_rank_position_v<TestType> );
+  CHECK( !has_width_v<TestType> );
+  CHECK( !has_sort_rank_v<TestType> );
+  CHECK( !has_foreach_node_in_rank_v<TestType> );
+  CHECK( !has_foreach_gate_in_rank_v<TestType> );
+  CHECK( !is_topologically_sorted_v<TestType> );
+
+  using rank_ntk = rank_view<TestType>;
+
+  CHECK( is_network_type_v<rank_ntk> );
+  CHECK( has_rank_position_v<rank_ntk> );
+  CHECK( has_at_rank_position_v<rank_ntk> );
+  CHECK( has_width_v<rank_ntk> );
+  CHECK( has_sort_rank_v<rank_ntk> );
+  CHECK( has_foreach_node_in_rank_v<rank_ntk> );
+  CHECK( has_foreach_gate_in_rank_v<rank_ntk> );
+  CHECK( is_topologically_sorted_v<rank_ntk> );
+
+  using rank_rank_ntk = rank_view<rank_ntk>;
+
+  CHECK( is_network_type_v<rank_rank_ntk> );
+  CHECK( has_rank_position_v<rank_rank_ntk> );
+  CHECK( has_at_rank_position_v<rank_rank_ntk> );
+  CHECK( has_width_v<rank_rank_ntk> );
+  CHECK( has_sort_rank_v<rank_rank_ntk> );
+  CHECK( has_foreach_node_in_rank_v<rank_rank_ntk> );
+  CHECK( has_foreach_gate_in_rank_v<rank_rank_ntk> );
+  CHECK( is_topologically_sorted_v<rank_rank_ntk> );
+}
+
+TEMPLATE_TEST_CASE( "compute ranks for a simple network", "[rank_view]", aig_network, mig_network, xag_network, xmg_network, klut_network, cover_network, buffered_aig_network, buffered_mig_network, crossed_klut_network, buffered_crossed_klut_network )
+{
+  TestType ntk{};
+  auto const x1 = ntk.create_pi();
+  auto const x2 = ntk.create_pi();
+  auto const a1 = ntk.create_and( x1, x2 );
+  ntk.create_po( a1 );
+
+  rank_view rank_ntk{ ntk };
+
+  REQUIRE( rank_ntk.size() == ntk.size() );
+
+  CHECK( rank_ntk.width() == 2u );
+
+  auto const x1_lvl = rank_ntk.level( rank_ntk.get_node( x1 ) );
+  auto const x2_lvl = rank_ntk.level( rank_ntk.get_node( x2 ) );
+  auto const a1_lvl = rank_ntk.level( rank_ntk.get_node( a1 ) );
+
+  CHECK( x1_lvl == 0u );
+  CHECK( x2_lvl == 0u );
+  CHECK( a1_lvl == 1u );
+
+  auto const x1_pos = rank_ntk.rank_position( rank_ntk.get_node( x1 ) );
+  auto const x2_pos = rank_ntk.rank_position( rank_ntk.get_node( x2 ) );
+  auto const a1_pos = rank_ntk.rank_position( rank_ntk.get_node( a1 ) );
+
+  CHECK( ( x1_pos == 0u || x1_pos == 1u ) );
+  CHECK( ( x2_pos == 0u || x2_pos == 1u ) );
+  CHECK( a1_pos == 0u );
+
+  CHECK( rank_ntk.at_rank_position( x1_lvl, x1_pos ) == rank_ntk.get_node( x1 ) );
+  CHECK( rank_ntk.at_rank_position( x2_lvl, x2_pos ) == rank_ntk.get_node( x2 ) );
+  CHECK( rank_ntk.at_rank_position( a1_lvl, a1_pos ) == rank_ntk.get_node( a1 ) );
+
+  rank_ntk.foreach_node_in_rank( 0ul, [&]( auto const& n, auto i ) {
+    switch (i)
+    {
+    case( 0ul ):
+    {
+      CHECK( n == rank_ntk.get_node( x1 ) );
+      break;
+    }
+    case( 1ul ):
+    {
+      CHECK( n == rank_ntk.get_node( x2 ) );
+      break;
+    }
+    default:
+    {
+      CHECK( false );
+    }
+    } } );
+
+  rank_ntk.foreach_node_in_rank( 1ul, [&]( auto const& n ) { CHECK( n == rank_ntk.get_node( a1 ) ); } );
+
+  rank_ntk.swap( rank_ntk.get_node( x1 ), rank_ntk.get_node( x2 ) );
+
+  CHECK( rank_ntk.at_rank_position( x1_lvl, x1_pos ) == rank_ntk.get_node( x2 ) );
+  CHECK( rank_ntk.at_rank_position( x2_lvl, x2_pos ) == rank_ntk.get_node( x1 ) );
+
+  rank_ntk.foreach_node_in_rank( 0ul, [&]( auto const& n, auto i ) {
+    switch (i)
+    {
+    case( 0ul ):
+    {
+      CHECK( n == rank_ntk.get_node( x2 ) );
+      break;
+    }
+    case( 1ul ):
+    {
+      CHECK( n == rank_ntk.get_node( x1 ) );
+      break;
+    }
+    default:
+    {
+      CHECK( false );
+    }
+    } } );
+}
+
+TEMPLATE_TEST_CASE( "compute ranks during node construction", "[rank_view]", aig_network, mig_network, xag_network, xmg_network, klut_network, cover_network, buffered_aig_network, buffered_mig_network, crossed_klut_network, buffered_crossed_klut_network )
+{
+  depth_view const depth_ntk{ TestType{} };
+  rank_view rank_ntk{ depth_ntk };
+
+  auto const a = rank_ntk.create_pi();
+  auto const b = rank_ntk.create_pi();
+  auto const c = rank_ntk.create_pi();
+
+  auto const a1 = rank_ntk.create_and( a, b );
+  auto const a2 = rank_ntk.create_and( a1, c );
+  rank_ntk.create_po( a2 );
+
+  CHECK( rank_ntk.width() == 3u );
+
+  rank_ntk.foreach_node_in_rank( 0ul, [&]( auto const& n, auto i ) {
+    switch (i)
+    {
+    case( 0ul ):
+    {
+      CHECK( n == rank_ntk.get_node( a ) );
+      break;
+    }
+    case( 1ul ):
+    {
+      CHECK( n == rank_ntk.get_node( b ) );
+      break;
+    }
+    case ( 2ul ):
+    {
+      CHECK( n == rank_ntk.get_node( c ) );
+      break;
+    }
+    default:
+    {
+      CHECK( false );
+    }
+    } } );
+
+  rank_ntk.foreach_node_in_rank( 1ul, [&]( auto const& n, auto i ) {
+    switch (i)
+    {
+    case( 0ul ):
+    {
+      CHECK( n == rank_ntk.get_node( a1 ) );
+      break;
+    }
+    case( 1ul ):
+    {
+      CHECK( n == rank_ntk.get_node( a2 ) );
+      break;
+    }
+    default:
+    {
+      CHECK( false );
+    }
+    } } );
+
+  auto const a3 = rank_ntk.create_and( b, c );
+  auto const a4 = rank_ntk.create_and( a, c );
+  auto const o1 = rank_ntk.create_or( a, b );
+  auto const o2 = rank_ntk.create_or( a3, a4 );
+  rank_ntk.create_po( o1 );
+  rank_ntk.create_po( o2 );
+
+  CHECK( rank_ntk.width() == 4u );
+}
+
+TEMPLATE_TEST_CASE( "compute ranks during node construction after copy ctor", "[rank_view]", aig_network, mig_network, xag_network, xmg_network, klut_network, cover_network, buffered_aig_network, buffered_mig_network, crossed_klut_network, buffered_crossed_klut_network )
+{
+  TestType ntk{};
+  {
+    auto tmp = std::make_unique<rank_view<TestType>>( ntk );
+    CHECK( ntk.events().on_add.size() == 2u );
+
+    rank_view cpy_rank{ *tmp }; // copy ctor
+    CHECK( ntk.events().on_add.size() == 4u );
+
+    tmp.reset(); // don't access tmp anymore after this line!
+    CHECK( ntk.events().on_add.size() == 2u );
+
+    auto const a = cpy_rank.create_pi();
+    auto const b = cpy_rank.create_pi();
+    auto const c = cpy_rank.create_pi();
+    auto const t0 = cpy_rank.create_or( a, b );
+    auto const t1 = cpy_rank.create_or( b, c );
+    auto const t2 = cpy_rank.create_and( t0, t1 );
+    auto const t3 = cpy_rank.create_or( b, t2 );
+    cpy_rank.create_po( t3 );
+    CHECK( cpy_rank.width() == 3u );
+
+    auto const t4 = cpy_rank.create_and( a, c );
+    auto const t5 = cpy_rank.create_or( a, c );
+    auto const t6 = cpy_rank.create_and( t4, t5 );
+    cpy_rank.create_po( t6 );
+    CHECK( cpy_rank.width() == 4u );
+
+    CHECK( ntk.events().on_add.size() == 2u );
+  }
+
+  CHECK( ntk.events().on_add.size() == 0u );
+}
+
+TEMPLATE_TEST_CASE( "compute ranks during node construction after copy assignment", "[rank_view]", aig_network, mig_network, xag_network, xmg_network, klut_network, cover_network, buffered_aig_network, buffered_mig_network, crossed_klut_network, buffered_crossed_klut_network )
+{
+  rank_view<TestType> rank_ntk{};
+  {
+    auto tmp = std::make_unique<rank_view<TestType>>( rank_ntk );
+    rank_ntk = *tmp; // copy assignment
+    tmp.reset();
+  }
+
+  auto const a = rank_ntk.create_pi();
+  auto const b = rank_ntk.create_pi();
+  auto const c = rank_ntk.create_pi();
+  rank_ntk.create_po( rank_ntk.create_or( b, rank_ntk.create_and( rank_ntk.create_or( a, b ), rank_ntk.create_or( b, c ) ) ) );
+
+  CHECK( rank_ntk.width() == 3u );
+}
+
+TEMPLATE_TEST_CASE( "sort ranks according to a comparator", "[rank_view]", aig_network, mig_network, xag_network, xmg_network, klut_network, cover_network, buffered_aig_network, buffered_mig_network, crossed_klut_network, buffered_crossed_klut_network )
+{
+  using Ntk = rank_view<TestType>;
+
+  Ntk rank_ntk{};
+
+  auto const a = rank_ntk.create_pi();
+  auto const b = rank_ntk.create_pi();
+
+  auto const a1 = rank_ntk.create_and( a, b );
+
+  auto const c = rank_ntk.create_pi();
+
+  auto const a2 = rank_ntk.create_and( a1, c );
+
+  rank_ntk.create_po( a2 );
+
+  // verify order before sorting
+  REQUIRE( rank_ntk.rank_position( rank_ntk.get_node( a ) ) == 0u );
+  REQUIRE( rank_ntk.rank_position( rank_ntk.get_node( b ) ) == 1u );
+  REQUIRE( rank_ntk.rank_position( rank_ntk.get_node( c ) ) == 2u );
+
+  REQUIRE( rank_ntk.at_rank_position( 0u, 0u ) == rank_ntk.get_node( a ) );
+  REQUIRE( rank_ntk.at_rank_position( 0u, 1u ) == rank_ntk.get_node( b ) );
+  REQUIRE( rank_ntk.at_rank_position( 0u, 2u ) == rank_ntk.get_node( c ) );
+
+  // sort rank 0 in descending order
+  rank_ntk.sort_rank( 0u, std::greater<node<Ntk>>{} );
+
+  // check order after sorting
+  CHECK( rank_ntk.rank_position( rank_ntk.get_node( a ) ) == 2u );
+  CHECK( rank_ntk.rank_position( rank_ntk.get_node( b ) ) == 1u );
+  CHECK( rank_ntk.rank_position( rank_ntk.get_node( c ) ) == 0u );
+
+  CHECK( rank_ntk.at_rank_position( 0u, 2u ) == rank_ntk.get_node( a ) );
+  CHECK( rank_ntk.at_rank_position( 0u, 0u ) == rank_ntk.get_node( c ) );
+  CHECK( rank_ntk.at_rank_position( 0u, 1u ) == rank_ntk.get_node( b ) );
+
+  // sort rank 0 in ascending order
+  rank_ntk.sort_rank( 0u, std::less<node<Ntk>>{} );
+
+  CHECK( rank_ntk.rank_position( rank_ntk.get_node( a ) ) == 0u );
+  CHECK( rank_ntk.rank_position( rank_ntk.get_node( b ) ) == 1u );
+  CHECK( rank_ntk.rank_position( rank_ntk.get_node( c ) ) == 2u );
+
+  CHECK( rank_ntk.at_rank_position( 0u, 0u ) == rank_ntk.get_node( a ) );
+  CHECK( rank_ntk.at_rank_position( 0u, 1u ) == rank_ntk.get_node( b ) );
+  CHECK( rank_ntk.at_rank_position( 0u, 2u ) == rank_ntk.get_node( c ) );
+}
+
+template<typename Ntk>
+void check_pi_permutation( Ntk const& ntk, std::vector<node<Ntk>> const& perm )
+{
+  REQUIRE( ntk.num_pis() == perm.size() );
+  ntk.foreach_pi( [&]( auto const& n, auto const i ) {
+    CHECK( n == perm[i] );
+  } );
+}
+
+TEMPLATE_TEST_CASE( "sort primary inputs", "[rank_view]", aig_network, mig_network, xag_network, xmg_network, klut_network, cover_network, buffered_aig_network, buffered_mig_network, crossed_klut_network, buffered_crossed_klut_network )
+{
+  using Ntk = rank_view<TestType>;
+
+  Ntk rank_ntk{};
+
+  auto const a = rank_ntk.get_node( rank_ntk.create_pi() );
+  auto const b = rank_ntk.get_node( rank_ntk.create_pi() );
+  auto const c = rank_ntk.get_node( rank_ntk.create_pi() );
+  auto const d = rank_ntk.get_node( rank_ntk.create_pi() );
+  auto const e = rank_ntk.get_node( rank_ntk.create_pi() );
+  // order is a, b, c, d, e
+  check_pi_permutation( rank_ntk, { a, b, c, d, e } );
+
+  rank_ntk.swap( a, b );
+  // order is b, a, c, d, e
+  check_pi_permutation( rank_ntk, { b, a, c, d, e } );
+
+  rank_ntk.swap( c, d );
+  // order is b, a, d, c, e
+  check_pi_permutation( rank_ntk, { b, a, d, c, e } );
+
+  rank_ntk.swap( c, e );
+  // order is b, a, d, e, c
+  check_pi_permutation( rank_ntk, { b, a, d, e, c } );
+}


### PR DESCRIPTION
A `rank_view` tracks node positions within each level of the network. Nodes can be swapped within their ranks, sorted given a comparator, and iterated over in rank order.