### PR TITLE
Fix `substitute_node`; substitute without re-strashing

### DIFF
--- a/include/mockturtle/algorithms/cut_rewriting.hpp
+++ b/include/mockturtle/algorithms/cut_rewriting.hpp
@@ -550,10 +550,7 @@ public:
         std::cout << "[i] optimize cut #" << v_cut << " in node #" << ntk.node_to_index( v_node ) << " and replace with node " << ntk.node_to_index( ntk.get_node( replacement ) ) << "\n";
       }
 
-      if ( !ntk.is_dead( ntk.get_node( replacement ) ) )
-      {
-        ntk.substitute_node( v_node, replacement );
-      }
+      ntk.substitute_node( v_node, replacement );
     }
   }
 

--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -543,7 +543,7 @@ public:
     if ( n == 0 || is_ci( n ) || is_dead( n ) )
       return;
 
-    /* delete the node (ignoring it's current fanout_size) */
+    /* delete the node (ignoring its current fanout_size) */
     auto& nobj = _storage->nodes[n];
     nobj.data[0].h1 = UINT32_C( 0x80000000 ); /* fanout size 0, but dead */
     _storage->hash.erase( nobj );
@@ -568,6 +568,32 @@ public:
     }
   }
 
+  void revive_node( node const& n )
+  {
+    if ( !is_dead( n ) )
+      return;
+    
+    assert( n < _storage->nodes.size() );
+    auto& nobj = _storage->nodes[n];
+    nobj.data[0].h1 = UINT32_C( 0 ); /* fanout size 0, but not dead (like just created) */
+    _storage->hash[nobj] = n;
+
+    for ( auto const& fn : _events->on_add )
+    {
+      ( *fn )( n );
+    }
+
+    /* revive its children if dead, and increment their fanout_size */
+    for ( auto i = 0u; i < 2u; ++i )
+    {
+      if ( is_dead( nobj.children[i].index ) )
+      {
+        revive_node( nobj.children[i].index );
+      }
+      incr_fanout_size( nobj.children[i].index );
+    }
+  }
+
   inline bool is_dead( node const& n ) const
   {
     return ( _storage->nodes[n].data[0].h1 >> 31 ) & 1;
@@ -585,11 +611,20 @@ public:
       to_substitute.pop();
 
       signal _new = _curr;
-      while ( is_dead( get_node( _new ) ) )
+      /* find the real new node */
+      if ( is_dead( get_node( _new ) ) )
       {
-        const auto it = old_to_new.find( get_node( _new ) );
-        assert( it != old_to_new.end() );
-        _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+        auto it = old_to_new.find( get_node( _new ) );
+        while ( it != old_to_new.end() )
+        {
+          _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+          it = old_to_new.find( get_node( _new ) );
+        }
+      }
+      /* revive */
+      if ( is_dead( get_node( _new ) ) )
+      {
+        revive_node( get_node( _new ) );
       }
 
       for ( auto idx = 1u; idx < _storage->nodes.size(); ++idx )

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -604,6 +604,32 @@ public:
     }
   }
 
+  void revive_node( node const& n )
+  {
+    if ( !is_dead( n ) )
+      return;
+
+    assert( n < _storage->nodes.size() );
+    auto& nobj = _storage->nodes[n];
+    nobj.data[0].h1 = UINT32_C( 0 ); /* fanout size 0, but not dead (like just created) */
+    _storage->hash[nobj] = n;
+
+    for ( auto const& fn : _events->on_add )
+    {
+      ( *fn )( n );
+    }
+
+    /* revive its children if dead, and increment their fanout_size */
+    for ( auto i = 0u; i < 3u; ++i )
+    {
+      if ( is_dead( nobj.children[i].index ) )
+      {
+        revive_node( nobj.children[i].index );
+      }
+      incr_fanout_size( nobj.children[i].index );
+    }
+  }
+
   inline bool is_dead( node const& n ) const
   {
     return ( _storage->nodes[n].data[0].h1 >> 31 ) & 1;
@@ -621,11 +647,20 @@ public:
       to_substitute.pop();
 
       signal _new = _curr;
-      while ( is_dead( get_node( _new ) ) )
+      /* find the real new node */
+      if ( is_dead( get_node( _new ) ) )
       {
-        const auto it = old_to_new.find( get_node( _new ) );
-        assert( it != old_to_new.end() );
-        _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+        auto it = old_to_new.find( get_node( _new ) );
+        while ( it != old_to_new.end() )
+        {
+          _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+          it = old_to_new.find( get_node( _new ) );
+        }
+      }
+      /* revive */
+      if ( is_dead( get_node( _new ) ) )
+      {
+        revive_node( get_node( _new ) );
       }
 
       for ( auto idx = 1u; idx < _storage->nodes.size(); ++idx )

--- a/include/mockturtle/networks/xag.hpp
+++ b/include/mockturtle/networks/xag.hpp
@@ -637,6 +637,32 @@ public:
     }
   }
 
+  void revive_node( node const& n )
+  {
+    if ( !is_dead( n ) )
+      return;
+
+    assert( n < _storage->nodes.size() );
+    auto& nobj = _storage->nodes[n];
+    nobj.data[0].h1 = UINT32_C( 0 ); /* fanout size 0, but not dead (like just created) */
+    _storage->hash[nobj] = n;
+
+    for ( auto const& fn : _events->on_add )
+    {
+      ( *fn )( n );
+    }
+
+    /* revive its children if dead, and increment their fanout_size */
+    for ( auto i = 0u; i < 2u; ++i )
+    {
+      if ( is_dead( nobj.children[i].index ) )
+      {
+        revive_node( nobj.children[i].index );
+      }
+      incr_fanout_size( nobj.children[i].index );
+    }
+  }
+
   inline bool is_dead( node const& n ) const
   {
     return ( _storage->nodes[n].data[0].h1 >> 31 ) & 1;
@@ -654,11 +680,20 @@ public:
       to_substitute.pop();
 
       signal _new = _curr;
-      while ( is_dead( get_node( _new ) ) )
+      /* find the real new node */
+      if ( is_dead( get_node( _new ) ) )
       {
-        const auto it = old_to_new.find( get_node( _new ) );
-        assert( it != old_to_new.end() );
-        _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+        auto it = old_to_new.find( get_node( _new ) );
+        while ( it != old_to_new.end() )
+        {
+          _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+          it = old_to_new.find( get_node( _new ) );
+        }
+      }
+      /* revive */
+      if ( is_dead( get_node( _new ) ) )
+      {
+        revive_node( get_node( _new ) );
       }
 
       for ( auto idx = 1u; idx < _storage->nodes.size(); ++idx )

--- a/include/mockturtle/networks/xmg.hpp
+++ b/include/mockturtle/networks/xmg.hpp
@@ -768,6 +768,32 @@ public:
     }
   }
 
+  void revive_node( node const& n )
+  {
+    if ( !is_dead( n ) )
+      return;
+
+    assert( n < _storage->nodes.size() );
+    auto& nobj = _storage->nodes[n];
+    nobj.data[0].h1 = UINT32_C( 0 ); /* fanout size 0, but not dead (like just created) */
+    _storage->hash[nobj] = n;
+
+    for ( auto const& fn : _events->on_add )
+    {
+      ( *fn )( n );
+    }
+
+    /* revive its children if dead, and increment their fanout_size */
+    for ( auto i = 0u; i < 3u; ++i )
+    {
+      if ( is_dead( nobj.children[i].index ) )
+      {
+        revive_node( nobj.children[i].index );
+      }
+      incr_fanout_size( nobj.children[i].index );
+    }
+  }
+
   inline bool is_dead( node const& n ) const
   {
     return ( _storage->nodes[n].data[0].h1 >> 31 ) & 1;
@@ -785,11 +811,20 @@ public:
       to_substitute.pop();
 
       signal _new = _curr;
-      while ( is_dead( get_node( _new ) ) )
+      /* find the real new node */
+      if ( is_dead( get_node( _new ) ) )
       {
-        const auto it = old_to_new.find( get_node( _new ) );
-        assert( it != old_to_new.end() );
-        _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+        auto it = old_to_new.find( get_node( _new ) );
+        while ( it != old_to_new.end() )
+        {
+          _new = is_complemented( _new ) ? create_not( it->second ) : it->second;
+          it = old_to_new.find( get_node( _new ) );
+        }
+      }
+      /* revive */
+      if ( is_dead( get_node( _new ) ) )
+      {
+        revive_node( get_node( _new ) );
       }
 
       for ( auto idx = 1u; idx < _storage->nodes.size(); ++idx )

--- a/include/mockturtle/views/fanout_view.hpp
+++ b/include/mockturtle/views/fanout_view.hpp
@@ -175,11 +175,20 @@ public:
       to_substitute.pop();
 
       signal _new = _curr;
-      while ( Ntk::is_dead( Ntk::get_node( _new ) ) )
+      /* find the real new node */
+      if ( Ntk::is_dead( Ntk::get_node( _new ) ) )
       {
-        const auto it = old_to_new.find( Ntk::get_node( _new ) );
-        assert( it != old_to_new.end() );
-        _new = Ntk::is_complemented( _new ) ? Ntk::create_not( it->second ) : it->second;
+        auto it = old_to_new.find( Ntk::get_node( _new ) );
+        while ( it != old_to_new.end() )
+        {
+          _new = Ntk::is_complemented( _new ) ? Ntk::create_not( it->second ) : it->second;
+          it = old_to_new.find( Ntk::get_node( _new ) );
+        }
+      }
+      /* revive */
+      if ( Ntk::is_dead( Ntk::get_node( _new ) ) )
+      {
+        Ntk::revive_node( Ntk::get_node( _new ) );
       }
 
       if ( Ntk::get_node( _new ) == _old && !Ntk::is_complemented( _new ) )

--- a/include/mockturtle/views/fanout_view.hpp
+++ b/include/mockturtle/views/fanout_view.hpp
@@ -164,7 +164,11 @@ public:
     if ( Ntk::get_node( new_signal ) == old_node && !Ntk::is_complemented( new_signal ) )
       return;
 
-    assert( !Ntk::is_dead( Ntk::get_node( new_signal ) ) );
+    if ( Ntk::is_dead( Ntk::get_node( new_signal ) ) )
+    {
+      Ntk::revive_node( Ntk::get_node( new_signal ) );
+    }
+
     std::unordered_map<node, signal> old_to_new;
     std::stack<std::pair<node, signal>> to_substitute;
     to_substitute.push( { old_node, new_signal } );

--- a/test/algorithms/quality.cpp
+++ b/test/algorithms/quality.cpp
@@ -139,7 +139,7 @@ TEST_CASE( "Test quality improvement of MIG cut rewriting with compatibility gra
     return before - ntk.num_gates();
   } );
 
-  CHECK( v2 == std::vector<uint32_t>{ { 0, 20, 78, 49, 158, 79, 198, 132, 525, 2, 255 } } );
+  CHECK( v2 == std::vector<uint32_t>{ { 0, 20, 78, 49, 158, 79, 196, 132, 525, 2, 255 } } );
 }
 
 TEST_CASE( "Test quality improvement of MIG refactoring with Akers resynthesis", "[quality]" )
@@ -486,7 +486,7 @@ TEST_CASE( "Test quality improvement of cut rewriting with XAG NPN4 resynthesis"
     return before - ntk.num_gates();
   } );
 
-  CHECK( v == std::vector<uint32_t>{ { 0, 31, 152, 50, 176, 79, 215, 138, 412, 869, 293 } } );
+  CHECK( v == std::vector<uint32_t>{ { 0, 31, 152, 50, 176, 79, 215, 134, 411, 869, 293 } } );
 }
 
 TEST_CASE( "Test quality improvement of cut rewriting with XAG NPN4 resynthesis using a complete XAG database", "[quality]" )
@@ -504,7 +504,7 @@ TEST_CASE( "Test quality improvement of cut rewriting with XAG NPN4 resynthesis 
     return before - ntk.num_gates();
   } );
 
-  CHECK( v == std::vector<uint32_t>{ { 0, 31, 152, 49, 176, 89, 216, 140, 423, 804, 279 } } );
+  CHECK( v == std::vector<uint32_t>{ { 0, 31, 152, 49, 176, 88, 216, 135, 423, 789, 279 } } );
 }
 
 TEST_CASE( "Test quality improvement for XMG3 rewriting with 4-input NPN database", "[quality]" )

--- a/test/networks/aig.cpp
+++ b/test/networks/aig.cpp
@@ -1004,7 +1004,7 @@ TEST_CASE( "substitute node and re-strash case 2", "[aig]" )
   aig.substitute_node( aig.get_node( n6 ), n4 );
   /* replace in node n7: n6 <- n4 => re-strash with fanins (x1, n4) => n7 <- n5
    * take out node n6 => take out node n5 => take out node n4 (MFFC)
-   * execute n7 <- n5, but n5 is dead => skip this operation and keep n7 */
+   * execute n7 <- n5, but n5 is dead => revive n5 and n4 */
 
   CHECK( !aig.is_dead( aig.get_node( n4 ) ) );
   CHECK( !aig.is_dead( aig.get_node( n5 ) ) );
@@ -1024,4 +1024,60 @@ TEST_CASE( "substitute node and re-strash case 2", "[aig]" )
     }
   } );
   CHECK( aig.fanout_size( aig.get_node( n4 ) ) == 1 );
+}
+
+TEST_CASE( "substitute node without re-strashing case 1", "[aig]" )
+{
+  aig_network aig;
+  auto const x1 = aig.create_pi();
+  auto const x2 = aig.create_pi();
+  auto const f1 = aig.create_and( x1, x2 );
+  auto const f2 = aig.create_and( f1, x2 );
+  aig.create_po( f2 );
+
+  aig.substitute_node_no_restrash( aig.get_node( f1 ), x1 );
+  aig = cleanup_dangling( aig );
+  CHECK( aig.num_gates() == 1 );
+  CHECK( simulate<kitty::static_truth_table<2u>>( aig )[0]._bits == 0x8 );
+}
+
+TEST_CASE( "substitute node without re-strashing case 2", "[aig]" )
+{
+  aig_network aig;
+
+  auto const a = aig.create_pi();
+  auto const b = aig.create_pi();
+  auto const c = aig.create_pi();
+  auto const tmp = aig.create_and( b, c );
+  auto const f1 = aig.create_and( a, b );
+  auto const f2 = aig.create_and( f1, tmp );
+  auto const f3 = aig.create_and( f1, a );
+  aig.create_po( f2 );
+
+  aig.substitute_node_no_restrash( aig.get_node( tmp ), f3 );
+  aig.substitute_node_no_restrash( aig.get_node( f1 ), aig.get_constant( 1 ) );
+  aig = cleanup_dangling( aig );
+
+  CHECK( aig.num_gates() == 0 );
+  CHECK( !aig.is_dead( aig.get_node( aig.po_at( 0 ) ) ) );
+  CHECK( aig.get_node( aig.po_at( 0 ) ) == aig.pi_at( 0 ) );
+}
+
+TEST_CASE( "substitute node without re-strashing case 3", "[aig]" )
+{
+  aig_network aig;
+
+  auto const x1 = aig.create_pi();
+  auto const x2 = aig.create_pi();
+  auto const x3 = aig.create_pi();
+  auto const n4 = aig.create_and( x2, x3 );
+  auto const n5 = aig.create_and( x1, n4 );
+  auto const n6 = aig.create_and( n5, x3 );
+  auto const n7 = aig.create_and( x1, n6 );
+  aig.create_po( n7 );
+
+  aig.substitute_node_no_restrash( aig.get_node( n6 ), n4 );
+  aig = cleanup_dangling( aig );
+  CHECK( aig.num_gates() == 2 );
+  CHECK( simulate<kitty::static_truth_table<3u>>( aig )[0]._bits == 0x80 );
 }


### PR DESCRIPTION
- Adds a failing testcase where re-strashing in the propagated substitutions caused problem (segfault in release mode or assertion fail in debug mode) (related to the fix in #560)
- Fixes the above problem in AIG, XAG, MIG, XMG, TIG, fanout_view
- Implements a simpler function to substitute without re-strashing `substitute_node_no_restrash` (only for AIG, as it is still experimental). This function may be used to directly replace `substitute_node` in some algorithms (they have the same interface). It could make substitution much faster when there is supposed to be lots of re-strashing and constant propagation. However, it could also cause overhead for algorithms to process redundant nodes. `cleanup_dangling` should be called in the end to strash nodes again.
- Implements `revive_node` to revive dead nodes (i.e. nodes marked as dead because their fanout size reduces to 0; they are removed from the hash but kept in the data structure). This function could solve #565.

IDEA: Besides the strategy of substitution without re-strashing, we could also implement another simpler `substitute_node` which does re-strashing normally but assumes that the network is in topological order (because in that case we don't need the fix in #560) --> future work