### PR TITLE
Sequential cuts and mapping

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,24 +9,6 @@ on:
     - master
 
 jobs:
-  build-gcc7:
-    runs-on: ubuntu-18.04
-    name: GNU GCC 7
-    
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Build mockturtle
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_CXX_COMPILER=g++-7 -DMOCKTURTLE_TEST=ON ..
-        make run_tests
-    - name: Run tests
-      run: |
-        cd build
-        ./test/run_tests "~[quality]"
   build-gcc9:
     runs-on: ubuntu-latest
     name: GNU GCC 9
@@ -76,6 +58,24 @@ jobs:
         mkdir build
         cd build
         cmake -DMOCKTURTLE_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=g++-10 -DMOCKTURTLE_TEST=ON ..
+        make run_tests
+    - name: Run tests
+      run: |
+        cd build
+        ./test/run_tests "~[quality]"
+  build-gcc12:
+    runs-on: ubuntu-latest
+    name: GNU GCC 12
+    
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Build mockturtle
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_CXX_COMPILER=g++-12 -DMOCKTURTLE_TEST=ON ..
         make run_tests
     - name: Run tests
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,24 +9,6 @@ on:
     - master
 
 jobs:
-  build-gcc9:
-    name: GNU GCC 9
-    runs-on: macOS-11
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Build mockturtle
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_CXX_COMPILER=$(which g++-9) -DMOCKTURTLE_TEST=ON ..
-        make run_tests
-    - name: Run tests
-      run: |
-        cd build
-        ./test/run_tests "~[quality]"
   build-gcc10:
     name: GNU GCC 10
     runs-on: macOS-11
@@ -58,6 +40,24 @@ jobs:
         mkdir build
         cd build
         cmake -DCMAKE_CXX_COMPILER=$(which g++-11) -DMOCKTURTLE_TEST=ON ..
+        make run_tests
+    - name: Run tests
+      run: |
+        cd build
+        ./test/run_tests "~[quality]"
+  build-gcc12:
+    name: GNU GCC 12
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Build mockturtle
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_CXX_COMPILER=$(which g++-12) -DMOCKTURTLE_TEST=ON ..
         make run_tests
     - name: Run tests
       run: |

--- a/docs/algorithms/mapper.rst
+++ b/docs/algorithms/mapper.rst
@@ -7,7 +7,7 @@ A versatile mapper that supports technology mapping and graph mapping
 (optimized network conversion). The mapper is independent of the
 underlying graph representation. Hence, it supports generic subject
 graph representations (e.g., AIG, and MIG) and a generic target
-representation (e.g. cell library, XMG). The mapper aims at finding a
+representation (e.g. cell library, XAG, XMG). The mapper aims at finding a
 good mapping with respect to delay, area, and switching power.
 
 The mapper uses a library (hash table) to facilitate Boolean matching.
@@ -58,6 +58,45 @@ using a NPN resynthesis database of structures:
 For graph mapping, we suggest reading the network directly in the
 target graph representation if possible (e.g. read an AIG as a MIG)
 since the mapping often leads to better results in this setting.
+
+For technology mapping of sequential networks, a dedicated command
+`seq_map` should be called. Only in case of graph mapping, the
+command `map` can be used on sequential networks.
+
+The following example shows how to perform delay-oriented technology
+mapping from a sequential and-inverter graph:
+
+.. code-block:: c++
+
+   sequential<aig_network> aig = ...;
+
+   /* read cell library in genlib format */
+   std::vector<gate> gates;
+   std::ifstream in( ... );
+   lorina::read_genlib( in, genlib_reader( gates ) )
+   tech_library tech_lib( gates );
+
+   /* perform technology mapping */
+   using res_t = binding_view<sequential<klut_network>>;
+   res_t res = seq_map( aig, tech_lib );
+
+The next example performs area-oriented graph mapping from a 
+sequential AIG to a sequential MIG using a NPN resynthesis
+database of structures:
+
+.. code-block:: c++
+
+   sequential<aig_network> aig = ...;
+   
+   /* load the npn database in the library */
+   mig_npn_resynthesis resyn{ true };
+   exact_library<sequential<mig_network>, mig_npn_resynthesis> exact_lib( resyn );
+
+   /* perform graph mapping */
+   map_params ps;
+   ps.skip_delay_round = true;
+   ps.required_time = std::numeric_limits<double>::max();
+   sequential<mig_network> res = map( aig, exact_lib, ps );
 
 As a default setting, cut enumeration minimizes the truth tables.
 This helps improving the results but slows down the computation.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ v0.4 (not yet released)
     - Support for external don't cares (mainly in `circuit_validator`, `sim_resub`, `miter` and `equivalence_checking_bill`) `#585 <https://github.com/lsils/mockturtle/pull/585>`_
     - Register retiming (`retime`) `#594 <https://github.com/lsils/mockturtle/pull/594>`_
     - AQFP buffer insertion & optimization updates (`buffer_insertion`, `aqfp_retiming`) `#594 <https://github.com/lsils/mockturtle/pull/594>`_
+    - Mapping of sequential networks (`map`, `seq_map`) `#599 <https://github.com/lsils/mockturtle/pull/599>`_
 * Views:
     - Add cost view to evaluate costs in the network and to maintain contexts (`cost_view`) `#554 <https://github.com/lsils/mockturtle/pull/554>`_
     - Support for external don't cares (`dont_care_view`) `#585 <https://github.com/lsils/mockturtle/pull/585>`_

--- a/include/mockturtle/algorithms/cut_enumeration.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration.hpp
@@ -320,7 +320,7 @@ public:
       {
         cuts.add_zero_cut( index );
       }
-      else if ( ntk.is_pi( node ) )
+      else if ( ntk.is_ci( node ) )
       {
         cuts.add_unit_cut( index );
       }
@@ -562,7 +562,7 @@ private:
  *
  * **Required network functions:**
  * - `is_constant`
- * - `is_pi`
+ * - `is_ci`
  * - `size`
  * - `get_node`
  * - `node_to_index`
@@ -589,7 +589,7 @@ network_cuts<Ntk, ComputeTruth, CutData> cut_enumeration( Ntk const& ntk, cut_en
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
-  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
   static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
@@ -803,7 +803,7 @@ public:
       {
         cuts.add_zero_cut( index );
       }
-      else if ( ntk.is_pi( node ) )
+      else if ( ntk.is_ci( node ) )
       {
         cuts.add_unit_cut( index );
       }
@@ -1049,7 +1049,7 @@ private:
  *
  * **Required network functions:**
  * - `is_constant`
- * - `is_pi`
+ * - `is_ci`
  * - `size`
  * - `get_node`
  * - `node_to_index`
@@ -1076,7 +1076,7 @@ fast_network_cuts<Ntk, NumVars, ComputeTruth, CutData> fast_cut_enumeration( Ntk
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
-  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
   static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
@@ -1128,7 +1128,7 @@ fast_network_cuts<Ntk, NumVars, ComputeTruth, CutData> fast_cut_enumeration( Ntk
  * - `fanin_size`
  * - `foreach_fanin`
  * - `foreach_gate`
- * - `foreach_pi`
+ * - `foreach_ci`
  * - `get_node`
  * - `node_to_index`
  * - `size`
@@ -1159,7 +1159,7 @@ fast_small_cut_enumeration( Ntk const& ntk, const uint8_t cut_size = 4 )
   // static_assert( is_topologically_sorted_v<Ntk>, "Ntk is not a topologically-sorted network" );
   static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
-  static_assert( has_foreach_pi_v<Ntk>, "Ntk does not implement the foreach_pi method" );
+  static_assert( has_foreach_ci_v<Ntk>, "Ntk does not implement the foreach_ci method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
 
   // Max 64 nodes, so 8 bits are enough for indices.
@@ -1330,7 +1330,7 @@ fast_small_cut_enumeration( Ntk const& ntk, const uint8_t cut_size = 4 )
   //////////////////////////////////////////////////////////////////////////////
 
   // Primary inputs only have themselves as their cut-set.
-  ntk.foreach_pi(
+  ntk.foreach_ci(
       [&]( auto node ) {
         auto const idx = ntk.node_to_index( node );
         cut_sets.at( idx ) = { set_bit( idx ) };

--- a/include/mockturtle/algorithms/lut_mapper.hpp
+++ b/include/mockturtle/algorithms/lut_mapper.hpp
@@ -660,7 +660,7 @@ private:
       add_zero_cut( ntk.node_to_index( ntk.get_node( ntk.get_constant( true ) ) ), true );
 
     /* init PIs cuts */
-    ntk.foreach_pi( [&]( auto const& n ) {
+    ntk.foreach_ci( [&]( auto const& n ) {
       add_unit_cut( ntk.node_to_index( n ) );
     } );
   }
@@ -684,7 +684,7 @@ private:
         }
       }
 
-      if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
       {
         continue;
       }
@@ -752,7 +752,7 @@ private:
 
     for ( auto const& n : topo_order )
     {
-      if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
       {
         continue;
       }
@@ -779,7 +779,7 @@ private:
 
     /* compute the current worst delay and update the mapping refs */
     delay = 0;
-    ntk.foreach_po( [this]( auto s ) {
+    ntk.foreach_co( [this]( auto s ) {
       const auto index = ntk.node_to_index( ntk.get_node( s ) );
 
       delay = std::max( delay, cuts[index][0]->data.delay );
@@ -796,7 +796,7 @@ private:
     for ( auto it = topo_order.rbegin(); it != topo_order.rend(); ++it )
     {
       /* skip constants and PIs */
-      if ( ntk.is_constant( *it ) || ntk.is_pi( *it ) )
+      if ( ntk.is_constant( *it ) || ntk.is_ci( *it ) )
       {
         continue;
       }
@@ -858,7 +858,7 @@ private:
     }
 
     /* set the required time at POs */
-    ntk.foreach_po( [&]( auto const& s ) {
+    ntk.foreach_co( [&]( auto const& s ) {
       const auto index = ntk.node_to_index( ntk.get_node( s ) );
       node_match[index].required = required;
     } );
@@ -866,7 +866,7 @@ private:
     /* propagate required time to the PIs */
     for ( auto it = topo_order.rbegin(); it != topo_order.rend(); ++it )
     {
-      if ( ntk.is_pi( *it ) || ntk.is_constant( *it ) )
+      if ( ntk.is_ci( *it ) || ntk.is_constant( *it ) )
         continue;
 
       const auto index = ntk.node_to_index( *it );
@@ -1419,7 +1419,7 @@ private:
 
     for ( auto leaf : cut )
     {
-      if ( ntk.is_pi( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
+      if ( ntk.is_ci( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
       {
         continue;
       }
@@ -1440,7 +1440,7 @@ private:
 
     for ( auto leaf : cut )
     {
-      if ( ntk.is_pi( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
+      if ( ntk.is_ci( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
       {
         continue;
       }
@@ -1476,7 +1476,7 @@ private:
 
     for ( auto leaf : cut )
     {
-      if ( ntk.is_pi( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
+      if ( ntk.is_ci( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
       {
         continue;
       }
@@ -1500,7 +1500,7 @@ private:
 
     for ( auto leaf : cut )
     {
-      if ( ntk.is_pi( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
+      if ( ntk.is_ci( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
       {
         continue;
       }
@@ -1520,7 +1520,7 @@ private:
 
     for ( auto leaf : cut )
     {
-      if ( ntk.is_pi( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
+      if ( ntk.is_ci( ntk.index_to_node( leaf ) ) || ntk.is_constant( ntk.index_to_node( leaf ) ) )
       {
         continue;
       }
@@ -1540,7 +1540,7 @@ private:
 
     for ( auto const& n : topo_order )
     {
-      if ( ntk.is_pi( n ) || ntk.is_constant( n ) )
+      if ( ntk.is_ci( n ) || ntk.is_constant( n ) )
         continue;
 
       const auto index = ntk.node_to_index( n );
@@ -1799,9 +1799,9 @@ private:
     ntk.clear_mapping();
 
     /* map POs */
-    ntk.foreach_po( [&]( auto const& f ) {
+    ntk.foreach_co( [&]( auto const& f ) {
       node const& n = ntk.get_node( f );
-      if ( ntk.is_pi( n ) || ntk.is_constant( n ) )
+      if ( ntk.is_ci( n ) || ntk.is_constant( n ) )
         return;
 
       compute_mffc_mapping_node( n );
@@ -1810,7 +1810,7 @@ private:
     for ( auto it = topo_order.rbegin(); it != topo_order.rend(); ++it )
     {
       node const& n = *it;
-      if ( ntk.is_pi( n ) || ntk.is_constant( n ) )
+      if ( ntk.is_ci( n ) || ntk.is_constant( n ) )
         continue;
       if ( ntk.fanout_size( n ) <= 1 ) /* it should be unnecessary */
         continue;
@@ -1895,7 +1895,7 @@ private:
 
   void get_fc_nodes_rec( node const& n, std::vector<node>& nodes )
   {
-    if ( ntk.is_pi( n ) || ntk.is_constant( n ) )
+    if ( ntk.is_ci( n ) || ntk.is_constant( n ) )
       return;
 
     nodes.push_back( n );
@@ -1971,12 +1971,12 @@ private:
  *
  * **Required network functions:**
  * - `size`
- * - `is_pi`
+ * - `is_ci`
  * - `is_constant`
  * - `node_to_index`
  * - `index_to_node`
  * - `get_node`
- * - `foreach_po`
+ * - `foreach_co`
  * - `foreach_node`
  * - `fanout_size`
  * - `clear_mapping`
@@ -1997,12 +1997,13 @@ void lut_map( Ntk& ntk, lut_map_params const& ps = {}, lut_map_stats* pst = null
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
-  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
   static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
   static_assert( has_index_to_node_v<Ntk>, "Ntk does not implement the index_to_node method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
-  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_foreach_ci_v<Ntk>, "Ntk does not implement the foreach_ci method" );
+  static_assert( has_foreach_co_v<Ntk>, "Ntk does not implement the foreach_co method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
   static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
   static_assert( has_clear_mapping_v<Ntk>, "Ntk does not implement the clear_mapping method" );

--- a/include/mockturtle/algorithms/mapper.hpp
+++ b/include/mockturtle/algorithms/mapper.hpp
@@ -3302,7 +3302,7 @@ NtkDest map( Ntk& ntk, exact_library<NtkDest, RewritingFn, NInputs> const& libra
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
   static_assert( has_index_to_node_v<Ntk>, "Ntk does not implement the index_to_node method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
-  static_assert( has_foreach_pi_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_foreach_pi_v<Ntk>, "Ntk does not implement the foreach_pi method" );
   static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
   static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );

--- a/include/mockturtle/algorithms/mapper.hpp
+++ b/include/mockturtle/algorithms/mapper.hpp
@@ -38,6 +38,7 @@
 #include <fmt/format.h>
 
 #include "../networks/klut.hpp"
+#include "../networks/sequential.hpp"
 #include "../utils/node_map.hpp"
 #include "../utils/stopwatch.hpp"
 #include "../utils/tech_library.hpp"
@@ -193,6 +194,8 @@ public:
   using cut_t = typename network_cuts_t::cut_t;
   using match_map = std::unordered_map<uint32_t, std::vector<cut_match_tech<NInputs>>>;
   using klut_map = std::unordered_map<uint32_t, std::array<signal<klut_network>, 2>>;
+  using map_ntk_t = binding_view<klut_network>;
+  using seq_map_ntk_t = binding_view<sequential<klut_network>>;
 
 public:
   explicit tech_map_impl( Ntk const& ntk, tech_library<NInputs, Configuration> const& library, map_params const& ps, map_stats& st )
@@ -223,7 +226,7 @@ public:
     std::tie( lib_buf_area, lib_buf_delay, lib_buf_id ) = library.get_buffer_info();
   }
 
-  binding_view<klut_network> run()
+  map_ntk_t run()
   {
     stopwatch t( st.time_mapping );
 
@@ -241,12 +244,59 @@ public:
     /* init the data structure */
     init_nodes();
 
+    /* execute mapping */
+    if ( !execute_mapping() )
+      return res;
+    
+    /* insert buffers for POs driven by PIs */
+    insert_buffers();
+
+    /* generate the output network */
+    finalize_cover<map_ntk_t>( res, old2new );
+
+    return res;
+  }
+
+  seq_map_ntk_t run_seq()
+  {
+    stopwatch t( st.time_mapping );
+
+    auto [res, old2new] = initialize_map_seq_network();
+
+    /* compute and save topological order */
+    top_order.reserve( ntk.size() );
+    topo_view<Ntk>( ntk ).foreach_node( [this]( auto n ) {
+      top_order.push_back( n );
+    } );
+
+    /* match cuts with gates */
+    compute_matches();
+
+    /* init the data structure */
+    init_nodes();
+
+    /* execute mapping */
+    if ( !execute_mapping() )
+      return res;
+    
+    /* insert buffers for POs driven by PIs */
+    insert_buffers();
+
+    /* generate the output network */
+    finalize_cover<seq_map_ntk_t>( res, old2new );
+
+    return res;
+  }
+
+private:
+  bool execute_mapping()
+  {
     /* compute mapping for delay */
     if ( !ps.skip_delay_round )
     {
       if ( !compute_mapping<false>() )
       {
-        return res;
+        return false;
       }
     }
 
@@ -256,7 +306,7 @@ public:
       compute_required_time();
       if ( !compute_mapping<true>() )
       {
-        return res;
+        return false;
       }
     }
 
@@ -266,7 +316,7 @@ public:
       compute_required_time();
       if ( !compute_mapping_exact<false>() )
       {
-        return res;
+        return false;
       }
     }
 
@@ -276,20 +326,13 @@ public:
       compute_required_time();
       if ( !compute_mapping_exact<true>() )
       {
-        return res;
+        return false;
       }
     }
 
-    /* insert buffers for POs driven by PIs */
-    insert_buffers();
-
-    /* generate the output network */
-    finalize_cover( res, old2new );
-
-    return res;
+    return true;
   }
 
-private:
   void init_nodes()
   {
     ntk.foreach_node( [this]( auto const& n, auto ) {
@@ -1320,9 +1363,9 @@ private:
     }
   }
 
-  std::pair<binding_view<klut_network>, klut_map> initialize_map_network()
+  std::pair<map_ntk_t, klut_map> initialize_map_network()
   {
-    binding_view<klut_network> dest( library.get_gates() );
+    map_ntk_t dest( library.get_gates() );
     klut_map old2new;
 
     old2new[ntk.node_to_index( ntk.get_node( ntk.get_constant( false ) ) )][0] = dest.get_constant( false );
@@ -1331,10 +1374,30 @@ private:
     ntk.foreach_ci( [&]( auto const& n ) {
       old2new[ntk.node_to_index( n )][0] = dest.create_pi();
     } );
+
     return { dest, old2new };
   }
 
-  void finalize_cover( binding_view<klut_network>& res, klut_map& old2new )
+  std::pair<seq_map_ntk_t, klut_map> initialize_map_seq_network()
+  {
+    seq_map_ntk_t dest( library.get_gates() );
+    klut_map old2new;
+
+    old2new[ntk.node_to_index( ntk.get_node( ntk.get_constant( false ) ) )][0] = dest.get_constant( false );
+    old2new[ntk.node_to_index( ntk.get_node( ntk.get_constant( false ) ) )][1] = dest.get_constant( true );
+
+    ntk.foreach_pi( [&]( auto const& n ) {
+      old2new[ntk.node_to_index( n )][0] = dest.create_pi();
+    } );
+    ntk.foreach_ro( [&]( auto const& n ) {
+      old2new[ntk.node_to_index( n )][0] = dest.create_ro();
+    } );
+
+    return { dest, old2new };
+  }
+
+  template<class NtkDest>
+  void finalize_cover( NtkDest& res, klut_map& old2new )
   {
     for ( auto const& n : top_order )
     {
@@ -1366,7 +1429,7 @@ private:
       /* add used cut */
       if ( node_data.same_match || node_data.map_refs[phase] > 0 )
       {
-        create_lut_for_gate( res, old2new, index, phase );
+        create_lut_for_gate<NtkDest>( res, old2new, index, phase );
 
         /* add inverted version if used */
         if ( node_data.same_match && node_data.map_refs[phase ^ 1] > 0 )
@@ -1380,12 +1443,12 @@ private:
       /* add the optional other match if used */
       if ( !node_data.same_match && node_data.map_refs[phase] > 0 )
       {
-        create_lut_for_gate( res, old2new, index, phase );
+        create_lut_for_gate<NtkDest>( res, old2new, index, phase );
       }
     }
 
     /* create POs */
-    ntk.foreach_co( [&]( auto const& f ) {
+    ntk.foreach_po( [&]( auto const& f ) {
       if ( ntk.is_complemented( f ) )
       {
         res.create_po( old2new[ntk.node_to_index( ntk.get_node( f ) )][1] );
@@ -1406,6 +1469,30 @@ private:
       }
     } );
 
+    if constexpr ( has_foreach_ri_v<Ntk> )
+    {
+      ntk.foreach_ri( [&]( auto const& f ) {
+        if ( ntk.is_complemented( f ) )
+        {
+          res.create_ri( old2new[ntk.node_to_index( ntk.get_node( f ) )][1] );
+        }
+        else if ( !ntk.is_constant( ntk.get_node( f ) ) && ntk.is_ci( ntk.get_node( f ) ) && lib_buf_id != UINT32_MAX )
+        {
+          /* create buffers for RIs */
+          static uint64_t _buf = 0x2;
+          kitty::dynamic_truth_table tt_buf( 1 );
+          kitty::create_from_words( tt_buf, &_buf, &_buf + 1 );
+          const auto buf = res.create_node( { old2new[ntk.node_to_index( ntk.get_node( f ) )][0] }, tt_buf );
+          res.create_ri( buf );
+          res.add_binding( res.get_node( buf ), lib_buf_id );
+        }
+        else
+        {
+          res.create_ri( old2new[ntk.node_to_index( ntk.get_node( f ) )][0] );
+        }
+      } );
+    }
+
     /* write final results */
     st.area = area;
     st.delay = delay;
@@ -1413,7 +1500,8 @@ private:
       st.power = compute_switching_power();
   }
 
-  void create_lut_for_gate( binding_view<klut_network>& res, klut_map& old2new, uint32_t index, unsigned phase )
+  template<class NtkDest>
+  void create_lut_for_gate( NtkDest& res, klut_map& old2new, uint32_t index, unsigned phase )
   {
     auto const& node_data = node_match[index];
     auto& best_cut = cuts.cuts( index )[node_data.best_cut[phase]];
@@ -1443,14 +1531,15 @@ private:
     else
     {
       /* supergate, create sub-gates */
-      auto f = create_lut_for_gate_rec( res, *gate, children );
+      auto f = create_lut_for_gate_rec<NtkDest>( res, *gate, children );
 
       /* add the node in the data structure */
       old2new[index][phase] = f;
     }
   }
 
-  signal<klut_network> create_lut_for_gate_rec( binding_view<klut_network>& res, composed_gate<NInputs> const& gate, std::vector<signal<klut_network>> const& children )
+  template<class NtkDest>
+  signal<klut_network> create_lut_for_gate_rec( NtkDest& res, composed_gate<NInputs> const& gate, std::vector<signal<klut_network>> const& children )
   {
     std::vector<signal<klut_network>> children_local( gate.fanin.size() );
 
@@ -1464,7 +1553,7 @@ private:
       }
       else
       {
-        children_local[i] = create_lut_for_gate_rec( res, *fanin, children );
+        children_local[i] = create_lut_for_gate_rec<NtkDest>( res, *fanin, children );
       }
       ++i;
     }
@@ -1627,6 +1716,7 @@ private:
  * - `node_to_index`
  * - `index_to_node`
  * - `get_node`
+ * - `foreach_po`
  * - `foreach_co`
  * - `foreach_node`
  * - `fanout_size`
@@ -1649,13 +1739,47 @@ binding_view<klut_network> map( Ntk const& ntk, tech_library<NInputs, Configurat
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
   static_assert( has_index_to_node_v<Ntk>, "Ntk does not implement the index_to_node method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
-  static_assert( has_foreach_co_v<Ntk>, "Ntk does not implement the foreach_co method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
   static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
 
   map_stats st;
   detail::tech_map_impl<Ntk, CutSize, CutData, NInputs, Configuration> p( ntk, library, ps, st );
   auto res = p.run();
+
+  st.time_total = st.time_mapping + st.cut_enumeration_st.time_total;
+  if ( ps.verbose && !st.mapping_error )
+  {
+    st.report();
+  }
+
+  if ( pst )
+  {
+    *pst = st;
+  }
+  return res;
+}
+
+template<class Ntk, unsigned CutSize = 5u, typename CutData = cut_enumeration_tech_map_cut, unsigned NInputs, classification_type Configuration>
+binding_view<sequential<klut_network>> seq_map( Ntk const& ntk, tech_library<NInputs, Configuration> const& library, map_params const& ps = {}, map_stats* pst = nullptr )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
+  static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
+  static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
+  static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
+  static_assert( has_index_to_node_v<Ntk>, "Ntk does not implement the index_to_node method" );
+  static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+  static_assert( has_foreach_co_v<Ntk>, "Ntk does not implement the foreach_co method" );
+  static_assert( has_foreach_ri_v<Ntk>, "Ntk does not implement the has_foreach_ri method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the has_foreach_po method" );
+  static_assert( has_foreach_ro_v<Ntk>, "Ntk does not implement the has_foreach_ro method" );
+  static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+  static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
+
+  map_stats st;
+  detail::tech_map_impl<Ntk, CutSize, CutData, NInputs, Configuration> p( ntk, library, ps, st );
+  auto res = p.run_seq();
 
   st.time_total = st.time_mapping + st.cut_enumeration_st.time_total;
   if ( ps.verbose && !st.mapping_error )
@@ -2020,7 +2144,7 @@ private:
     }
 
     /* create POs */
-    ntk.foreach_co( [&]( auto const& f ) {
+    ntk.foreach_po( [&]( auto const& f ) {
       res.create_po( ntk.is_complemented( f ) ? res.create_not( old2new[f] ) : old2new[f] );
     } );
 
@@ -3097,7 +3221,7 @@ private:
  * - `node_to_index`
  * - `index_to_node`
  * - `get_node`
- * - `foreach_co`
+ * - `foreach_po`
  * - `foreach_node`
  * - `fanout_size`
  *
@@ -3116,7 +3240,8 @@ NtkDest map( Ntk& ntk, exact_library<NtkDest, RewritingFn, NInputs> const& libra
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
   static_assert( has_index_to_node_v<Ntk>, "Ntk does not implement the index_to_node method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
-  static_assert( has_foreach_co_v<Ntk>, "Ntk does not implement the foreach_co method" );
+  static_assert( has_foreach_pi_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
   static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
   static_assert( has_incr_value_v<NtkDest>, "Ntk does not implement the incr_value method" );

--- a/include/mockturtle/algorithms/mapper.hpp
+++ b/include/mockturtle/algorithms/mapper.hpp
@@ -305,7 +305,7 @@ private:
         node_data.arrival[0] = node_data.arrival[1] = 0.0f;
         match_constants( index );
       }
-      else if ( ntk.is_pi( n ) )
+      else if ( ntk.is_ci( n ) )
       {
         /* all terminals have flow 1.0 */
         node_data.flows[0] = node_data.flows[1] = node_data.flows[2] = 0.0f;
@@ -391,7 +391,7 @@ private:
   {
     for ( auto const& n : top_order )
     {
-      if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
       {
         continue;
       }
@@ -437,7 +437,7 @@ private:
   {
     for ( auto const& n : top_order )
     {
-      if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
         continue;
 
       auto index = ntk.node_to_index( n );
@@ -496,7 +496,7 @@ private:
 
     /* compute the current worst delay and update the mapping refs */
     delay = 0.0f;
-    ntk.foreach_po( [this]( auto s ) {
+    ntk.foreach_co( [this]( auto s ) {
       const auto index = ntk.node_to_index( ntk.get_node( s ) );
 
       if ( ntk.is_complemented( s ) )
@@ -536,7 +536,7 @@ private:
         }
         continue;
       }
-      else if ( ntk.is_pi( *it ) )
+      else if ( ntk.is_ci( *it ) )
       {
         if ( node_match[index].map_refs[1] > 0u )
         {
@@ -646,7 +646,7 @@ private:
     }
 
     /* set the required time at POs */
-    ntk.foreach_po( [&]( auto const& s ) {
+    ntk.foreach_co( [&]( auto const& s ) {
       const auto index = ntk.node_to_index( ntk.get_node( s ) );
       if ( ntk.is_complemented( s ) )
         node_match[index].required[1] = required;
@@ -657,7 +657,7 @@ private:
     /* propagate required time to the PIs */
     for ( auto it = top_order.rbegin(); it != top_order.rend(); ++it )
     {
-      if ( ntk.is_pi( *it ) || ntk.is_constant( *it ) )
+      if ( ntk.is_ci( *it ) || ntk.is_constant( *it ) )
         break;
 
       const auto index = ntk.node_to_index( *it );
@@ -1172,7 +1172,7 @@ private:
       {
         continue;
       }
-      else if ( ntk.is_pi( ntk.index_to_node( leaf ) ) )
+      else if ( ntk.is_ci( ntk.index_to_node( leaf ) ) )
       {
         /* reference PIs, add inverter cost for negative phase */
         if ( leaf_phase == 1u )
@@ -1241,7 +1241,7 @@ private:
       {
         continue;
       }
-      else if ( ntk.is_pi( ntk.index_to_node( leaf ) ) )
+      else if ( ntk.is_ci( ntk.index_to_node( leaf ) ) )
       {
         /* dereference PIs, add inverter cost for negative phase */
         if ( leaf_phase == 1u )
@@ -1296,9 +1296,9 @@ private:
       double area_old = area;
       bool buffers = false;
 
-      ntk.foreach_po( [&]( auto const& f ) {
+      ntk.foreach_co( [&]( auto const& f ) {
         auto const& n = ntk.get_node( f );
-        if ( !ntk.is_constant( n ) && ntk.is_pi( n ) && !ntk.is_complemented( f ) )
+        if ( !ntk.is_constant( n ) && ntk.is_ci( n ) && !ntk.is_complemented( f ) )
         {
           area += lib_buf_area;
           delay = std::max( delay, node_match[ntk.node_to_index( n )].arrival[0] + lib_inv_delay );
@@ -1328,7 +1328,7 @@ private:
     old2new[ntk.node_to_index( ntk.get_node( ntk.get_constant( false ) ) )][0] = dest.get_constant( false );
     old2new[ntk.node_to_index( ntk.get_node( ntk.get_constant( false ) ) )][1] = dest.get_constant( true );
 
-    ntk.foreach_pi( [&]( auto const& n ) {
+    ntk.foreach_ci( [&]( auto const& n ) {
       old2new[ntk.node_to_index( n )][0] = dest.create_pi();
     } );
     return { dest, old2new };
@@ -1347,7 +1347,7 @@ private:
         if ( node_data.best_supergate[0] == nullptr && node_data.best_supergate[1] == nullptr )
           continue;
       }
-      else if ( ntk.is_pi( n ) )
+      else if ( ntk.is_ci( n ) )
       {
         if ( node_data.map_refs[1] > 0 )
         {
@@ -1385,12 +1385,12 @@ private:
     }
 
     /* create POs */
-    ntk.foreach_po( [&]( auto const& f ) {
+    ntk.foreach_co( [&]( auto const& f ) {
       if ( ntk.is_complemented( f ) )
       {
         res.create_po( old2new[ntk.node_to_index( ntk.get_node( f ) )][1] );
       }
-      else if ( !ntk.is_constant( ntk.get_node( f ) ) && ntk.is_pi( ntk.get_node( f ) ) && lib_buf_id != UINT32_MAX )
+      else if ( !ntk.is_constant( ntk.get_node( f ) ) && ntk.is_ci( ntk.get_node( f ) ) && lib_buf_id != UINT32_MAX )
       {
         /* create buffers for POs */
         static uint64_t _buf = 0x2;
@@ -1536,7 +1536,7 @@ private:
         if ( node_data.best_supergate[0] == nullptr && node_data.best_supergate[1] == nullptr )
           continue;
       }
-      else if ( ntk.is_pi( n ) )
+      else if ( ntk.is_ci( n ) )
       {
         if ( node_data.map_refs[1] > 0 )
           power += switch_activity[ntk.node_to_index( n )];
@@ -1622,12 +1622,12 @@ private:
  *
  * **Required network functions:**
  * - `size`
- * - `is_pi`
+ * - `is_ci`
  * - `is_constant`
  * - `node_to_index`
  * - `index_to_node`
  * - `get_node`
- * - `foreach_po`
+ * - `foreach_co`
  * - `foreach_node`
  * - `fanout_size`
  *
@@ -1644,12 +1644,12 @@ binding_view<klut_network> map( Ntk const& ntk, tech_library<NInputs, Configurat
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
-  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
   static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
   static_assert( has_index_to_node_v<Ntk>, "Ntk does not implement the index_to_node method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
-  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_foreach_co_v<Ntk>, "Ntk does not implement the foreach_co method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
   static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
 
@@ -1813,7 +1813,7 @@ private:
         node_data.flows[0] = node_data.flows[1] = node_data.flows[2] = 0.0f;
         node_data.arrival[0] = node_data.arrival[1] = 0.0f;
       }
-      else if ( ntk.is_pi( n ) )
+      else if ( ntk.is_ci( n ) )
       {
         /* all terminals have flow 1.0 */
         node_data.flows[0] = node_data.flows[1] = node_data.flows[2] = 0.0f;
@@ -1892,7 +1892,7 @@ private:
   {
     for ( auto const& n : top_order )
     {
-      if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
         continue;
 
       /* match positive phase */
@@ -1935,7 +1935,7 @@ private:
   {
     for ( auto const& n : top_order )
     {
-      if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
         continue;
 
       auto index = ntk.node_to_index( n );
@@ -1983,7 +1983,7 @@ private:
       auto const& db = library.get_database();
 
       ntk.foreach_node( [&]( auto const& n ) {
-        if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+        if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
           return true;
         auto index = ntk.node_to_index( n );
         if ( node_match[index].map_refs[2] == 0u )
@@ -2020,7 +2020,7 @@ private:
     }
 
     /* create POs */
-    ntk.foreach_po( [&]( auto const& f ) {
+    ntk.foreach_co( [&]( auto const& f ) {
       res.create_po( ntk.is_complemented( f ) ? res.create_not( old2new[f] ) : old2new[f] );
     } );
 
@@ -2044,7 +2044,7 @@ private:
 
     /* compute current delay and update mapping refs */
     delay = 0.0f;
-    ntk.foreach_po( [this]( auto s ) {
+    ntk.foreach_co( [this]( auto s ) {
       const auto index = ntk.node_to_index( ntk.get_node( s ) );
       if ( ntk.is_complemented( s ) )
         delay = std::max( delay, node_match[index].arrival[1] );
@@ -2071,7 +2071,7 @@ private:
       {
         continue;
       }
-      else if ( ntk.is_pi( *it ) )
+      else if ( ntk.is_ci( *it ) )
       {
         if ( node_match[index].map_refs[1] > 0u )
         {
@@ -2182,7 +2182,7 @@ private:
     }
 
     /* set the required time at POs */
-    ntk.foreach_po( [&]( auto const& s ) {
+    ntk.foreach_co( [&]( auto const& s ) {
       const auto index = ntk.node_to_index( ntk.get_node( s ) );
       if ( ntk.is_complemented( s ) )
         node_match[index].required[1] = required;
@@ -2195,7 +2195,7 @@ private:
     while ( i-- > 0u )
     {
       const auto n = ntk.index_to_node( i );
-      if ( ntk.is_pi( n ) || ntk.is_constant( n ) )
+      if ( ntk.is_ci( n ) || ntk.is_constant( n ) )
         break;
 
       if ( node_match[i].map_refs[2] == 0 )
@@ -2485,7 +2485,7 @@ private:
 
     for ( auto const& n : top_order )
     {
-      if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      if ( ntk.is_constant( n ) || ntk.is_ci( n ) )
         continue;
 
       auto index = ntk.node_to_index( n );
@@ -2897,7 +2897,7 @@ private:
         ++ctr;
         continue;
       }
-      else if ( ntk.is_pi( ntk.index_to_node( leaf ) ) )
+      else if ( ntk.is_ci( ntk.index_to_node( leaf ) ) )
       {
         /* reference PIs, add inverter cost for negative phase */
         if ( leaf_phase == 1u )
@@ -2953,7 +2953,7 @@ private:
         ++ctr;
         continue;
       }
-      else if ( ntk.is_pi( ntk.index_to_node( leaf ) ) )
+      else if ( ntk.is_ci( ntk.index_to_node( leaf ) ) )
       {
         /* dereference PIs, add inverter cost for negative phase */
         if ( leaf_phase == 1u )
@@ -3092,12 +3092,12 @@ private:
  *
  * **Required network functions:**
  * - `size`
- * - `is_pi`
+ * - `is_ci`
  * - `is_constant`
  * - `node_to_index`
  * - `index_to_node`
  * - `get_node`
- * - `foreach_po`
+ * - `foreach_co`
  * - `foreach_node`
  * - `fanout_size`
  *
@@ -3111,12 +3111,12 @@ NtkDest map( Ntk& ntk, exact_library<NtkDest, RewritingFn, NInputs> const& libra
 {
   static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
   static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
-  static_assert( has_is_pi_v<Ntk>, "Ntk does not implement the is_pi method" );
+  static_assert( has_is_ci_v<Ntk>, "Ntk does not implement the is_ci method" );
   static_assert( has_is_constant_v<Ntk>, "Ntk does not implement the is_constant method" );
   static_assert( has_node_to_index_v<Ntk>, "Ntk does not implement the node_to_index method" );
   static_assert( has_index_to_node_v<Ntk>, "Ntk does not implement the index_to_node method" );
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
-  static_assert( has_foreach_po_v<Ntk>, "Ntk does not implement the foreach_po method" );
+  static_assert( has_foreach_co_v<Ntk>, "Ntk does not implement the foreach_co method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
   static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
   static_assert( has_incr_value_v<NtkDest>, "Ntk does not implement the incr_value method" );

--- a/test/algorithms/mapper.cpp
+++ b/test/algorithms/mapper.cpp
@@ -26,7 +26,7 @@ std::string const test_library = "GATE   inv1    1 O=!a;            PIN * INV 1 
                                  "GATE   inv2    2 O=!a;            PIN * INV 2 999 1.0 0.1 1.0 0.1\n"
                                  "GATE   nand2   2 O=!(a*b);        PIN * INV 1 999 1.0 0.2 1.0 0.2\n"
                                  "GATE   xor2    5 O=a^b;           PIN * UNKNOWN 2 999 1.9 0.5 1.9 0.5\n"
-                                 "GATE   mig3    3 O=a*b+a*c+b*c;   PIN * INV 1 999 2.0 0.2 2.0 0.2\n"
+                                 "GATE   maj3    3 O=a*b+a*c+b*c;   PIN * INV 1 999 2.0 0.2 2.0 0.2\n"
                                  "GATE   buf     2 O=a;             PIN * NONINV 1 999 1.0 0.0 1.0 0.0\n"
                                  "GATE   zero    0 O=CONST0;\n"
                                  "GATE   one     0 O=CONST1;";
@@ -330,6 +330,49 @@ TEST_CASE( "Map with supergates", "[mapper]" )
   CHECK( st.area == 6.0f );
   CHECK( st.delay > 3.8f - eps );
   CHECK( st.delay < 3.8f + eps );
+}
+
+TEST_CASE( "Map of sequential AIG", "[mapper]" )
+{
+  std::vector<gate> gates;
+
+  std::istringstream in( test_library );
+  auto result = lorina::read_genlib( in, genlib_reader( gates ) );
+  CHECK( result == lorina::return_code::success );
+
+  tech_library<3, classification_type::np_configurations> lib( gates );
+
+  sequential<aig_network> aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_ro(); // f2 <- f1
+  const auto f3 = aig.create_xor( f2, c );
+
+  aig.create_po( f3 );
+  aig.create_ri( f1 ); // f3 <- f1
+
+  CHECK( aig.num_gates() == 4u );
+  CHECK( aig.num_registers() == 1u );
+  CHECK( aig.num_pis() == 3u );
+  CHECK( aig.num_pos() == 1u );
+
+  map_params ps;
+  map_stats st;
+  binding_view<sequential<klut_network>> luts = seq_map( aig, lib, ps, &st );
+
+  const float eps{ 0.005f };
+
+  CHECK( luts.size() == 8u );
+  CHECK( luts.num_pis() == 3u );
+  CHECK( luts.num_pos() == 1u );
+  CHECK( luts.num_registers() == 1u );
+  CHECK( luts.num_gates() == 2u );
+  CHECK( st.area == 7.0f );
+  CHECK( st.delay > 1.9f - eps );
+  CHECK( st.delay < 1.9f + eps );
 }
 
 TEST_CASE( "Exact map of bad MAJ3 and constant output", "[mapper]" )

--- a/test/algorithms/mapper.cpp
+++ b/test/algorithms/mapper.cpp
@@ -498,3 +498,33 @@ TEST_CASE( "Exact map with logic sharing", "[mapper]" )
   CHECK( res.num_pos() == 2 );
   CHECK( res.num_gates() == 4 );
 }
+
+TEST_CASE( "exact map of sequential AIG", "[mapper]" )
+{
+  using resyn_fn = xag_npn_resynthesis<xag_network>;
+
+  resyn_fn resyn;
+  exact_library<sequential<xag_network>, resyn_fn> lib( resyn );
+
+  sequential<aig_network> aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+
+  const auto f1 = aig.create_nand( a, b );
+  const auto f2 = aig.create_ro(); // f2 <- f1
+  const auto f3 = aig.create_xor( f2, c );
+
+  aig.create_po( f3 );
+  aig.create_ri( f1 ); // f3 <- f1
+
+  map_params ps;
+  map_stats st;
+  sequential<xag_network> res = map( aig, lib, ps, &st );
+
+  CHECK( res.size() == 7u );
+  CHECK( res.num_pis() == 3u );
+  CHECK( res.num_pos() == 1u );
+  CHECK( res.num_registers() == 1u );
+  CHECK( res.num_gates() == 2u );
+}


### PR DESCRIPTION
This pull request fixes cut computation for sequential networks (#598).
Moreover, it implements sequential network support in technology mapping (a new command `seq_map`), graph mapping (old command `map`), and LUT mapper (command `lut_map`).