### PR TITLE
In-place rewriting

### DIFF
--- a/docs/algorithms/aig_balancing.rst
+++ b/docs/algorithms/aig_balancing.rst
@@ -1,5 +1,5 @@
 AIG balancing
----------
+-------------
 
 **Header:** ``mockturtle/algorithms/aig_balancing.hpp``
 

--- a/docs/algorithms/index_restructuring.rst
+++ b/docs/algorithms/index_restructuring.rst
@@ -14,6 +14,7 @@ Logic restructuring and optimization
    :maxdepth: 1
    :caption: Rewriting and resubstitution
 
+   rewrite
    cut_rewriting
    xag_algebraic_rewriting
    mig_algebraic_rewriting

--- a/docs/algorithms/rewrite.rst
+++ b/docs/algorithms/rewrite.rst
@@ -1,0 +1,63 @@
+Rewrite
+-------
+
+**Header:** ``mockturtle/algorithms/rewrite.hpp``
+
+The following example shows how to rewrite an MIG using precomputed optimum
+networks.  In this case the maximum number of variables for a node function is
+4.
+
+.. code-block:: c++
+
+   /* derive some MIG */
+   mig_network mig = ...;
+
+   /* node resynthesis */
+   mig_npn_resynthesis resyn;
+   exact_library_params eps;
+   eps.np_classification = false;
+   exact_library<xag_network, decltype( resyn )> exact_lib( resyn, eps );
+
+   /* rewrite */
+   rewrite( mig, exact_lib );
+
+It is possible to change the cost function of nodes in rewrite.  Here is
+an example, in which the cost function only accounts for AND gates in a network,
+which corresponds to the multiplicative complexity of a function.
+
+.. code-block:: c++
+
+   template<class Ntk>
+   struct mc_cost
+   {
+     uint32_t operator()( Ntk const& ntk, node<Ntk> const& n ) const
+     {
+       return ntk.is_and( n ) ? 1 : 0;
+     }
+   };
+
+   SomeResynthesisClass resyn;
+   exact_library_params eps;
+   eps.np_classification = false;
+   exact_library<xag_network, decltype( resyn )> exact_lib( resyn, eps );
+   rewrite<decltype( Ntk ), decltype( exact_lib ), mc_cost>( ntk, exact_lib );
+
+Parameters and statistics
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygenstruct:: mockturtle::rewrite_params
+   :members:
+
+.. doxygenstruct:: mockturtle::rewrite_stats
+   :members:
+
+Algorithm
+~~~~~~~~~
+
+.. doxygenfunction:: mockturtle::rewrite
+
+Rewriting functions
+~~~~~~~~~~~~~~~~~~~
+
+One can use resynthesis functions with a pre-computed database and process
+them using :ref:`exact_library`, see :ref:`node_resynthesis_functions`.

--- a/docs/utils/util_data_structures.rst
+++ b/docs/utils/util_data_structures.rst
@@ -70,6 +70,8 @@ Tech Library
 .. doxygenclass:: mockturtle::tech_library
    :members:
 
+.. _exact_library:
+
 Exact Library
 ~~~~~~~~~~~~~
 

--- a/experiments/rewrite.cpp
+++ b/experiments/rewrite.cpp
@@ -42,7 +42,7 @@ int main()
   using namespace mockturtle;
 
   experiment<std::string, uint32_t, uint32_t, uint32_t, uint32_t, float, bool>
-      exp( "refactoring", "benchmark", "size_before", "size_after", "depth_before", "depth_after", "runtime", "equivalent" );
+      exp( "rewrite", "benchmark", "size_before", "size_after", "depth_before", "depth_after", "runtime", "equivalent" );
 
   xag_npn_resynthesis<xag_network, xag_network, xag_npn_db_kind::xag_incomplete> resyn;
   exact_library_params eps;

--- a/experiments/rewrite.cpp
+++ b/experiments/rewrite.cpp
@@ -1,0 +1,78 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2023  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <mockturtle/algorithms/rewrite.hpp>
+#include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
+#include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/io/aiger_reader.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/utils/tech_library.hpp>
+#include <mockturtle/views/depth_view.hpp>
+#include <lorina/aiger.hpp>
+
+#include <experiments.hpp>
+#include <fmt/format.h>
+#include <string>
+
+int main()
+{
+  using namespace experiments;
+  using namespace mockturtle;
+
+  experiment<std::string, uint32_t, uint32_t, uint32_t, uint32_t, float, bool>
+    exp( "refactoring", "benchmark", "size_before", "size_after", "depth_before", "depth_after", "runtime", "equivalent" );
+
+  xag_npn_resynthesis<aig_network, aig_network, xag_npn_db_kind::aig_complete> resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<aig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  for ( auto const& benchmark : epfl_benchmarks() )
+  {
+    fmt::print( "[i] processing {}\n", benchmark );
+
+    aig_network aig;
+    if ( lorina::read_aiger( benchmark_path( benchmark ), aiger_reader( aig ) ) != lorina::return_code::success )
+    {
+      continue;
+    }
+
+    rewrite_params ps;
+    rewrite_stats st;
+
+    uint32_t const size_before = aig.num_gates();
+    uint32_t const depth_before = depth_view( aig ).depth();
+
+    rewrite( aig, exact_lib, ps, &st );
+
+    bool const cec = benchmark == "hyp" ? true : abc_cec( aig, benchmark );
+    exp( benchmark, size_before, aig.num_gates(), depth_before, depth_view( aig ).depth(), to_seconds( st.time_total ), cec );
+  }
+
+  exp.save();
+  exp.table();
+
+  return 0;
+}

--- a/experiments/rewrite.cpp
+++ b/experiments/rewrite.cpp
@@ -27,7 +27,7 @@
 #include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
 #include <mockturtle/algorithms/cleanup.hpp>
 #include <mockturtle/io/aiger_reader.hpp>
-#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xag.hpp>
 #include <mockturtle/utils/tech_library.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <lorina/aiger.hpp>
@@ -44,17 +44,17 @@ int main()
   experiment<std::string, uint32_t, uint32_t, uint32_t, uint32_t, float, bool>
     exp( "refactoring", "benchmark", "size_before", "size_after", "depth_before", "depth_after", "runtime", "equivalent" );
 
-  xag_npn_resynthesis<aig_network, aig_network, xag_npn_db_kind::aig_complete> resyn;
+  xag_npn_resynthesis<xag_network, xag_network, xag_npn_db_kind::xag_incomplete> resyn;
   exact_library_params eps;
   eps.np_classification = false;
-  exact_library<aig_network, decltype( resyn )> exact_lib( resyn, eps );
+  exact_library<xag_network, decltype( resyn )> exact_lib( resyn, eps );
 
   for ( auto const& benchmark : epfl_benchmarks() )
   {
     fmt::print( "[i] processing {}\n", benchmark );
 
-    aig_network aig;
-    if ( lorina::read_aiger( benchmark_path( benchmark ), aiger_reader( aig ) ) != lorina::return_code::success )
+    xag_network xag;
+    if ( lorina::read_aiger( benchmark_path( benchmark ), aiger_reader( xag ) ) != lorina::return_code::success )
     {
       continue;
     }
@@ -62,13 +62,13 @@ int main()
     rewrite_params ps;
     rewrite_stats st;
 
-    uint32_t const size_before = aig.num_gates();
-    uint32_t const depth_before = depth_view( aig ).depth();
+    uint32_t const size_before = xag.num_gates();
+    uint32_t const depth_before = depth_view( xag ).depth();
 
-    rewrite( aig, exact_lib, ps, &st );
+    rewrite( xag, exact_lib, ps, &st );
 
-    bool const cec = benchmark == "hyp" ? true : abc_cec( aig, benchmark );
-    exp( benchmark, size_before, aig.num_gates(), depth_before, depth_view( aig ).depth(), to_seconds( st.time_total ), cec );
+    bool const cec = benchmark == "hyp" ? true : abc_cec( xag, benchmark );
+    exp( benchmark, size_before, xag.num_gates(), depth_before, depth_view( xag ).depth(), to_seconds( st.time_total ), cec );
   }
 
   exp.save();

--- a/experiments/rewrite.cpp
+++ b/experiments/rewrite.cpp
@@ -23,14 +23,14 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <mockturtle/algorithms/rewrite.hpp>
-#include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
+#include <lorina/aiger.hpp>
 #include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
+#include <mockturtle/algorithms/rewrite.hpp>
 #include <mockturtle/io/aiger_reader.hpp>
 #include <mockturtle/networks/xag.hpp>
 #include <mockturtle/utils/tech_library.hpp>
 #include <mockturtle/views/depth_view.hpp>
-#include <lorina/aiger.hpp>
 
 #include <experiments.hpp>
 #include <fmt/format.h>
@@ -42,7 +42,7 @@ int main()
   using namespace mockturtle;
 
   experiment<std::string, uint32_t, uint32_t, uint32_t, uint32_t, float, bool>
-    exp( "refactoring", "benchmark", "size_before", "size_after", "depth_before", "depth_after", "runtime", "equivalent" );
+      exp( "refactoring", "benchmark", "size_before", "size_after", "depth_before", "depth_after", "runtime", "equivalent" );
 
   xag_npn_resynthesis<xag_network, xag_network, xag_npn_db_kind::xag_incomplete> resyn;
   exact_library_params eps;

--- a/include/mockturtle/algorithms/cut_enumeration.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration.hpp
@@ -1121,7 +1121,7 @@ class dynamic_cut_enumeration_impl;
  * Comparing to `network_cuts`, it supports dynamic allocation of cuts for
  * networks in expansion. Moreover, it uses static truth tables instead of
  * dynamic truth tables to speed-up the truth table computation.
- * 
+ *
  * An instance of type `dynamic_network_cuts` can only be constructed from the
  * `dynamic_cut_enumeration_impl` algorithm.
  */
@@ -1427,7 +1427,7 @@ private:
   {
     const auto fanin = 2;
 
-    uint32_t pairs{1};
+    uint32_t pairs{ 1 };
     ntk.foreach_fanin( ntk.index_to_node( index ), [this, &pairs]( auto child, auto i ) {
       lcuts[i] = &cuts.cuts( ntk.node_to_index( ntk.get_node( child ) ) );
       pairs *= static_cast<uint32_t>( lcuts[i]->size() );
@@ -1481,7 +1481,7 @@ private:
 
   void merge_cuts( uint32_t index )
   {
-    uint32_t pairs{1};
+    uint32_t pairs{ 1 };
     std::vector<uint32_t> cut_sizes;
     ntk.foreach_fanin( ntk.index_to_node( index ), [this, &pairs, &cut_sizes]( auto child, auto i ) {
       lcuts[i] = &cuts.cuts( ntk.node_to_index( ntk.get_node( child ) ) );
@@ -1544,15 +1544,18 @@ private:
 
       /* limit the maximum number of cuts */
       rcuts.limit( ps.cut_limit );
-    } else if ( fanin == 1 ) {
+    }
+    else if ( fanin == 1 )
+    {
       rcuts.clear();
 
-      for ( auto const& cut : *lcuts[0] ) {
+      for ( auto const& cut : *lcuts[0] )
+      {
         cut_t new_cut = *cut;
 
         if constexpr ( ComputeTruth )
         {
-          new_cut->func_id = compute_truth_table( index, {cut}, new_cut );
+          new_cut->func_id = compute_truth_table( index, { cut }, new_cut );
         }
 
         cut_enumeration_update_cut<CutData>::apply( new_cut, cuts, ntk, ntk.index_to_node( index ) );

--- a/include/mockturtle/algorithms/cut_enumeration.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration.hpp
@@ -1101,6 +1101,485 @@ fast_network_cuts<Ntk, NumVars, ComputeTruth, CutData> fast_cut_enumeration( Ntk
   return res;
 }
 
+/* forward declarations */
+/*! \cond PRIVATE */
+template<typename Ntk, uint32_t NumVars, bool ComputeTruth, typename CutData>
+struct dynamic_network_cuts;
+
+namespace detail
+{
+template<typename Ntk, uint32_t NumVars, bool ComputeTruth, typename CutData>
+class dynamic_cut_enumeration_impl;
+}
+/*! \endcond */
+
+/*! \brief Dynamic cut database for a network.
+ *
+ * Struct `dynamic_network_cuts` contains a cut database and can be queried
+ * to return all cuts of a node, or the function of a cut (if it was computed).
+ *
+ * Comparing to `network_cuts`, it supports dynamic allocation of cuts for
+ * networks in expansion. Moreover, it uses static truth tables instead of
+ * dynamic truth tables to speed-up the truth table computation.
+ * 
+ * An instance of type `dynamic_network_cuts` can only be constructed from the
+ * `dynamic_cut_enumeration_impl` algorithm.
+ */
+template<typename Ntk, uint32_t NumVars, bool ComputeTruth, typename CutData>
+struct dynamic_network_cuts
+{
+public:
+  static constexpr uint32_t max_cut_num = 16u;
+  using cut_t = cut_type<ComputeTruth, CutData>;
+  using cut_set_t = cut_set<cut_t, max_cut_num>;
+  static constexpr bool compute_truth = ComputeTruth;
+
+public:
+  explicit dynamic_network_cuts( uint32_t size ) : _cuts( size )
+  {
+    kitty::static_truth_table<NumVars> zero, proj;
+    kitty::create_nth_var( proj, 0u );
+
+    _truth_tables.insert( zero );
+    _truth_tables.insert( proj );
+  }
+
+public:
+  /*! \brief Returns the cut set of a node */
+  cut_set_t& cuts( uint32_t node_index )
+  {
+    if ( node_index >= _cuts.size() )
+      _cuts.resize( node_index + 1 );
+
+    return _cuts[node_index];
+  }
+
+  /*! \brief Returns the cut set of a node */
+  cut_set_t const& cuts( uint32_t node_index ) const
+  {
+    assert( node_index < _cuts.size() );
+    return _cuts[node_index];
+  }
+
+  /*! \brief Returns the truth table of a cut */
+  template<bool enabled = ComputeTruth, typename = std::enable_if_t<std::is_same_v<Ntk, Ntk> && enabled>>
+  auto truth_table( cut_t const& cut ) const
+  {
+    return _truth_tables[cut->func_id];
+  }
+
+  /*! \brief Returns the total number of tuples that were tried to be merged */
+  auto total_tuples() const
+  {
+    return _total_tuples;
+  }
+
+  /*! \brief Returns the total number of cuts in the database. */
+  auto total_cuts() const
+  {
+    return _total_cuts;
+  }
+
+  /*! \brief Returns the number of nodes for which cuts are computed */
+  auto nodes_size() const
+  {
+    return _cuts.size();
+  }
+
+  /* compute positions of leave indices in cut `sub` (subset) with respect to
+   * leaves in cut `sup` (super set).
+   *
+   * Example:
+   *   compute_truth_table_support( {1, 3, 6}, {0, 1, 2, 3, 6, 7} ) = {1, 3, 4}
+   */
+  std::vector<uint8_t> compute_truth_table_support( cut_t const& sub, cut_t const& sup ) const
+  {
+    std::vector<uint8_t> support;
+    support.reserve( sub.size() );
+
+    auto itp = sup.begin();
+    for ( auto i : sub )
+    {
+      itp = std::find( itp, sup.end(), i );
+      support.push_back( static_cast<uint8_t>( std::distance( sup.begin(), itp ) ) );
+    }
+
+    return support;
+  }
+
+  /*! \brief Inserts a truth table into the truth table cache.
+   *
+   * This message can be used when manually adding or modifying cuts from the
+   * cut sets.
+   *
+   * \param tt Truth table to add
+   * \return Literal id from the truth table store
+   */
+  uint32_t insert_truth_table( kitty::static_truth_table<NumVars> const& tt )
+  {
+    return _truth_tables.insert( tt );
+  }
+
+private:
+  template<typename _Ntk, uint32_t _NumVars, bool _ComputeTruth, typename _CutData>
+  friend class detail::dynamic_cut_enumeration_impl;
+
+private:
+  void add_zero_cut( uint32_t index )
+  {
+    auto& cut = _cuts[index].add_cut( &index, &index ); /* fake iterator for emptyness */
+
+    if constexpr ( ComputeTruth )
+    {
+      cut->func_id = 0;
+    }
+  }
+
+  void add_unit_cut( uint32_t index )
+  {
+    auto& cut = _cuts[index].add_cut( &index, &index + 1 );
+
+    if constexpr ( ComputeTruth )
+    {
+      cut->func_id = 2;
+    }
+  }
+
+  void clear_cut_set( uint32_t index )
+  {
+    _cuts[index].clear();
+  }
+
+private:
+  /* compressed representation of cuts */
+  std::deque<cut_set_t> _cuts;
+
+  /* cut truth tables */
+  truth_table_cache<kitty::static_truth_table<NumVars>> _truth_tables;
+
+  /* statistics */
+  uint32_t _total_tuples{};
+  std::size_t _total_cuts{};
+};
+
+/*! \cond PRIVATE */
+namespace detail
+{
+template<typename Ntk, uint32_t NumVars, bool ComputeTruth, typename CutData>
+class dynamic_cut_enumeration_impl
+{
+public:
+  using cut_t = typename dynamic_network_cuts<Ntk, NumVars, ComputeTruth, CutData>::cut_t;
+  using cut_set_t = typename dynamic_network_cuts<Ntk, NumVars, ComputeTruth, CutData>::cut_set_t;
+
+  explicit dynamic_cut_enumeration_impl( Ntk const& ntk, cut_enumeration_params const& ps, cut_enumeration_stats& st, dynamic_network_cuts<Ntk, NumVars, ComputeTruth, CutData>& cuts )
+      : ntk( ntk ),
+        ps( ps ),
+        st( st ),
+        cuts( cuts )
+  {
+    assert( ps.cut_limit < cuts.max_cut_num && "cut_limit exceeds the compile-time limit for the maximum number of cuts" );
+  }
+
+public:
+  void run()
+  {
+    stopwatch t( st.time_total );
+
+    ntk.foreach_node( [this]( auto node ) {
+      const auto index = ntk.node_to_index( node );
+
+      if ( ps.very_verbose )
+      {
+        std::cout << fmt::format( "[i] compute cut for node at index {}\n", index );
+      }
+
+      if ( ntk.is_constant( node ) )
+      {
+        cuts.add_zero_cut( index );
+      }
+      else if ( ntk.is_pi( node ) )
+      {
+        cuts.add_unit_cut( index );
+      }
+      else
+      {
+        if constexpr ( Ntk::min_fanin_size == 2 && Ntk::max_fanin_size == 2 )
+        {
+          merge_cuts2( index );
+        }
+        else
+        {
+          merge_cuts( index );
+        }
+      }
+    } );
+  }
+
+  void compute_cuts( node<Ntk> const& n )
+  {
+    const auto index = ntk.node_to_index( n );
+
+    if ( cuts.cuts( index ).size() > 0 )
+      return;
+
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      compute_cuts( ntk.get_node( f ) );
+    } );
+
+    if constexpr ( Ntk::min_fanin_size == 2 && Ntk::max_fanin_size == 2 )
+    {
+      merge_cuts2( index );
+    }
+    else
+    {
+      merge_cuts( index );
+    }
+  }
+
+  void init_cuts()
+  {
+    cuts.add_zero_cut( ntk.node_to_index( ntk.get_node( ntk.get_constant( false ) ) ) );
+    if ( ntk.get_node( ntk.get_constant( false ) ) != ntk.get_node( ntk.get_constant( true ) ) )
+      cuts.add_zero_cut( ntk.node_to_index( ntk.get_node( ntk.get_constant( true ) ) ) );
+    ntk.foreach_pi( [&]( auto const& n ) {
+      cuts.add_unit_cut( ntk.node_to_index( n ) );
+    } );
+  }
+
+  void clear_cuts( node<Ntk> const& n )
+  {
+    const auto index = ntk.node_to_index( n );
+    if ( cuts.cuts( index ).size() == 0 )
+      return;
+
+    cuts.clear_cut_set( index );
+  }
+
+private:
+  inline bool fast_support_minimization( kitty::static_truth_table<NumVars> const& tt, cut_t& res )
+  {
+    uint32_t support = 0u;
+    uint32_t support_size = 0u;
+    for ( uint32_t i = 0u; i < tt.num_vars(); ++i )
+    {
+      if ( kitty::has_var( tt, i ) )
+      {
+        support |= 1u << i;
+        ++support_size;
+      }
+    }
+
+    /* has not minimized support? */
+    if ( ( support & ( support + 1u ) ) != 0u )
+    {
+      return false;
+    }
+
+    /* variables not in the support are the most significative */
+    if ( support_size != res.size() )
+    {
+      std::vector<uint32_t> leaves( res.begin(), res.begin() + support_size );
+      res.set_leaves( leaves.begin(), leaves.end() );
+    }
+
+    return true;
+  }
+
+  uint32_t compute_truth_table( uint32_t index, std::vector<cut_t const*> const& vcuts, cut_t& res )
+  {
+    stopwatch t( st.time_truth_table );
+
+    std::vector<kitty::static_truth_table<NumVars>> tt( vcuts.size() );
+    auto i = 0;
+    for ( auto const& cut : vcuts )
+    {
+      tt[i] = cuts._truth_tables[( *cut )->func_id];
+      const auto supp = cuts.compute_truth_table_support( *cut, res );
+      kitty::expand_inplace( tt[i], supp );
+      ++i;
+    }
+
+    auto tt_res = ntk.compute( ntk.index_to_node( index ), tt.begin(), tt.end() );
+
+    if ( ps.minimize_truth_table && !fast_support_minimization( tt_res, res ) )
+    {
+      const auto support = kitty::min_base_inplace( tt_res );
+      if ( support.size() != res.size() )
+      {
+        std::vector<uint32_t> leaves_before( res.begin(), res.end() );
+        std::vector<uint32_t> leaves_after( support.size() );
+
+        auto it_support = support.begin();
+        auto it_leaves = leaves_after.begin();
+        while ( it_support != support.end() )
+        {
+          *it_leaves++ = leaves_before[*it_support++];
+        }
+        res.set_leaves( leaves_after.begin(), leaves_after.end() );
+      }
+    }
+
+    return cuts._truth_tables.insert( tt_res );
+  }
+
+  void merge_cuts2( uint32_t index )
+  {
+    const auto fanin = 2;
+
+    uint32_t pairs{1};
+    ntk.foreach_fanin( ntk.index_to_node( index ), [this, &pairs]( auto child, auto i ) {
+      lcuts[i] = &cuts.cuts( ntk.node_to_index( ntk.get_node( child ) ) );
+      pairs *= static_cast<uint32_t>( lcuts[i]->size() );
+    } );
+    lcuts[2] = &cuts.cuts( index );
+    auto& rcuts = *lcuts[fanin];
+    rcuts.clear();
+
+    cut_t new_cut;
+
+    std::vector<cut_t const*> vcuts( fanin );
+
+    cuts._total_tuples += pairs;
+    for ( auto const& c1 : *lcuts[0] )
+    {
+      for ( auto const& c2 : *lcuts[1] )
+      {
+        if ( !c1->merge( *c2, new_cut, NumVars ) )
+        {
+          continue;
+        }
+
+        if ( rcuts.is_dominated( new_cut ) )
+        {
+          continue;
+        }
+
+        if constexpr ( ComputeTruth )
+        {
+          vcuts[0] = c1;
+          vcuts[1] = c2;
+          new_cut->func_id = compute_truth_table( index, vcuts, new_cut );
+        }
+
+        cut_enumeration_update_cut<CutData>::apply( new_cut, cuts, ntk, index );
+
+        rcuts.insert( new_cut );
+      }
+    }
+
+    /* limit the maximum number of cuts */
+    rcuts.limit( ps.cut_limit );
+
+    cuts._total_cuts += rcuts.size();
+
+    if ( rcuts.size() > 1 || ( *rcuts.begin() )->size() > 1 )
+    {
+      cuts.add_unit_cut( index );
+    }
+  }
+
+  void merge_cuts( uint32_t index )
+  {
+    uint32_t pairs{1};
+    std::vector<uint32_t> cut_sizes;
+    ntk.foreach_fanin( ntk.index_to_node( index ), [this, &pairs, &cut_sizes]( auto child, auto i ) {
+      lcuts[i] = &cuts.cuts( ntk.node_to_index( ntk.get_node( child ) ) );
+      cut_sizes.push_back( static_cast<uint32_t>( lcuts[i]->size() ) );
+      pairs *= cut_sizes.back();
+    } );
+
+    const auto fanin = cut_sizes.size();
+    lcuts[fanin] = &cuts.cuts( index );
+
+    auto& rcuts = *lcuts[fanin];
+
+    if ( fanin > 1 && fanin <= ps.fanin_limit )
+    {
+      rcuts.clear();
+
+      cut_t new_cut, tmp_cut;
+
+      std::vector<cut_t const*> vcuts( fanin );
+
+      cuts._total_tuples += pairs;
+      foreach_mixed_radix_tuple( cut_sizes.begin(), cut_sizes.end(), [&]( auto begin, auto end ) {
+        auto it = vcuts.begin();
+        auto i = 0u;
+        while ( begin != end )
+        {
+          *it++ = &( ( *lcuts[i++] )[*begin++] );
+        }
+
+        if ( !vcuts[0]->merge( *vcuts[1], new_cut, NumVars ) )
+        {
+          return true; /* continue */
+        }
+
+        for ( i = 2; i < fanin; ++i )
+        {
+          tmp_cut = new_cut;
+          if ( !vcuts[i]->merge( tmp_cut, new_cut, NumVars ) )
+          {
+            return true; /* continue */
+          }
+        }
+
+        if ( rcuts.is_dominated( new_cut ) )
+        {
+          return true; /* continue */
+        }
+
+        if constexpr ( ComputeTruth )
+        {
+          new_cut->func_id = compute_truth_table( index, vcuts, new_cut );
+        }
+
+        cut_enumeration_update_cut<CutData>::apply( new_cut, cuts, ntk, ntk.index_to_node( index ) );
+
+        rcuts.insert( new_cut );
+
+        return true;
+      } );
+
+      /* limit the maximum number of cuts */
+      rcuts.limit( ps.cut_limit );
+    } else if ( fanin == 1 ) {
+      rcuts.clear();
+
+      for ( auto const& cut : *lcuts[0] ) {
+        cut_t new_cut = *cut;
+
+        if constexpr ( ComputeTruth )
+        {
+          new_cut->func_id = compute_truth_table( index, {cut}, new_cut );
+        }
+
+        cut_enumeration_update_cut<CutData>::apply( new_cut, cuts, ntk, ntk.index_to_node( index ) );
+
+        rcuts.insert( new_cut );
+      }
+
+      /* limit the maximum number of cuts */
+      rcuts.limit( ps.cut_limit );
+    }
+
+    cuts._total_cuts += static_cast<uint32_t>( rcuts.size() );
+
+    cuts.add_unit_cut( index );
+  }
+
+private:
+  Ntk const& ntk;
+  cut_enumeration_params const& ps;
+  cut_enumeration_stats& st;
+  dynamic_network_cuts<Ntk, NumVars, ComputeTruth, CutData>& cuts;
+
+  std::array<cut_set_t*, Ntk::max_fanin_size + 1> lcuts;
+};
+} /* namespace detail */
+/*! \endcond */
+
 // This function expects to receive a network where nodes are sorted in
 // topological order. Cuts are represented as a 64-bit bit vector where each bit
 // determines whether a given node exists in the cut.

--- a/include/mockturtle/algorithms/cut_enumeration/rewrite_cut.hpp
+++ b/include/mockturtle/algorithms/cut_enumeration/rewrite_cut.hpp
@@ -1,0 +1,88 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2023  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file rewrite_cut.hpp
+  \brief Cut enumeration for rewriting
+
+  \author Alessandro Tempia Calvino
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include "../cut_enumeration.hpp"
+
+namespace mockturtle
+{
+
+/*! \brief Cut implementation for rewrite */
+struct cut_enumeration_rewrite_cut
+{
+  uint32_t cost;
+};
+
+template<bool ComputeTruth>
+bool operator<( cut_type<ComputeTruth, cut_enumeration_rewrite_cut> const& c1, cut_type<ComputeTruth, cut_enumeration_rewrite_cut> const& c2 )
+{
+  if ( c1->data.cost < c2->data.cost )
+    return true;
+  if ( c1->data.cost > c2->data.cost )
+    return false;
+  return c1.size() < c2.size();
+}
+
+template<>
+struct cut_enumeration_update_cut<cut_enumeration_rewrite_cut>
+{
+  template<typename Cut, typename NetworkCuts, typename Ntk>
+  static void apply( Cut& cut, NetworkCuts const& cuts, Ntk const& ntk, node<Ntk> const& n )
+  {
+    uint32_t value = 0;
+
+    for ( auto leaf : cut )
+    {
+      value += ( ntk.fanout_size( ntk.index_to_node( leaf ) ) == 1 ) ? 1u : 0u;
+    }
+
+    cut->data.cost = value;
+  }
+};
+
+template<int MaxLeaves>
+std::ostream& operator<<( std::ostream& os, cut<MaxLeaves, cut_data<false, cut_enumeration_rewrite_cut>> const& c )
+{
+  os << "{ ";
+  std::copy( c.begin(), c.end(), std::ostream_iterator<uint32_t>( os, " " ) );
+  os << "}, C = " << std::setw( 3 ) << c->data.cost;
+  return os;
+}
+
+} // namespace mockturtle

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -39,8 +39,8 @@
 #include "../views/depth_view.hpp"
 #include "../views/fanout_view.hpp"
 #include "cleanup.hpp"
-#include "cut_enumeration/rewrite_cut.hpp"
 #include "cut_enumeration.hpp"
+#include "cut_enumeration/rewrite_cut.hpp"
 
 #include <fmt/format.h>
 #include <kitty/dynamic_truth_table.hpp>
@@ -89,13 +89,13 @@ struct rewrite_params
 struct rewrite_stats
 {
   /*! \brief Total runtime. */
-  stopwatch<>::duration time_total{0};
+  stopwatch<>::duration time_total{ 0 };
 
   /*! \brief Expected gain. */
-  uint32_t estimated_gain{0};
+  uint32_t estimated_gain{ 0 };
 
   /*! \brief Candidates */
-  uint32_t candidates{0};
+  uint32_t candidates{ 0 };
 
   void report() const
   {
@@ -121,7 +121,7 @@ public:
   {
     register_events();
   }
-  
+
   ~rewrite_impl()
   {
     if constexpr ( has_level_v<Ntk> )
@@ -290,7 +290,7 @@ public:
       if ( best_gain > 0 || ( ps.allow_zero_gain && best_gain == 0 ) )
       {
         /* replace node wth the new structure */
-        topo_view topo{db, best_signal};
+        topo_view topo{ db, best_signal };
         auto new_f = cleanup_dangling( topo, ntk, best_leaves.begin(), best_leaves.end() ).front();
 
         assert( n != ntk.get_node( new_f ) );
@@ -317,7 +317,7 @@ public:
   }
 
 private:
-  int32_t measure_mffc_ref( node<Ntk> const& n,  cut_t const* cut )
+  int32_t measure_mffc_ref( node<Ntk> const& n, cut_t const* cut )
   {
     /* reference cut leaves */
     for ( auto leaf : *cut )
@@ -336,7 +336,7 @@ private:
     return mffc_size;
   }
 
-  int32_t measure_mffc_deref( node<Ntk> const& n,  cut_t const* cut )
+  int32_t measure_mffc_deref( node<Ntk> const& n, cut_t const* cut )
   {
     /* reference cut leaves */
     for ( auto leaf : *cut )
@@ -526,11 +526,11 @@ private:
     /* recursively update required time */
     ntk.foreach_fanin( n, [&]( auto const& f ) {
       auto const g = ntk.get_node( f );
-      
+
       /* recur if it is still a node to explore and to update */
       if ( ntk.node_to_index( g ) > root && ( ntk.node_to_index( g ) > size || required[g] > req ) )
         propagate_required_rec( root, g, size, req - 1 );
-      
+
       /* update the required time */
       if ( ntk.node_to_index( g ) < size )
         required[g] = std::min( required[g], req - 1 );
@@ -617,8 +617,8 @@ private:
 
   node_map<uint32_t, Ntk> required;
 
-  uint32_t _candidates{0};
-  uint32_t _estimated_gain{0};
+  uint32_t _candidates{ 0 };
+  uint32_t _estimated_gain{ 0 };
 
   /* events */
   std::shared_ptr<typename network_events<Ntk>::add_event_type> add_event;

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -1,0 +1,704 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2023  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file rewrite.hpp
+  \brief Inplace rewrite
+
+  \author Alessandro Tempia Calvino
+*/
+
+#pragma once
+
+#include "../traits.hpp"
+#include "../utils/cost_functions.hpp"
+#include "../utils/node_map.hpp"
+#include "../utils/stopwatch.hpp"
+#include "../views/depth_view.hpp"
+#include "../views/fanout_view.hpp"
+#include "cleanup.hpp"
+#include "cut_enumeration/rewrite_cut.hpp"
+#include "cut_enumeration.hpp"
+
+#include <fmt/format.h>
+#include <kitty/dynamic_truth_table.hpp>
+#include <kitty/npn.hpp>
+#include <kitty/operations.hpp>
+#include <kitty/static_truth_table.hpp>
+
+namespace mockturtle
+{
+
+/*! \brief Parameters for Rewrite.
+ *
+ * The data structure `rewrite_params` holds configurable parameters with
+ * default arguments for `rewrite`.
+ */
+struct rewrite_params
+{
+  rewrite_params()
+  {
+    /* 0 < Cut limit < 16 */
+    cut_enumeration_ps.cut_limit = 8;
+    cut_enumeration_ps.minimize_truth_table = true;
+  }
+
+  /*! \brief Cut enumeration parameters. */
+  cut_enumeration_params cut_enumeration_ps{};
+
+  /*! \brief If true, candidates are only accepted if they do not increase logic depth. */
+  bool preserve_depth{ false };
+
+  /*! \brief Allow rewrite with multiple structures */
+  bool allow_multiple_structures{ true };
+
+  /*! \brief Allow zero-gain substitutions */
+  bool allow_zero_gain{ false };
+
+  /*! \brief Be verbose. */
+  bool verbose{ false };
+};
+
+/*! \brief Statistics for rewrite.
+ *
+ * The data structure `rewrite_stats` provides data collected by running
+ * `rewrite`.
+ */
+struct rewrite_stats
+{
+  /*! \brief Total runtime. */
+  stopwatch<>::duration time_total{0};
+
+  /*! \brief Expected gain. */
+  uint32_t estimated_gain{0};
+
+  /*! \brief Candidates */
+  uint32_t candidates{0};
+
+  void report() const
+  {
+    std::cout << fmt::format( "[i] total time       = {:>5.2f} secs\n", to_seconds( time_total ) );
+  }
+};
+
+namespace detail
+{
+
+template<class Ntk, class Library, class NodeCostFn>
+class rewrite_impl
+{
+  static constexpr uint32_t num_vars = 4u;
+  using network_cuts_t = dynamic_network_cuts<Ntk, num_vars, true, cut_enumeration_rewrite_cut>;
+  using cut_manager_t = detail::dynamic_cut_enumeration_impl<Ntk, num_vars, true, cut_enumeration_rewrite_cut>;
+  using cut_t = typename network_cuts_t::cut_t;
+  using node_data = typename Ntk::storage::element_type::node_type;
+
+public:
+  rewrite_impl( Ntk& ntk, Library&& library, rewrite_params const& ps, rewrite_stats& st, NodeCostFn const& cost_fn )
+      : ntk( ntk ), library( library ), ps( ps ), st( st ), cost_fn( cost_fn ), required( ntk, UINT32_MAX )
+  {
+    register_events();
+  }
+  
+  ~rewrite_impl()
+  {
+    if constexpr ( has_level_v<Ntk> )
+    {
+      ntk.events().release_add_event( add_event );
+      ntk.events().release_modified_event( modified_event );
+      ntk.events().release_delete_event( delete_event );
+    }
+  }
+
+  void run()
+  {
+    stopwatch t( st.time_total );
+
+    ntk.incr_trav_id();
+
+    if ( ps.preserve_depth )
+    {
+      compute_required();
+    }
+
+    /* initialize the cut manager */
+    cut_enumeration_stats cst;
+    network_cuts_t cuts( ntk.size() + ( ntk.size() >> 1 ) );
+    cut_manager_t cut_manager( ntk, ps.cut_enumeration_ps, cst, cuts );
+
+    /* initialize cuts for constant nodes and PIs */
+    cut_manager.init_cuts();
+
+    auto& db = library.get_database();
+
+    const auto size = ntk.size();
+    ntk.foreach_gate( [&]( auto const& n, auto i ) {
+      if ( ntk.fanout_size( n ) == 0u )
+        return;
+
+      int32_t best_gain = -1;
+      int32_t best_gain2 = -1;
+      uint32_t best_level = UINT32_MAX;
+      uint32_t best_cut = 0;
+      signal<Ntk> best_signal;
+      std::vector<signal<Ntk>> best_leaves;
+      bool best_phase = false;
+      std::vector<signal<Ntk>> leaves( num_vars, ntk.get_constant( false ) );
+
+      /* update level for node */
+      if constexpr ( has_level_v<Ntk> )
+      {
+        if ( ps.preserve_depth )
+        {
+          uint32_t level = 0;
+          ntk.foreach_fanin( n, [&]( auto const& f ) {
+            level = std::max( level, ntk.level( ntk.get_node( f ) ) );
+          } );
+          ntk.set_level( n, level + 1 );
+          best_level = level + 1;
+        }
+      }
+
+      {
+        /* use cuts */
+        cut_manager.clear_cuts( n );
+        cut_manager.compute_cuts( n );
+
+        uint32_t cut_index = 0;
+        for ( auto& cut : cuts.cuts( ntk.node_to_index( n ) ) )
+        {
+          /* skip trivial cut */
+          if ( ( cut->size() == 1 && *cut->begin() == ntk.node_to_index( n ) ) )
+          {
+            ++cut_index;
+            continue;
+          }
+
+          /* Boolean matching */
+          auto config = kitty::exact_npn_canonization( cuts.truth_table( *cut ) );
+          auto tt_npn = std::get<0>( config );
+          auto neg = std::get<1>( config );
+          auto perm = std::get<2>( config );
+
+          auto const structures = library.get_supergates( tt_npn );
+
+          if ( structures == nullptr )
+          {
+            ++cut_index;
+            continue;
+          }
+
+          uint32_t negation = 0;
+          std::array<uint8_t, num_vars> permutation;
+
+          for ( auto j = 0u; j < num_vars; ++j )
+          {
+            permutation[perm[j]] = j;
+            negation |= ( ( neg >> perm[j] ) & 1 ) << j;
+          }
+
+          /* save output negation to apply */
+          bool phase = ( neg >> num_vars == 1 ) ? true : false;
+
+          {
+            auto j = 0u;
+            for ( auto const leaf : *cut )
+            {
+              leaves[permutation[j++]] = ntk.make_signal( ntk.index_to_node( leaf ) );
+            }
+          }
+
+          for ( auto j = 0u; j < num_vars; ++j )
+          {
+            if ( ( negation >> j ) & 1 )
+            {
+              leaves[j] = !leaves[j];
+            }
+          }
+
+          {
+            /* measure the MFFC contained in the cut */
+            int32_t mffc_size = measure_mffc_deref( n, cut );
+
+            for ( auto const& dag : *structures )
+            {
+              auto [nodes_added, level] = evaluate_entry( db.get_node( dag.root ), leaves );
+              int32_t gain = mffc_size - nodes_added;
+
+              /* discard if dag.root and n are the same */
+              if ( ntk.node_to_index( n ) == db.value( db.get_node( dag.root ) ) )
+                continue;
+
+              /* discard if no gain */
+              if ( gain < 0 || ( !ps.allow_zero_gain && gain == 0 ) )
+                continue;
+
+              /* discard if level increases */
+              if constexpr ( has_level_v<Ntk> )
+              {
+                if ( ps.preserve_depth && level > required[n] )
+                  continue;
+              }
+
+              if ( ( gain > best_gain ) || ( gain == best_gain && level < best_level ) )
+              {
+                ++_candidates;
+                best_gain = gain;
+                best_signal = dag.root;
+                best_leaves = leaves;
+                best_phase = phase;
+                best_cut = cut_index;
+                best_level = level;
+              }
+
+              if ( !ps.allow_multiple_structures )
+                break;
+            }
+
+            /* restore contained MFFC */
+            measure_mffc_ref( n, cut );
+            ++cut_index;
+
+            if ( cut->size() == 0 || ( cut->size() == 1 && *cut->begin() != ntk.node_to_index( n ) ) )
+              break;
+          }
+        }
+      }
+
+      if ( best_gain > 0 || ( ps.allow_zero_gain && best_gain == 0 ) )
+      {
+        /* replace node wth the new structure */
+        topo_view topo{db, best_signal};
+        auto new_f = cleanup_dangling( topo, ntk, best_leaves.begin(), best_leaves.end() ).front();
+
+        assert( n != ntk.get_node( new_f ) );
+
+        _estimated_gain += best_gain;
+        ntk.substitute_node( n, new_f ^ best_phase );
+
+        if constexpr ( has_level_v<Ntk> )
+        {
+          /* TODO: propagate new required to leaves */
+          if ( ps.preserve_depth )
+          {
+            propagate_required_rec( ntk.node_to_index( n ), ntk.get_node( new_f ), size, required[n] );
+            assert( ntk.level( ntk.get_node( new_f ) ) <= required[n] );
+          }
+        }
+
+        clear_cuts_fanout_rec( cuts, cut_manager, ntk.get_node( new_f ) );
+      }
+    } );
+
+    st.estimated_gain = _estimated_gain;
+    st.candidates = _candidates;
+  }
+
+private:
+  int32_t measure_mffc_ref( node<Ntk> const& n,  cut_t const* cut )
+  {
+    /* reference cut leaves */
+    for ( auto leaf : *cut )
+    {
+      ntk.incr_fanout_size( ntk.index_to_node( leaf ) );
+    }
+
+    int32_t mffc_size = static_cast<int32_t>( recursive_ref( n ) );
+
+    /* dereference leaves */
+    for ( auto leaf : *cut )
+    {
+      ntk.decr_fanout_size( ntk.index_to_node( leaf ) );
+    }
+
+    return mffc_size;
+  }
+
+  int32_t measure_mffc_deref( node<Ntk> const& n,  cut_t const* cut )
+  {
+    /* reference cut leaves */
+    for ( auto leaf : *cut )
+    {
+      ntk.incr_fanout_size( ntk.index_to_node( leaf ) );
+    }
+
+    int32_t mffc_size = static_cast<int32_t>( recursive_deref( n ) );
+
+    /* dereference leaves */
+    for ( auto leaf : *cut )
+    {
+      ntk.decr_fanout_size( ntk.index_to_node( leaf ) );
+    }
+
+    return mffc_size;
+  }
+
+  uint32_t recursive_deref( node<Ntk> const& n )
+  {
+    /* terminate? */
+    if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      return 0;
+
+    /* recursively collect nodes */
+    uint32_t value{ cost_fn( ntk, n ) };
+    ntk.foreach_fanin( n, [&]( auto const& s ) {
+      if ( ntk.decr_fanout_size( ntk.get_node( s ) ) == 0 )
+      {
+        value += recursive_deref( ntk.get_node( s ) );
+      }
+    } );
+    return value;
+  }
+
+  uint32_t recursive_ref( node<Ntk> const& n )
+  {
+    /* terminate? */
+    if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      return 0;
+
+    /* recursively collect nodes */
+    uint32_t value{ cost_fn( ntk, n ) };
+    ntk.foreach_fanin( n, [&]( auto const& s ) {
+      if ( ntk.incr_fanout_size( ntk.get_node( s ) ) == 0 )
+      {
+        value += recursive_ref( ntk.get_node( s ) );
+      }
+    } );
+    return value;
+  }
+
+  inline std::pair<int32_t, uint32_t> evaluate_entry( node<Ntk> const& n, std::vector<signal<Ntk>> const& leaves )
+  {
+    auto& db = library.get_database();
+    db.incr_trav_id();
+
+    return evaluate_entry_rec( n, leaves );
+  }
+
+  std::pair<int32_t, uint32_t> evaluate_entry_rec( node<Ntk> const& n, std::vector<signal<Ntk>> const& leaves )
+  {
+    auto& db = library.get_database();
+    if ( db.is_pi( n ) || db.is_constant( n ) )
+      return { 0, 0 };
+    if ( db.visited( n ) == db.trav_id() )
+      return { 0, 0 };
+
+    db.set_visited( n, db.trav_id() );
+
+    int32_t area = 0;
+    uint32_t level = 0;
+    bool hashed = true;
+
+    std::array<signal<Ntk>, Ntk::max_fanin_size> node_data;
+    db.foreach_fanin( n, [&]( auto const& f, auto i ) {
+      node<Ntk> g = db.get_node( f );
+      if ( db.is_constant( g ) )
+      {
+        node_data[i] = f; /* ntk.get_costant( db.is_complemented( f ) ) */
+        return;
+      }
+      if ( db.is_pi( g ) )
+      {
+        node_data[i] = leaves[db.node_to_index( g ) - 1] ^ db.is_complemented( f );
+        if constexpr ( has_level_v<Ntk> )
+        {
+          level = std::max( level, ntk.level( ntk.get_node( leaves[db.node_to_index( g ) - 1] ) ) );
+        }
+        return;
+      }
+
+      auto [area_rec, level_rec] = evaluate_entry_rec( g, leaves );
+      area += area_rec;
+      level = std::max( level, level_rec );
+
+      /* check value */
+      if ( db.value( g ) < ntk.size() )
+      {
+        node_data[i] = ntk.make_signal( ntk.index_to_node( db.value( g ) ) ) ^ db.is_complemented( f );
+      }
+      else
+      {
+        hashed = false;
+      }
+    } );
+
+    if ( hashed )
+    {
+      /* try hash */
+      /* AIG, XAG, MIG, and XMG are supported now */
+      std::optional<node<Ntk>> val;
+      do
+      {
+        /* XAG */
+        if constexpr ( has_has_and_v<Ntk> && has_has_xor_v<Ntk> )
+        {
+          if ( db.is_and( n ) )
+            val = ntk.has_and( node_data[0], node_data[1] );
+          else
+            val = ntk.has_xor( node_data[0], node_data[1] );
+          break;
+        }
+
+        /* AIG */
+        if constexpr ( has_has_and_v<Ntk> )
+        {
+          val = ntk.has_and( node_data[0], node_data[1] );
+          break;
+        }
+
+        /* XMG */
+        if constexpr ( has_has_maj_v<Ntk> && has_has_xor3_v<Ntk> )
+        {
+          if ( db.is_maj( n ) )
+            val = ntk.has_maj( node_data[0], node_data[1], node_data[2] );
+          else
+            val = ntk.has_xor3( node_data[0], node_data[1], node_data[2] );
+          break;
+        }
+
+        /* MAJ */
+        if constexpr ( has_has_maj_v<Ntk> )
+        {
+          val = ntk.has_maj( node_data[0], node_data[1], node_data[2] );
+          break;
+        }
+        std::cerr << "[e] Only AIGs, XAGs, MAJs, and XMGs are currently supported \n";
+      } while ( false );
+
+      if ( val.has_value() )
+      {
+        db.set_value( n, *val );
+        return { area + ( ntk.fanout_size( *val ) > 0 ? 0 : cost_fn( ntk, n ) ), level + 1 };
+      }
+    }
+
+    db.set_value( n, ntk.size() );
+    return { area + cost_fn( ntk, n ), level + 1 };
+  }
+
+  void compute_required()
+  {
+    if constexpr ( has_level_v<Ntk> )
+    {
+      ntk.foreach_po( [&]( auto const& f ) {
+        required[f] = ntk.depth();
+      } );
+
+      for ( uint32_t index = ntk.size() - 1; index > ntk.num_pis(); index-- )
+      {
+        node<Ntk> n = ntk.index_to_node( index );
+        uint32_t req = required[n];
+
+        ntk.foreach_fanin( n, [&]( auto const& f ) {
+          required[f] = std::min( required[f], req - 1 );
+        } );
+      }
+    }
+  }
+
+  void propagate_required_rec( uint32_t root, node<Ntk> const& n, uint32_t size, uint32_t req )
+  {
+    if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      return;
+
+    /* recursively update required time */
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      auto const g = ntk.get_node( f );
+      
+      /* recur if it is still a node to explore and to update */
+      if ( ntk.node_to_index( g ) > root && ( ntk.node_to_index( g ) > size || required[g] > req ) )
+        propagate_required_rec( root, g, size, req - 1 );
+      
+      /* update the required time */
+      if ( ntk.node_to_index( g ) < size )
+        required[g] = std::min( required[g], req - 1 );
+    } );
+  }
+
+  void clear_cuts_fanout_rec( network_cuts_t& cuts, cut_manager_t& cut_manager, node<Ntk> const& n )
+  {
+    ntk.foreach_fanout( n, [&]( auto const& g ) {
+      auto const index = ntk.node_to_index( g );
+      if ( cuts.cuts( index ).size() > 0 )
+      {
+        cut_manager.clear_cuts( g );
+        clear_cuts_fanout_rec( cuts, cut_manager, g );
+      }
+    } );
+  }
+
+private:
+  void register_events()
+  {
+    if constexpr ( has_level_v<Ntk> )
+    {
+      auto const update_level_of_new_node = [&]( const auto& n ) {
+        ntk.resize_levels();
+        update_node_level( n );
+      };
+
+      auto const update_level_of_existing_node = [&]( node<Ntk> const& n, const auto& old_children ) {
+        (void)old_children;
+        ntk.resize_levels();
+        update_node_level( n );
+      };
+
+      auto const update_level_of_deleted_node = [&]( node<Ntk> const& n ) {
+        ntk.set_level( n, -1 );
+      };
+
+      // add_event = ntk.events().register_add_event( update_level_of_new_node );
+      modified_event = ntk.events().register_modified_event( update_level_of_existing_node );
+      delete_event = ntk.events().register_delete_event( update_level_of_deleted_node );
+    }
+  }
+
+  /* maybe it should be moved to depth_view */
+  void update_node_level( node<Ntk> const& n, bool top_most = true )
+  {
+    if constexpr ( has_level_v<Ntk> )
+    {
+      uint32_t curr_level = ntk.level( n );
+
+      uint32_t max_level = 0;
+      ntk.foreach_fanin( n, [&]( const auto& f ) {
+        auto const p = ntk.get_node( f );
+        auto const fanin_level = ntk.level( p );
+        if ( fanin_level > max_level )
+        {
+          max_level = fanin_level;
+        }
+      } );
+      ++max_level;
+
+      if ( curr_level != max_level )
+      {
+        ntk.set_level( n, max_level );
+
+        /* update only one more level */
+        if ( top_most )
+        {
+          ntk.foreach_fanout( n, [&]( const auto& p ) {
+            update_node_level( p, false );
+          } );
+        }
+      }
+    }
+  }
+
+private:
+  Ntk& ntk;
+  Library&& library;
+  rewrite_params const& ps;
+  rewrite_stats& st;
+  NodeCostFn cost_fn;
+
+  node_map<uint32_t, Ntk> required;
+
+  uint32_t _candidates{0};
+  uint32_t _estimated_gain{0};
+
+  /* events */
+  std::shared_ptr<typename network_events<Ntk>::add_event_type> add_event;
+  std::shared_ptr<typename network_events<Ntk>::modified_event_type> modified_event;
+  std::shared_ptr<typename network_events<Ntk>::delete_event_type> delete_event;
+};
+
+} /* namespace detail */
+
+/*! \brief Boolean rewrite.
+ *
+ * This algorithm rewrites enumerated cuts using new network structures from a database.
+ * The algorithm performs changes in-place and keeps the substituted structures dangling
+ * in the network.
+ *
+ * **Required network functions:**
+ * - `get_node`
+ * - `size`
+ * - `make_signal`
+ * - `foreach_gate`
+ * - `substitute_node`
+ * - `clear_visited`
+ * - `clear_values`
+ * - `fanout_size`
+ * - `set_value`
+ * - `foreach_node`
+ *
+ * \param ntk Input network (will be changed in-place)
+ * \param library Exact library containing pre-computed structures
+ * \param ps Rewrite params
+ * \param pst Rewrite statistics
+ * \param cost_fn Node cost function (a functor with signature `uint32_t(Ntk const&, node<Ntk> const&)`)
+ */
+template<class Ntk, class Library, class NodeCostFn = unit_cost<Ntk>>
+void rewrite( Ntk& ntk, Library&& library, rewrite_params const& ps = {}, rewrite_stats* pst = nullptr, NodeCostFn const& cost_fn = {} )
+{
+  static_assert( is_network_type_v<Ntk>, "Ntk is not a network type" );
+  static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
+  static_assert( has_size_v<Ntk>, "Ntk does not implement the size method" );
+  static_assert( has_make_signal_v<Ntk>, "Ntk does not implement the make_signal method" );
+  static_assert( has_foreach_gate_v<Ntk>, "Ntk does not implement the foreach_gate method" );
+  static_assert( has_substitute_node_v<Ntk>, "Ntk does not implement the substitute_node method" );
+  static_assert( has_clear_visited_v<Ntk>, "Ntk does not implement the clear_visited method" );
+  static_assert( has_clear_values_v<Ntk>, "Ntk does not implement the clear_values method" );
+  static_assert( has_fanout_size_v<Ntk>, "Ntk does not implement the fanout_size method" );
+  static_assert( has_set_value_v<Ntk>, "Ntk does not implement the set_value method" );
+  static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
+
+  rewrite_stats st;
+
+  if ( ps.preserve_depth )
+  {
+    using depth_view_t = depth_view<Ntk, NodeCostFn>;
+    depth_view_t depth_ntk{ ntk };
+    using fanout_view_t = fanout_view<depth_view_t>;
+    fanout_view_t fanout_view{ depth_ntk };
+
+    detail::rewrite_impl<fanout_view_t, Library, NodeCostFn> p( fanout_view, library, ps, st, cost_fn );
+    p.run();
+  }
+  else
+  {
+    using fanout_view_t = fanout_view<Ntk>;
+    fanout_view_t fanout_view{ ntk };
+
+    detail::rewrite_impl<fanout_view_t, Library, NodeCostFn> p( fanout_view, library, ps, st, cost_fn );
+    p.run();
+  }
+
+  if ( ps.verbose )
+  {
+    st.report();
+  }
+
+  if ( pst )
+  {
+    *pst = st;
+  }
+
+  ntk = cleanup_dangling( ntk );
+}
+
+} /* namespace mockturtle */

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -1,0 +1,217 @@
+#include <catch.hpp>
+
+#include <mockturtle/algorithms/rewrite.hpp>
+#include <mockturtle/algorithms/node_resynthesis/mig_npn.hpp>
+#include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
+#include <mockturtle/algorithms/node_resynthesis/xmg3_npn.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/networks/mig.hpp>
+#include <mockturtle/networks/xmg.hpp>
+#include <mockturtle/traits.hpp>
+#include <mockturtle/utils/cost_functions.hpp>
+#include <mockturtle/utils/tech_library.hpp>
+#include <mockturtle/views/fanout_view.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "Rewrite bad MAJ", "[rewrite]" )
+{
+  mig_network mig;
+  const auto a = mig.create_pi();
+  const auto b = mig.create_pi();
+  const auto c = mig.create_pi();
+
+  const auto f = mig.create_maj( a, mig.create_maj( a, b, c ), c );
+  mig.create_po( f );
+
+  mig_npn_resynthesis resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<mig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite( mig, exact_lib );
+
+  CHECK( mig.size() == 5 );
+  CHECK( mig.num_pis() == 3 );
+  CHECK( mig.num_pos() == 1 );
+  CHECK( mig.num_gates() == 1 );
+}
+
+TEST_CASE( "Rewrite XMG3 using a 4-input npn database", "[rewrite]" )
+{
+  xmg_network xmg;
+  const auto a = xmg.create_pi();
+  const auto b = xmg.create_pi();
+  const auto c = xmg.create_pi();
+
+  const auto h = xmg.create_xor3( a, xmg.create_maj( a, b, c ), c );
+
+  xmg.create_po( h );
+
+  xmg3_npn_resynthesis<xmg_network> resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<xmg_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite( xmg, exact_lib );
+
+  CHECK( xmg.size() == 5 );
+  CHECK( xmg.num_pis() == 3 );
+  CHECK( xmg.num_pos() == 1 );
+  CHECK( xmg.num_gates() == 1 );
+}
+
+TEST_CASE( "Rewrite constant", "[rewrite]" )
+{
+  mig_network mig;
+  mig.create_po( mig.get_constant( false ) );
+
+  mig_npn_resynthesis resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<mig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite( mig, exact_lib );
+
+  CHECK( mig.size() == 1 );
+  CHECK( mig.num_pis() == 0 );
+  CHECK( mig.num_pos() == 1 );
+  CHECK( mig.num_gates() == 0 );
+
+  mig.foreach_po( [&]( auto const& f ) {
+    CHECK( f == mig.get_constant( false ) );
+  } );
+}
+
+TEST_CASE( "Rewrite inverted constant", "[rewrite]" )
+{
+  mig_network mig;
+  mig.create_po( mig.get_constant( true ) );
+
+  mig_npn_resynthesis resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<mig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite( mig, exact_lib );
+
+  CHECK( mig.size() == 1 );
+  CHECK( mig.num_pis() == 0 );
+  CHECK( mig.num_pos() == 1 );
+  CHECK( mig.num_gates() == 0 );
+
+  mig.foreach_po( [&]( auto const& f ) {
+    CHECK( f == mig.get_constant( true ) );
+  } );
+}
+
+TEST_CASE( "Rewrite projection", "[rewrite]" )
+{
+  mig_network mig;
+  mig.create_po( mig.create_pi() );
+
+  mig_npn_resynthesis resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<mig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite( mig, exact_lib );
+
+  CHECK( mig.size() == 2 );
+  CHECK( mig.num_pis() == 1 );
+  CHECK( mig.num_pos() == 1 );
+  CHECK( mig.num_gates() == 0 );
+
+  mig.foreach_po( [&]( auto const& f ) {
+    CHECK( mig.get_node( f ) == 1 );
+    CHECK( !mig.is_complemented( f ) );
+  } );
+}
+
+TEST_CASE( "Rewrite inverted projection", "[rewrite]" )
+{
+  mig_network mig;
+  mig.create_po( !mig.create_pi() );
+
+  mig_npn_resynthesis resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<mig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite( mig, exact_lib );
+
+  CHECK( mig.size() == 2 );
+  CHECK( mig.num_pis() == 1 );
+  CHECK( mig.num_pos() == 1 );
+  CHECK( mig.num_gates() == 0 );
+
+  mig.foreach_po( [&]( auto const& f ) {
+    CHECK( mig.get_node( f ) == 1 );
+    CHECK( mig.is_complemented( f ) );
+  } );
+}
+
+TEST_CASE( "Rewrite should avoid cycles", "[rewrite]" )
+{
+  aig_network aig;
+  const auto x0 = aig.create_pi();
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+
+  const auto n0 = aig.create_and( x1, !x2 );
+  const auto n1 = aig.create_and( !x0, n0 );
+  const auto n2 = aig.create_and( x0, !n0 );
+  const auto n3 = aig.create_and( !n1, !n2 );
+  const auto n4 = aig.create_and( x1, x2 );
+  const auto n5 = aig.create_and( x0, !n4 );
+  const auto n6 = aig.create_and( !x0, n4 );
+  const auto n7 = aig.create_and( !n5, !n6 );
+  aig.create_po( n3 );
+  aig.create_po( n7 );
+
+  xag_npn_resynthesis<aig_network> resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<aig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite( aig, exact_lib );
+
+  CHECK( aig.size() == 11 );
+  CHECK( aig.num_pis() == 3 );
+  CHECK( aig.num_pos() == 2 );
+  CHECK( aig.num_gates() == 7 );
+}
+
+TEST_CASE( "Rewrite depth-preserving", "[rewrite]" )
+{
+  aig_network aig;
+  const auto x0 = aig.create_pi();
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+
+  const auto n0 = aig.create_and( x1, !x2 );
+  const auto n1 = aig.create_and( !x0, n0 );
+  const auto n2 = aig.create_and( x0, !n0 );
+  const auto n3 = aig.create_and( !n1, !n2 );
+  const auto n4 = aig.create_and( x1, x2 );
+  const auto n5 = aig.create_and( x0, !n4 );
+  const auto n6 = aig.create_and( !x0, n4 );
+  const auto n7 = aig.create_and( !n5, !n6 );
+  aig.create_po( n3 );
+  aig.create_po( n7 );
+
+  xag_npn_resynthesis<aig_network> resyn;
+  exact_library_params eps;
+  eps.np_classification = false;
+  exact_library<aig_network, decltype( resyn )> exact_lib( resyn, eps );
+
+  rewrite_params ps;
+  ps.preserve_depth = true;
+  rewrite( aig, exact_lib, ps );
+
+  CHECK( aig.size() == 12 );
+  CHECK( aig.num_pis() == 3 );
+  CHECK( aig.num_pos() == 2 );
+  CHECK( aig.num_gates() == 8 );
+}


### PR DESCRIPTION
Adding:
- In-place DAG-aware rewriting. Compared to `cut_rewriting`, replacements are substituted in place right away instead of accumulating them and solving a covering problem afterward)
- Dynamic cut enumeration (for expanding or changing networks)