### PR TITLE
Refactoring extensions and fixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ v0.4 (not yet released)
     - Mapping of sequential networks (`map`, `seq_map`) `#599 <https://github.com/lsils/mockturtle/pull/599>`_
     - DAG-aware in-place rewriting (`rewrite`) `#605 <https://github.com/lsils/mockturtle/pull/605>`_
     - Dynamic cut enumeration (`dynamic_cut_enumeration_impl`) `#605 <https://github.com/lsils/mockturtle/pull/605>`_
+    - Extensions and fixes in refactoring (`refactoring`) `#607 <https://github.com/lsils/mockturtle/pull/607>`_
 * I/O:
     - Write gates to GENLIB file (`write_genlib`) `#606 <https://github.com/lsils/mockturtle/pull/606>`_
 * Views:
@@ -36,6 +37,7 @@ v0.4 (not yet released)
     - Rank view for management of the ordering of nodes within each level (`rank_view`, contributed by Marcel Walter) `#589 <https://github.com/lsils/mockturtle/pull/589>`_
     - Choice view for management of equivalent classes (`choice_view`) `#594 <https://github.com/lsils/mockturtle/pull/594>`_
     - Deterministic randomization option in topological sorting (`topo_view`) `#594 <https://github.com/lsils/mockturtle/pull/594>`_
+    - Fixing MFFC view (`mffc_view`) `#607 <https://github.com/lsils/mockturtle/pull/607>`_
 * Properties:
     - Cost functions based on the factored form literals count (`factored_literal_cost`) `#579 <https://github.com/lsils/mockturtle/pull/579>`_
 * Utils:

--- a/experiments/refactoring.cpp
+++ b/experiments/refactoring.cpp
@@ -1,0 +1,80 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2023  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string>
+#include <fmt/format.h>
+#include <lorina/aiger.hpp>
+#include <mockturtle/algorithms/node_resynthesis/sop_factoring.hpp>
+#include <mockturtle/algorithms/cleanup.hpp>
+#include <mockturtle/algorithms/refactoring.hpp>
+#include <mockturtle/io/aiger_reader.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <mockturtle/views/depth_view.hpp>
+
+#include <experiments.hpp>
+
+
+int main()
+{
+  using namespace experiments;
+  using namespace mockturtle;
+
+  experiment<std::string, uint32_t, uint32_t, uint32_t, uint32_t, double, bool> exp(
+      "refactoring", "benchmark", "size", "size_after", "depth", "depth_after", "run time", "equivalent" );
+
+  sop_factoring<aig_network> resyn;
+
+  for ( auto const& benchmark : epfl_benchmarks() )
+  {
+    fmt::print( "[i] processing {}\n", benchmark );
+
+    aig_network aig;
+    if ( lorina::read_aiger( benchmark_path( benchmark ), aiger_reader( aig ) ) != lorina::return_code::success )
+    {
+      continue;
+    }
+
+    const uint32_t size_before = aig.num_gates();
+    const uint32_t depth_before = depth_view( aig ).depth();
+
+    refactoring_params ps;
+    refactoring_stats st;
+    refactoring( aig, resyn, ps, &st );
+
+    aig = cleanup_dangling( aig );
+
+    const uint32_t size_after = aig.num_gates();
+    const uint32_t depth_after = depth_view( aig ).depth();
+
+    const auto cec = benchmark == "hyp" ? true : abc_cec( aig, benchmark );
+
+    exp( benchmark, size_before, size_after, depth_before, depth_after, to_seconds( st.time_total ), cec );
+  }
+
+  exp.save();
+  exp.table();
+
+  return 0;
+}

--- a/include/mockturtle/algorithms/refactoring.hpp
+++ b/include/mockturtle/algorithms/refactoring.hpp
@@ -1,5 +1,5 @@
 /* mockturtle: C++ logic network library
- * Copyright (C) 2018-2022  EPFL
+ * Copyright (C) 2018-2023  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@
   \file refactoring.hpp
   \brief Refactoring
 
+  \author Alessandro Tempia Calvino
   \author Eleonora Testa
   \author Heinz Riener
   \author Mathias Soeken
@@ -42,6 +43,8 @@
 #include "../views/cut_view.hpp"
 #include "../views/mffc_view.hpp"
 #include "../views/topo_view.hpp"
+#include "../views/window_view.hpp"
+#include "../views/color_view.hpp"
 #include "cleanup.hpp"
 #include "detail/mffc_utils.hpp"
 #include "dont_cares.hpp"
@@ -60,11 +63,14 @@ namespace mockturtle
  */
 struct refactoring_params
 {
-  /*! \brief Maximum number of PIs in MFFCs. */
+  /*! \brief Maximum number of PIs of the MFFC or window. */
   uint32_t max_pis{ 6 };
 
   /*! \brief Allow zero-gain substitutions */
   bool allow_zero_gain{ false };
+
+  /*! \brief Extract a reconvergent-driven cut for large MFFcs */
+  bool use_reconvergent_cut{ true };
 
   /*! \brief Use don't cares for optimization. */
   bool use_dont_cares{ false };
@@ -141,10 +147,13 @@ public:
     stopwatch t( st.time_total );
 
     ntk.clear_visited();
-    ntk.clear_values();
-    ntk.foreach_node( [&]( auto const& n ) {
-      ntk.set_value( n, ntk.fanout_size( n ) );
-    } );
+
+    reconvergence_driven_cut_parameters rps;
+    rps.max_leaves = ps.max_pis;
+    reconvergence_driven_cut_statistics rst;
+    detail::reconvergence_driven_cut_impl<Ntk, false, false> reconv_cuts( ntk, rps, rst );
+
+    color_view<Ntk> color_ntk{ ntk };
 
     const auto size = ntk.num_gates();
     ntk.foreach_gate( [&]( auto const& n, auto i ) {
@@ -160,22 +169,54 @@ public:
 
       pbar( i, i, _candidates, _estimated_gain );
 
-      if ( mffc.num_pos() == 0 || mffc.num_pis() > ps.max_pis || mffc.size() < 4 )
+      if ( mffc.num_pos() == 0 || ( !ps.use_reconvergent_cut && mffc.num_pis() > ps.max_pis ) || mffc.size() < 4 )
       {
         return true;
       }
 
-      std::vector<signal<Ntk>> leaves( mffc.num_pis() );
-      mffc.foreach_pi( [&]( auto const& m, auto j ) {
-        leaves[j] = ntk.make_signal( m );
-      } );
+      kitty::dynamic_truth_table tt;
+      std::vector<signal<Ntk>> leaves( ps.max_pis );
+      uint32_t num_leaves = 0;
 
-      default_simulator<kitty::dynamic_truth_table> sim( mffc.num_pis() );
-      const auto tt = call_with_stopwatch( st.time_simulation,
-                                           [&]() { return simulate<kitty::dynamic_truth_table>( mffc, sim )[0]; } );
+      if ( mffc.num_pis() <= ps.max_pis )
+      {
+        /* use MFFC */
+        mffc.foreach_pi( [&]( auto const& m, auto j ) {
+          leaves[j] = ntk.make_signal( m );
+        } );
+
+        num_leaves = mffc.num_pis();
+
+        default_simulator<kitty::dynamic_truth_table> sim( mffc.num_pis() );
+        tt = call_with_stopwatch( st.time_simulation,
+                                  [&]() { return simulate<kitty::dynamic_truth_table>( mffc, sim )[0]; } );
+      }
+      else
+      {
+        /* compute a reconvergent-driven cut */
+        std::vector<node<Ntk>> roots = { n };
+        auto const extended_leaves = reconv_cuts.run( roots ).first;
+
+        num_leaves = extended_leaves.size();
+        assert( num_leaves <= ps.max_pis );
+
+        for ( auto j = 0u; j < num_leaves; ++j )
+        {
+          leaves[j] = ntk.make_signal( extended_leaves[j] );
+        }
+
+        cut_view<Ntk> cut( ntk, extended_leaves, ntk.make_signal( n ) );
+        default_simulator<kitty::dynamic_truth_table> sim( num_leaves );
+        tt = call_with_stopwatch( st.time_simulation,
+                                  [&]() { return simulate<kitty::dynamic_truth_table>( cut, sim )[0]; } );
+      }
 
       signal<Ntk> new_f;
       bool resynthesized{ false };
+
+      ntk.incr_trav_id();
+      int32_t gain = recursive_deref_mark( n );
+
       {
         if ( ps.use_dont_cares )
         {
@@ -188,64 +229,87 @@ public:
             }
             stopwatch t( st.time_refactoring );
 
-            refactoring_fn( ntk, tt, satisfiability_dont_cares( ntk, pivots, 16u ), leaves.begin(), leaves.end(), [&]( auto const& f ) { new_f = f; resynthesized = true; return false; } );
+            refactoring_fn( ntk, tt, satisfiability_dont_cares( ntk, pivots, 16u ), leaves.begin(), leaves.begin() + num_leaves, [&]( auto const& f ) { new_f = f; resynthesized = true; return false; } );
           }
           else
           {
             stopwatch t( st.time_refactoring );
-            refactoring_fn( ntk, tt, leaves.begin(), leaves.end(), [&]( auto const& f ) { new_f = f; resynthesized = true; return false; } );
+            refactoring_fn( ntk, tt, leaves.begin(), leaves.begin() + num_leaves, [&]( auto const& f ) { new_f = f; resynthesized = true; return false; } );
           }
         }
         else
         {
           stopwatch t( st.time_refactoring );
-          refactoring_fn( ntk, tt, leaves.begin(), leaves.end(), [&]( auto const& f ) { new_f = f; resynthesized = true; return false; } );
+          refactoring_fn( ntk, tt, leaves.begin(), leaves.begin() + num_leaves, [&]( auto const& f ) { new_f = f; resynthesized = true; return false; } );
         }
       }
 
       if ( !resynthesized || n == ntk.get_node( new_f ) )
       {
+        recursive_ref( n );
         return true;
       }
 
-      int32_t gain = recursive_deref( n );
-      gain -= recursive_ref( ntk.get_node( new_f ) );
+      /* ref only if it is a new node */
+      if ( ntk.fanout_size( ntk.get_node( new_f ) ) == 0 )
+      {
+        recursive_deref_check_mark( ntk.get_node( new_f ) );
+        gain -= recursive_ref( ntk.get_node( new_f ) );
+      }
+
+      recursive_ref( n );
 
       if ( gain > 0 || ( ps.allow_zero_gain && gain == 0 ) )
       {
-
         ++_candidates;
         _estimated_gain += gain;
         ntk.substitute_node( n, new_f );
-        ntk.set_value( n, 0 );
-        ntk.set_value( ntk.get_node( new_f ), ntk.fanout_size( ntk.get_node( new_f ) ) );
-        for ( auto i = 0u; i < leaves.size(); i++ )
-        {
-          ntk.set_value( ntk.get_node( leaves[i] ), ntk.fanout_size( ntk.get_node( leaves[i] ) ) );
-        }
       }
       else
       {
-        recursive_deref( ntk.get_node( new_f ) );
-        recursive_ref( n );
+        /* remove */
+        if ( ntk.fanout_size( ntk.get_node( new_f ) ) == 0 )
+          ntk.take_out_node( ntk.get_node( new_f ) );
       }
       return true;
     } );
   }
 
 private:
-  uint32_t recursive_deref( node<Ntk> const& n )
+  uint32_t recursive_deref_mark( node<Ntk> const& n )
   {
     /* terminate? */
     if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      return 0;
+    
+    ntk.set_visited( n, ntk.trav_id() );
+
+    /* recursively collect nodes */
+    uint32_t value{ cost_fn( ntk, n ) };
+    ntk.foreach_fanin( n, [&]( auto const& s ) {
+      if ( ntk.decr_fanout_size( ntk.get_node( s ) ) == 0 )
+      {
+        value += recursive_deref_mark( ntk.get_node( s ) );
+      }
+    } );
+    return value;
+  }
+
+  uint32_t recursive_deref_check_mark( node<Ntk> const& n )
+  {
+    /* terminate? */
+    if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
+      return 0;
+    
+    if ( ntk.visited( n ) == ntk.trav_id() )
       return 0;
 
     /* recursively collect nodes */
     uint32_t value{ cost_fn( ntk, n ) };
     ntk.foreach_fanin( n, [&]( auto const& s ) {
-      if ( ntk.decr_value( ntk.get_node( s ) ) == 0 )
+      if ( ntk.decr_fanout_size( ntk.get_node( s ) ) == 0 )
       {
-        value += recursive_deref( ntk.get_node( s ) );
+        value += recursive_deref_check_mark( ntk.get_node( s ) );
       }
     } );
     return value;
@@ -260,7 +324,7 @@ private:
     /* recursively collect nodes */
     uint32_t value{ cost_fn( ntk, n ) };
     ntk.foreach_fanin( n, [&]( auto const& s ) {
-      if ( ntk.incr_value( ntk.get_node( s ) ) == 0 )
+      if ( ntk.incr_fanout_size( ntk.get_node( s ) ) == 0 )
       {
         value += recursive_ref( ntk.get_node( s ) );
       }
@@ -285,6 +349,7 @@ private:
  *
  * This algorithm performs refactoring by collapsing maximal fanout-free cones
  * (MFFCs) into truth tables and recreating a new network structure from it.
+ * If the MFFC is too large a reconvergent-driven cut is extracted.
  * The algorithm performs changes directly in the input network and keeps the
  * substituted structures dangling in the network.  They can be cleaned up using
  * the `cleanup_dangling` algorithm.
@@ -331,8 +396,10 @@ void refactoring( Ntk& ntk, RefactoringFn&& refactoring_fn, refactoring_params c
   static_assert( has_set_value_v<Ntk>, "Ntk does not implement the set_value method" );
   static_assert( has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node method" );
 
+  fanout_view<Ntk> f_ntk{ ntk };
+
   refactoring_stats st;
-  detail::refactoring_impl<Ntk, RefactoringFn, NodeCostFn> p( ntk, refactoring_fn, ps, st, cost_fn );
+  detail::refactoring_impl<fanout_view<Ntk>, RefactoringFn, NodeCostFn> p( f_ntk, refactoring_fn, ps, st, cost_fn );
   p.run();
   if ( ps.verbose )
   {

--- a/include/mockturtle/algorithms/refactoring.hpp
+++ b/include/mockturtle/algorithms/refactoring.hpp
@@ -69,8 +69,8 @@ struct refactoring_params
   /*! \brief Allow zero-gain substitutions */
   bool allow_zero_gain{ false };
 
-  /*! \brief Extract a reconvergent-driven cut for large MFFcs */
-  bool use_reconvergent_cut{ true };
+  /*! \brief Extract a reconvergence-driven cut for large MFFcs */
+  bool use_reconvergence_cut{ true };
 
   /*! \brief Use don't cares for optimization. */
   bool use_dont_cares{ false };
@@ -169,7 +169,7 @@ public:
 
       pbar( i, i, _candidates, _estimated_gain );
 
-      if ( mffc.num_pos() == 0 || ( !ps.use_reconvergent_cut && mffc.num_pis() > ps.max_pis ) || mffc.size() < 4 )
+      if ( mffc.num_pos() == 0 || ( !ps.use_reconvergence_cut && mffc.num_pis() > ps.max_pis ) || mffc.size() < 4 )
       {
         return true;
       }
@@ -349,7 +349,7 @@ private:
  *
  * This algorithm performs refactoring by collapsing maximal fanout-free cones
  * (MFFCs) into truth tables and recreating a new network structure from it.
- * If the MFFC is too large a reconvergent-driven cut is extracted.
+ * If the MFFC is too large a reconvergence-driven cut is extracted.
  * The algorithm performs changes directly in the input network and keeps the
  * substituted structures dangling in the network.  They can be cleaned up using
  * the `cleanup_dangling` algorithm.

--- a/include/mockturtle/views/mffc_view.hpp
+++ b/include/mockturtle/views/mffc_view.hpp
@@ -1,5 +1,5 @@
 /* mockturtle: C++ logic network library
- * Copyright (C) 2018-2022  EPFL
+ * Copyright (C) 2018-2023  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@
   \file mffc_view.hpp
   \brief Implements an isolated view on a single cut in a network
 
+  \author Alessandro Tempia Calvino
   \author Bruno Schmitt
   \author Heinz Riener
   \author Mathias Soeken
@@ -183,7 +184,7 @@ public:
     /* restore ref counts */
     for ( auto const& n : _nodes )
     {
-      this->incr_value( n );
+      this->incr_fanout_size( n );
     }
   }
 
@@ -195,7 +196,6 @@ private:
 
     if ( Ntk::is_pi( n ) )
     {
-      _nodes.push_back( n );
       return true;
     }
 
@@ -204,7 +204,7 @@ private:
     bool ret_val = true;
     this->foreach_fanin( n, [&]( auto const& f ) {
       _nodes.push_back( this->get_node( f ) );
-      if ( this->decr_value( this->get_node( f ) ) == 0 && ( _nodes.size() > _limit || !collect( this->get_node( f ) ) ) )
+      if ( this->decr_fanout_size( this->get_node( f ) ) == 0 && ( _nodes.size() > _limit || !collect( this->get_node( f ) ) ) )
       {
         ret_val = false;
         return false;
@@ -228,7 +228,7 @@ private:
         continue;
       }
 
-      if ( this->value( n ) > 0 || Ntk::is_pi( n ) ) /* PI candidate */
+      if ( this->fanout_size( n ) > 0 || Ntk::is_pi( n ) ) /* PI candidate */
       {
         if ( _leaves.empty() || _leaves.back() != n )
         {

--- a/test/algorithms/quality.cpp
+++ b/test/algorithms/quality.cpp
@@ -148,12 +148,14 @@ TEST_CASE( "Test quality improvement of MIG refactoring with Akers resynthesis",
   const auto v = foreach_benchmark<mig_network>( []( auto& ntk, auto ) {
     const auto before = ntk.num_gates();
     akers_resynthesis<mig_network> resyn;
-    refactoring( ntk, resyn );
+    refactoring_params ps;
+    ps.use_reconvergent_cut = false;
+    refactoring( ntk, resyn, ps );
     ntk = cleanup_dangling( ntk );
     return before - ntk.num_gates();
   } );
 
-  CHECK( v == std::vector<uint32_t>{ { 0, 18, 34, 22, 114, 56, 153, 107, 432, 449, 69 } } );
+  CHECK( v == std::vector<uint32_t>{ { 0, 18, 34, 22, 114, 56, 138, 102, 402, 449, 69 } } );
 
   // with zero gain
   const auto v2 = foreach_benchmark<mig_network>( []( auto& ntk, auto ) {
@@ -161,12 +163,13 @@ TEST_CASE( "Test quality improvement of MIG refactoring with Akers resynthesis",
     akers_resynthesis<mig_network> resyn;
     refactoring_params ps;
     ps.allow_zero_gain = true;
+    ps.use_reconvergent_cut = false;
     refactoring( ntk, resyn, ps );
     ntk = cleanup_dangling( ntk );
     return before - ntk.num_gates();
   } );
 
-  CHECK( v2 == std::vector<uint32_t>{ { 0, 18, 34, 21, 115, 55, 139, 107, 409, 449, 66 } } );
+  CHECK( v2 == std::vector<uint32_t>{ { 0, 18, 34, 21, 115, 55, 139, 107, 405, 449, 66 } } );
 }
 
 TEST_CASE( "Test quality improvement of MIG mapping", "[quality]" )

--- a/test/algorithms/quality.cpp
+++ b/test/algorithms/quality.cpp
@@ -149,7 +149,7 @@ TEST_CASE( "Test quality improvement of MIG refactoring with Akers resynthesis",
     const auto before = ntk.num_gates();
     akers_resynthesis<mig_network> resyn;
     refactoring_params ps;
-    ps.use_reconvergent_cut = false;
+    ps.use_reconvergence_cut = false;
     refactoring( ntk, resyn, ps );
     ntk = cleanup_dangling( ntk );
     return before - ntk.num_gates();
@@ -163,7 +163,7 @@ TEST_CASE( "Test quality improvement of MIG refactoring with Akers resynthesis",
     akers_resynthesis<mig_network> resyn;
     refactoring_params ps;
     ps.allow_zero_gain = true;
-    ps.use_reconvergent_cut = false;
+    ps.use_reconvergence_cut = false;
     refactoring( ntk, resyn, ps );
     ntk = cleanup_dangling( ntk );
     return before - ntk.num_gates();


### PR DESCRIPTION
This PR includes:
- Extending refactoring to extract a reconvergence-driven cut on large MFFCs instead of skipping them
- Fixes in MFFC view (issue #571): use of fanout counters instead of values, fixing the erroneous double reference
- Fixes in refactoring (issue #571): use of fanout counters instead of values