### PR TITLE
Fixed compilation issues on MSVC compilers

### DIFF
--- a/experiments/experiments.hpp
+++ b/experiments/experiments.hpp
@@ -30,6 +30,8 @@
   \author Mathias Soeken
 */
 
+#pragma once
+
 #include <array>
 #include <cstdio>
 #include <fstream>
@@ -517,7 +519,11 @@ inline bool abc_cec_impl( Ntk const& ntk, std::string const& benchmark_fullpath 
 
   std::array<char, 128> buffer;
   std::string result;
+#if WIN32
+  std::unique_ptr<FILE, decltype( &_pclose )> pipe( _popen( command.c_str(), "r" ), _pclose );
+#else
   std::unique_ptr<FILE, decltype( &pclose )> pipe( popen( command.c_str(), "r" ), pclose );
+#endif
   if ( !pipe )
   {
     throw std::runtime_error( "popen() failed" );


### PR DESCRIPTION
When compiling experiments that use the `abc_cec_impl` function under any MSVC compiler, the compilation fails. That is because the function uses the symbols `popen` and `pclose`, which do not exist in MSVC. Here, they are called `_popen` and `_pclose`.

This PR fixes this issue.