### PR TITLE
Fixing non-simplified gates handling in networks

### DIFF
--- a/include/mockturtle/networks/aig.hpp
+++ b/include/mockturtle/networks/aig.hpp
@@ -83,6 +83,7 @@ struct aig_hash
   `data[0].h1`: Fan-out size (we use MSB to indicate whether a node is dead)
   `data[0].h2`: Application-specific value
   `data[1].h1`: Visited flag
+  `data[1].h2`: Is terminal node (PI or CI)
 */
 using aig_storage = storage<regular_node<2, 2, 1>,
                             empty_storage_data,
@@ -206,6 +207,7 @@ public:
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = _storage->inputs.size();
+    node.data[1].h2 = 1; // mark as PI
     _storage->inputs.emplace_back( index );
     return { index, 0 };
   }
@@ -231,12 +233,12 @@ public:
 
   bool is_ci( node const& n ) const
   {
-    return _storage->nodes[n].children[0].data == _storage->nodes[n].children[1].data;
+    return _storage->nodes[n].data[1].h2 == 1;
   }
 
   bool is_pi( node const& n ) const
   {
-    return _storage->nodes[n].children[0].data == _storage->nodes[n].children[1].data && !is_constant( n );
+    return _storage->nodes[n].data[1].h2 == 1 && !is_constant( n );
   }
 
   bool constant_value( node const& n ) const

--- a/include/mockturtle/networks/mig.hpp
+++ b/include/mockturtle/networks/mig.hpp
@@ -67,6 +67,7 @@ namespace mockturtle
   `data[0].h1`: Fan-out size (we use MSB to indicate whether a node is dead)
   `data[0].h2`: Application-specific value
   `data[1].h1`: Visited flag
+  `data[1].h2`: Is terminal node (PI or CI)
 */
 using mig_storage = storage<regular_node<3, 2, 1>>;
 
@@ -187,6 +188,7 @@ public:
     const auto index = _storage->nodes.size();
     auto& node = _storage->nodes.emplace_back();
     node.children[0].data = node.children[1].data = node.children[2].data = _storage->inputs.size();
+    node.data[1].h2 = 1; // mark as PI
     _storage->inputs.emplace_back( index );
     return { index, 0 };
   }
@@ -212,12 +214,12 @@ public:
 
   bool is_ci( node const& n ) const
   {
-    return _storage->nodes[n].children[0].data == _storage->nodes[n].children[1].data && _storage->nodes[n].children[0].data == _storage->nodes[n].children[2].data;
+    return _storage->nodes[n].data[1].h2 == 1;
   }
 
   bool is_pi( node const& n ) const
   {
-    return _storage->nodes[n].children[0].data == _storage->nodes[n].children[1].data && _storage->nodes[n].children[0].data == _storage->nodes[n].children[2].data && !is_constant( n );
+    return _storage->nodes[n].data[1].h2 == 1 && !is_constant( n );
   }
 
   bool constant_value( node const& n ) const

--- a/test/algorithms/aig_balancing.cpp
+++ b/test/algorithms/aig_balancing.cpp
@@ -53,6 +53,34 @@ TEST_CASE( "Balance AND finding structural hashing", "[aig_balancing]" )
   CHECK( aig.num_gates() == 3u );
 }
 
+TEST_CASE( "Balance AND finding structural hashing slow", "[aig_balancing]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+  const auto d = aig.create_pi();
+
+  const auto f1 = aig.create_and( a, b );
+  const auto f2 = aig.create_and( f1, c );
+  const auto f3 = aig.create_and( b, c );
+  const auto f4 = aig.create_and( f3, d );
+
+  aig.create_po( f2 );
+  aig.create_po( f4 );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 4u );
+
+  aig_balancing_params ps;
+  ps.minimize_levels = false;
+  ps.fast_mode = false;
+  aig_balance( aig, ps );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 3u );
+}
+
 TEST_CASE( "Balance AND tree that is constant 0", "[aig_balancing]" )
 {
   aig_network aig;
@@ -92,6 +120,30 @@ TEST_CASE( "Balance AND tree that has redundant leaves", "[aig_balancing]" )
   CHECK( aig.num_gates() == 3u );
 
   aig_balance( aig );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 2u );
+}
+
+TEST_CASE( "Balance AND tree that has redundant leaves slow", "[aig_balancing]" )
+{
+  aig_network aig;
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto c = aig.create_pi();
+
+  const auto f1 = aig.create_and( a, b );
+  const auto f2 = aig.create_and( a, c );
+  const auto f3 = aig.create_and( f1, f2 );
+
+  aig.create_po( f3 );
+
+  CHECK( depth_view{ aig }.depth() == 2u );
+  CHECK( aig.num_gates() == 3u );
+
+  aig_balancing_params ps;
+  ps.fast_mode = false;
+  aig_balance( aig, ps );
 
   CHECK( depth_view{ aig }.depth() == 2u );
   CHECK( aig.num_gates() == 2u );

--- a/test/algorithms/xag_balancing.cpp
+++ b/test/algorithms/xag_balancing.cpp
@@ -53,6 +53,35 @@ TEST_CASE( "Balance AND finding structural hashing (XAG)", "[xag_balancing]" )
   CHECK( xag.num_gates() == 3u );
 }
 
+TEST_CASE( "Balance AND finding structural hashing (XAG) slow", "[xag_balancing]" )
+{
+  xag_network xag;
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+  const auto d = xag.create_pi();
+
+  const auto f1 = xag.create_and( a, b );
+  const auto f2 = xag.create_and( f1, c );
+  const auto f3 = xag.create_and( b, c );
+  const auto f4 = xag.create_and( f3, d );
+
+  xag.create_po( f2 );
+  xag.create_po( f4 );
+
+  CHECK( depth_view{ xag }.depth() == 2u );
+  CHECK( xag.num_gates() == 4u );
+
+  xag_balancing_params ps;
+  ps.minimize_levels = false;
+  ps.fast_mode = false;
+
+  xag_balance( xag, ps );
+
+  CHECK( depth_view{ xag }.depth() == 2u );
+  CHECK( xag.num_gates() == 3u );
+}
+
 TEST_CASE( "Balance AND tree that is constant 0 (XAG)", "[xag_balancing]" )
 {
   xag_network xag;
@@ -97,6 +126,30 @@ TEST_CASE( "Balance AND tree that has redundant leaves (XAG)", "[xag_balancing]"
   CHECK( xag.num_gates() == 2u );
 }
 
+TEST_CASE( "Balance AND tree that has redundant leaves (XAG) slow", "[xag_balancing]" )
+{
+  xag_network xag;
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+
+  const auto f1 = xag.create_and( a, b );
+  const auto f2 = xag.create_and( a, c );
+  const auto f3 = xag.create_and( f1, f2 );
+
+  xag.create_po( f3 );
+
+  CHECK( depth_view{ xag }.depth() == 2u );
+  CHECK( xag.num_gates() == 3u );
+
+  xag_balancing_params ps;
+  ps.fast_mode = false;
+  xag_balance( xag, ps );
+
+  CHECK( depth_view{ xag }.depth() == 2u );
+  CHECK( xag.num_gates() == 2u );
+}
+
 TEST_CASE( "Balancing XOR chain", "[xag_balancing]" )
 {
   xag_network xag;
@@ -135,6 +188,34 @@ TEST_CASE( "Balance XOR finding structural hashing", "[xag_balancing]" )
 
   xag_balancing_params ps;
   ps.minimize_levels = false;
+  xag_balance( xag, ps );
+
+  CHECK( depth_view{ xag }.depth() == 2u );
+  CHECK( xag.num_gates() == 3u );
+}
+
+TEST_CASE( "Balance XOR finding structural hashing slow", "[xag_balancing]" )
+{
+  xag_network xag;
+  const auto a = xag.create_pi();
+  const auto b = xag.create_pi();
+  const auto c = xag.create_pi();
+  const auto d = xag.create_pi();
+
+  const auto f1 = xag.create_xor( a, b );
+  const auto f2 = xag.create_xor( f1, c );
+  const auto f3 = xag.create_xor( b, c );
+  const auto f4 = xag.create_xor( f3, d );
+
+  xag.create_po( f2 );
+  xag.create_po( f4 );
+
+  CHECK( depth_view{ xag }.depth() == 2u );
+  CHECK( xag.num_gates() == 4u );
+
+  xag_balancing_params ps;
+  ps.minimize_levels = false;
+  ps.fast_mode = false;
   xag_balance( xag, ps );
 
   CHECK( depth_view{ xag }.depth() == 2u );


### PR DESCRIPTION
This PR solves a bug that may occur when using the methods `substitute_node_no_restrash` or `replace_in_node_no_restrash`.

In particular, these methods may create non-simplified gates such as buffer nodes. For instance, in an AIG, a buffer could be seen as an AND node where both fanins are connected to the same node with the same phase. In this case, this node is seen as a PI or a CI according to the previous code. This PR solves this issue by reserving the unused field `data[1].h2` to track if a node is a PI or CI.

Moreover, another related issue is present in the XAG and XMG networks. In `xag_network`, AND and XOR are distinguished by the ordering of the indexes such that AND: `index0 < index1`, and XOR: `index0 > index1`. The behavior is undefined when `index0 = index1`.
The proposed patch treats the equal case as an AND. When `index0 = index1` is an XOR gate, the gate is transformed into an AND gate by setting the inputs to constants, i.e. by performing the simplification. XMGs handles this case similarly by treating the equal case as an MAJ3 gate.

Finally, this PR includes runtime improvements to `air_balance` and `xag_balance`, which had long run times on very large benchmarks. The default optimization method to improve size has been reduced from quadratic to linear complexity, in terms of the number of nodes. The old version is available by setting the parameter `fast_mode` to false.