### PR TITLE
Docs and experiments update

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -55,6 +55,11 @@ operation of the algorithms.
 
 .. _ABC: https://github.com/berkeley-abc/abc
 
+mockturtle can be configured using CMake build types. For performance,
+configure CMake in release mode::
+
+  cmake -DCMAKE_BUILD_TYPE=Release ..
+
 Using mockturtle as a library in another project
 ------------------------------------------------
 

--- a/docs/io/writers.rst
+++ b/docs/io/writers.rst
@@ -37,7 +37,13 @@ Write into structural Verilog files
 
 .. doxygenfunction:: mockturtle::write_verilog(Ntk const&, std::ostream&, write_verilog_params const&)
 
+.. doxygenfunction:: mockturtle::write_verilog_with_binding(Ntk const&, std::string const&, write_verilog_params const&)
+
 .. doxygenfunction:: mockturtle::write_verilog_with_binding(Ntk const&, std::ostream&, write_verilog_params const&)
+
+.. doxygenfunction:: mockturtle::write_verilog_with_cell(Ntk const&, std::string const&, write_verilog_params const&)
+
+.. doxygenfunction:: mockturtle::write_verilog_with_cell(Ntk const&, std::ostream&, write_verilog_params const&)
 
 Write into DIMACS files (CNF)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/experiments/emap.cpp
+++ b/experiments/emap.cpp
@@ -30,9 +30,11 @@
 #include <fmt/format.h>
 #include <lorina/aiger.hpp>
 #include <lorina/genlib.hpp>
+#include <mockturtle/algorithms/aig_balancing.hpp>
 #include <mockturtle/algorithms/emap.hpp>
 #include <mockturtle/io/aiger_reader.hpp>
 #include <mockturtle/io/genlib_reader.hpp>
+#include <mockturtle/io/write_verilog.hpp>
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/block.hpp>
 #include <mockturtle/utils/name_utils.hpp>
@@ -76,6 +78,12 @@ int main()
       continue;
     }
 
+    /* remove structural redundancies */
+    aig_balancing_params bps;
+    bps.minimize_levels = false;
+    bps.fast_mode = false;
+    aig_balance( aig, bps );
+
     const uint32_t size_before = aig.num_gates();
     const uint32_t depth_before = depth_view( aig ).depth();
 
@@ -90,6 +98,9 @@ int main()
     restore_network_name( aig, res_names );
     restore_pio_names_by_order( aig, res_names );
     const auto cec = benchmark == "hyp" ? true : abc_cec_mapped_cell( res_names, benchmark, library );
+
+    /* write verilog netlist */
+    // write_verilog_with_cell( res_names, benchmark + "_mapped.v" );
 
     exp( benchmark, size_before, res.compute_area(), depth_before, res.compute_worst_delay(), st.multioutput_gates, to_seconds( st.time_total ), cec );
   }

--- a/experiments/extract_adders.cpp
+++ b/experiments/extract_adders.cpp
@@ -56,7 +56,10 @@ int main()
     }
 
     /* Remove structural redundancies (increases the number of discoverable HAs/FAs) */
-    aig_balance( aig, { false } );
+    aig_balancing_params bps;
+    bps.minimize_levels = false;
+    bps.fast_mode = false;
+    aig_balance( aig, bps );
 
     const uint32_t size_before = aig.num_gates();
 


### PR DESCRIPTION
This PR includes:
- adding a brief CMake building type guide on docs
- adding docs on `write_verilog` for mapped networks from `emap`
- updating the experiment `emap`
- updating the experiment `extract_adders`