### PR TITLE
Fix signal name assignment bug in ``names_view.hpp``

### DIFF
--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -65,21 +65,19 @@ public:
   names_view<Ntk>& operator=( names_view<Ntk> const& named_ntk )
   {
     std::map<signal, std::string> new_signal_names;
-    std::vector<signal> current_pis;
-    Ntk::foreach_pi( [this, &current_pis]( auto const& n ) {
-      current_pis.emplace_back( Ntk::make_signal( n ) );
-    } );
+
     named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
-      if ( !current_pis.empty() )
+      auto signal = named_ntk.make_signal( n );
+      if ( named_ntk.has_name( signal ) )
       {
-        if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
-          new_signal_names[named_ntk.make_signal( n )] = it->second;
+        new_signal_names[signal] = named_ntk.get_name( signal );
       }
     } );
 
     Ntk::operator=( named_ntk );
     _signal_names = new_signal_names;
     _network_name = named_ntk._network_name;
+
     return *this;
   }
 

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -65,11 +65,13 @@ public:
 
   names_view<Ntk>& operator=( names_view<Ntk> const& named_ntk )
   {
-    Ntk::operator=( named_ntk );
-    _signal_names = named_ntk.get_signal_names();
-    _network_name = named_ntk._network_name;
-    _output_names = named_ntk.get_output_names();
-
+    if ( this != &named_ntk ) // Check for self-assignment
+    {
+      Ntk::operator=( named_ntk );
+      _signal_names = named_ntk.get_signal_names();
+      _network_name = named_ntk._network_name;
+      _output_names = named_ntk.get_output_names();
+    }
     return *this;
   }
 

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -70,8 +70,11 @@ public:
       current_pis.emplace_back( Ntk::make_signal( n ) );
     } );
     named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
-      if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
-        new_signal_names[named_ntk.make_signal( n )] = it->second;
+      if ( !current_pis.empty() )
+      {
+        if ( const auto it = _signal_names.find( current_pis[i] ); it != _signal_names.end() )
+          new_signal_names[named_ntk.make_signal( n )] = it->second;
+      }
     } );
 
     Ntk::operator=( named_ntk );

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -204,7 +204,7 @@ public:
 
   /*! \brief Gets all names of all outputs.
    *
-   * \return Names of the outputs.
+   * \return All output names.
    */
   std::map<uint32_t, std::string> get_output_names() const
   {

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -24,13 +24,13 @@
  */
 
 /*!
-  \file names_view.hpp
-  \brief Implements methods to declare names for network signals
+ \file names_view.hpp
+ \brief Implements methods to declare names for network signals
 
-  \author Heinz Riener
-  \author Marcel Walter
-  \author Mathias Soeken
-  \author Siang-Yun (Sonia) Lee
+ \author Heinz Riener
+ \author Marcel Walter
+ \author Mathias Soeken
+ \author Siang-Yun (Sonia) Lee
 */
 
 #pragma once
@@ -38,6 +38,7 @@
 #include "../traits.hpp"
 
 #include <map>
+#include <string>
 
 namespace mockturtle
 {
@@ -64,19 +65,10 @@ public:
 
   names_view<Ntk>& operator=( names_view<Ntk> const& named_ntk )
   {
-    std::map<signal, std::string> new_signal_names;
-
-    named_ntk.foreach_pi( [&]( auto const& n, auto i ) {
-      auto signal = named_ntk.make_signal( n );
-      if ( named_ntk.has_name( signal ) )
-      {
-        new_signal_names[signal] = named_ntk.get_name( signal );
-      }
-    } );
-
     Ntk::operator=( named_ntk );
-    _signal_names = new_signal_names;
+    _signal_names = named_ntk.get_signal_names();
     _network_name = named_ntk._network_name;
+    _output_names = named_ntk.get_output_names();
 
     return *this;
   }
@@ -127,6 +119,15 @@ public:
   std::string get_network_name() const noexcept
   {
     return _network_name;
+  }
+
+  /*! \brief Gets all signal name.
+   *
+   * \return All signal names
+   */
+  std::map<signal, std::string> get_signal_names() const noexcept
+  {
+    return _signal_names;
   }
 
   /*! \brief Checks if a signal has a name.
@@ -199,6 +200,15 @@ public:
   std::string get_output_name( uint32_t index ) const
   {
     return _output_names.at( index );
+  }
+
+  /*! \brief Gets all names of all outputs.
+   *
+   * \return Names of the outputs.
+   */
+  std::map<uint32_t, std::string> get_output_names() const
+  {
+    return _output_names;
   }
 
 private:

--- a/include/mockturtle/views/names_view.hpp
+++ b/include/mockturtle/views/names_view.hpp
@@ -24,13 +24,13 @@
  */
 
 /*!
- \file names_view.hpp
- \brief Implements methods to declare names for network signals
+  \file names_view.hpp
+  \brief Implements methods to declare names for network signals
 
- \author Heinz Riener
- \author Marcel Walter
- \author Mathias Soeken
- \author Siang-Yun (Sonia) Lee
+  \author Heinz Riener
+  \author Marcel Walter
+  \author Mathias Soeken
+  \author Siang-Yun (Sonia) Lee
 */
 
 #pragma once
@@ -68,9 +68,9 @@ public:
     if ( this != &named_ntk ) // Check for self-assignment
     {
       Ntk::operator=( named_ntk );
-      _signal_names = named_ntk.get_signal_names();
+      _signal_names = named_ntk._signal_names;
       _network_name = named_ntk._network_name;
-      _output_names = named_ntk.get_output_names();
+      _output_names = named_ntk._output_names;
     }
     return *this;
   }
@@ -121,15 +121,6 @@ public:
   std::string get_network_name() const noexcept
   {
     return _network_name;
-  }
-
-  /*! \brief Gets all signal name.
-   *
-   * \return All signal names
-   */
-  std::map<signal, std::string> get_signal_names() const noexcept
-  {
-    return _signal_names;
   }
 
   /*! \brief Checks if a signal has a name.
@@ -202,15 +193,6 @@ public:
   std::string get_output_name( uint32_t index ) const
   {
     return _output_names.at( index );
-  }
-
-  /*! \brief Gets all names of all outputs.
-   *
-   * \return All output names.
-   */
-  std::map<uint32_t, std::string> get_output_names() const
-  {
-    return _output_names;
   }
 
 private:

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -89,7 +89,7 @@ void test_copy_names_view()
   named_ntk.set_name( c, "c" );
   named_ntk.set_output_name( 0, "f" );
 
-  // test & operator= for named_ntk_empty and non-empty ntk.
+  // test operator= for empty and non-empty ntk.
   names_view<Ntk> named_ntk_empty{};
   named_ntk_empty = ntk;
   CHECK( named_ntk_empty.get_network_name() == "" );

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -75,7 +75,8 @@ template<typename Ntk>
 void test_copy_names_view()
 {
   Ntk ntk_empty;
-  names_view<Ntk> new_named_ntk_empty = ntk_empty;
+  names_view<Ntk> new_named_ntk_empty;
+  new_named_ntk_empty = ntk_empty;
   CHECK( new_named_ntk_empty.get_network_name() == "" );
 
   Ntk ntk;

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -74,6 +74,10 @@ TEST_CASE( "create names view and test API", "[names_view]" )
 template<typename Ntk>
 void test_copy_names_view()
 {
+  Ntk ntk_empty;
+  names_view<Ntk> new_named_ntk_empty = ntk_empty;
+  CHECK( new_named_ntk_empty.get_network_name() == "" );
+
   Ntk ntk;
   auto const a = ntk.create_pi();
   auto const b = ntk.create_pi();

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -74,11 +74,6 @@ TEST_CASE( "create names view and test API", "[names_view]" )
 template<typename Ntk>
 void test_copy_names_view()
 {
-  Ntk ntk_empty;
-  names_view<Ntk> new_named_ntk_empty;
-  new_named_ntk_empty = ntk_empty;
-  CHECK( new_named_ntk_empty.get_network_name() == "" );
-
   Ntk ntk;
   auto const a = ntk.create_pi();
   auto const b = ntk.create_pi();
@@ -93,6 +88,11 @@ void test_copy_names_view()
   named_ntk.set_name( b, "b" );
   named_ntk.set_name( c, "c" );
   named_ntk.set_output_name( 0, "f" );
+
+  // test & operator= for named_ntk_empty and non-empty ntk.
+  names_view<Ntk> named_ntk_empty{};
+  named_ntk_empty = ntk;
+  CHECK( named_ntk_empty.get_network_name() == "" );
 
   CHECK( named_ntk.has_name( a ) );
   CHECK( named_ntk.has_name( b ) );

--- a/test/views/names_view.cpp
+++ b/test/views/names_view.cpp
@@ -99,7 +99,8 @@ void test_copy_names_view()
   CHECK( named_ntk.has_name( c ) );
   CHECK( named_ntk.has_output_name( 0 ) );
 
-  names_view<Ntk> new_named_ntk = named_ntk;
+  names_view<Ntk> new_named_ntk{};
+  new_named_ntk = named_ntk;
   CHECK( new_named_ntk.has_name( a ) );
   CHECK( new_named_ntk.has_name( b ) );
   CHECK( new_named_ntk.has_name( c ) );


### PR DESCRIPTION
This PR addresses a bug related to signal name assignment within the ``names_view<Ntk>::operator=`` method. The code has been refactored to include a check for the emptiness of the ``current_pis`` vector before attempting to access its elements. This change ensures that the loop is only executed when the ``current_pis`` vector is not empty, preventing potential out-of-range accesses and improving code safety.