### PR TITLE
Improvements to emap

### DIFF
--- a/docs/algorithms/mapper.rst
+++ b/docs/algorithms/mapper.rst
@@ -1,3 +1,87 @@
+Extended technology mapping
+---------------------------
+
+**Header:** ``mockturtle/algorithms/emap.hpp``
+
+The command `emap` stands for extended mapper. It supports large
+library cells, of more than 6 inputs, and can perform matching using 3
+different methods: Boolean, pattern, or hybrid. The current version
+can map to 2-output gates, such as full adders and half adders,
+and provides a 2x speedup in mapping time compared to command `map`
+for similar or better quality. Similarly, to `map`, the implementation
+is independent of the underlying graph representation.
+Additionally, `emap` supports "don't touch" white boxes (gates).
+
+Command `emap` can return the mapped network in two formats.
+Command `emap` returns a `cell_view<block_network>` that supports
+multi-output cells. Command `emap_klut` returns a `binding_view<klut_network>`
+similarly as command `map`.
+
+The following example shows how to perform delay-oriented technology mapping
+from an and-inverter graph using large cells up to 9 inputs:
+
+.. code-block:: c++
+
+   aig_network aig = ...;
+
+   /* read cell library in genlib format */
+   std::vector<gate> gates;
+   std::ifstream in( ... );
+   lorina::read_genlib( in, genlib_reader( gates ) )
+   tech_library<9> tech_lib( gates );
+
+   /* perform technology mapping */
+   cell_view<block_network> res = emap<9>( aig, tech_lib );
+
+The next example performs area-oriented graph mapping using multi-output cells:
+
+.. code-block:: c++
+
+   aig_network aig = ...;
+
+   /* read cell library in genlib format */
+   std::vector<gate> gates;
+   std::ifstream in( ... );
+   lorina::read_genlib( in, genlib_reader( gates ) )
+   tech_library tech_lib( gates );
+
+   /* perform technology mapping */
+   emap_params ps;
+   ps.area_oriented_mapping = true;
+   ps.map_multioutput = true;
+   cell_view<block_network> res = emap( aig, tech_lib, ps );
+
+In this case, `emap` is used to return a `block_network`, which can respresent multi-output
+cells as single nodes. Alternatively, also `emap_klut` can be used but multi-output cells
+would be reporesented by single-output nodes.
+
+The maximum number of cuts stored for each node is limited to 20.
+To increase this limit, change `max_cut_num` in `emap`.
+
+You can set the inputs arrival time and output required times using the parameters `arrival_times`
+and `required times`. Moreover, it is possible to ask for a required time relaxation. For instance,
+if we want to map a network with an increase of 10% over its minimal delay, we can set
+`relax_required` to 10.
+
+For further details and usage scenarios of `emap`, such as white boxes, please check the
+related tests.
+
+**Parameters and statistics**
+
+.. doxygenstruct:: mockturtle::emap_params
+   :members:
+
+.. doxygenstruct:: mockturtle::emap_stats
+   :members:
+
+**Algorithm**
+
+.. doxygenfunction:: mockturtle::emap(Ntk const&, tech_library<NInputs, Configuration> const&, emap_params const&, emap_stats*)
+.. doxygenfunction:: mockturtle::emap_klut(Ntk const&, tech_library<NInputs, Configuration> const&, emap_params const&, emap_stats*)
+.. doxygenfunction:: mockturtle::emap_node_map(Ntk const&, tech_library<NInputs, Configuration> const&, emap_params const&, emap_stats*)
+.. doxygenfunction:: mockturtle::emap_load_mapping(Ntk&)
+
+
 Technology mapping and network conversion
 -----------------------------------------
 
@@ -136,84 +220,4 @@ To increase this limit, change `max_cut_num` in `fast_network_cuts`.
 **Algorithm**
 
 .. doxygenfunction:: mockturtle::map(Ntk const&, tech_library<NInputs, Configuration> const&, map_params const&, map_stats*)
-.. doxygenfunction:: mockturtle::map(Ntk&, exact_library<NtkDest, RewritingFn, NInputs> const&, map_params const&, map_stats*)
-
-
-
-Extended technology mapping
----------------------------
-
-**Header:** ``mockturtle/algorithms/emap.hpp``
-
-The command `emap` stands for extended mapper. It supports large
-library cells, of more than 6 inputs, and can perform matching using 3
-different methods: Boolean, pattern, or hybrid. The current version
-can map to 2-output gates, such as full adders and half adders,
-and provides a 2x speedup in mapping time compared to command `map`
-for similar or better quality. Similarly, to `map`, the implementation
-is independent of the underlying graph representation.
-Additionally, `emap` supports "don't touch" white boxes (gates).
-
-Command `emap` can return the mapped network in two formats.
-Command `emap` returns a `cell_view<block_network>` that supports
-multi-output cells. Command `emap_klut` returns a `binding_view<klut_network>`
-similarly as command `map`.
-
-The following example shows how to perform delay-oriented technology mapping
-from an and-inverter graph using large cells up to 9 inputs:
-
-.. code-block:: c++
-
-   aig_network aig = ...;
-
-   /* read cell library in genlib format */
-   std::vector<gate> gates;
-   std::ifstream in( ... );
-   lorina::read_genlib( in, genlib_reader( gates ) )
-   tech_library<9> tech_lib( gates );
-
-   /* perform technology mapping */
-   cell_view<block_network> res = emap<9>( aig, tech_lib );
-
-The next example performs area-oriented graph mapping using multi-output cells:
-
-.. code-block:: c++
-
-   aig_network aig = ...;
-
-   /* read cell library in genlib format */
-   std::vector<gate> gates;
-   std::ifstream in( ... );
-   lorina::read_genlib( in, genlib_reader( gates ) )
-   tech_library tech_lib( gates );
-
-   /* perform technology mapping */
-   emap_params ps;
-   ps.area_oriented_mapping = true;
-   ps.map_multioutput = true;
-   cell_view<block_network> res = emap( aig, tech_lib, ps );
-
-In this case, `emap` is used to return a `block_network`, which can respresent multi-output
-cells as single nodes. Alternatively, also `emap_klut` can be used but multi-output cells
-would be reporesented by single-output nodes.
-
-The maximum number of cuts stored for each node is limited to 32.
-To increase this limit, change `max_cut_num` in `emap`.
-
-For further details and usage scenarios of `emap`, such as white boxes, please check the
-related tests.
-
-**Parameters and statistics**
-
-.. doxygenstruct:: mockturtle::emap_params
-   :members:
-
-.. doxygenstruct:: mockturtle::emap_stats
-   :members:
-
-**Algorithm**
-
-.. doxygenfunction:: mockturtle::emap(Ntk const&, tech_library<NInputs, Configuration> const&, emap_params const&, emap_stats*)
-.. doxygenfunction:: mockturtle::emap_klut(Ntk const&, tech_library<NInputs, Configuration> const&, emap_params const&, emap_stats*)
-.. doxygenfunction:: mockturtle::emap_node_map(Ntk const&, tech_library<NInputs, Configuration> const&, emap_params const&, emap_stats*)
-.. doxygenfunction:: mockturtle::emap_load_mapping(Ntk&)
+.. doxygenfunction:: mockturtle::map(Ntk&, exact_library<NtkDest, NInputs> const&, map_params const&, map_stats*)

--- a/experiments/emap.cpp
+++ b/experiments/emap.cpp
@@ -55,7 +55,7 @@ int main()
 
   /* library to map to technology */
   fmt::print( "[i] processing technology library\n" );
-  std::string library = "asap7";
+  std::string library = "multioutput";
   std::vector<gate> gates;
   std::ifstream in( cell_libraries_path( library ) );
 
@@ -66,9 +66,9 @@ int main()
 
   tech_library_params tps;
   tps.verbose = true;
-  tech_library<6> tech_lib( gates, tps );
+  tech_library<9> tech_lib( gates, tps );
 
-  for ( auto const& benchmark : iwls_benchmarks() )
+  for ( auto const& benchmark : epfl_benchmarks() )
   {
     fmt::print( "[i] processing {}\n", benchmark );
 
@@ -78,32 +78,27 @@ int main()
       continue;
     }
 
-    // if ( aig.num_gates() > 100000 )
-    //   continue;
-
     /* remove structural redundancies */
-    // aig_balancing_params bps;
-    // bps.minimize_levels = false;
-    // bps.fast_mode = true;
-    // aig_balance( aig, bps );
+    aig_balancing_params bps;
+    bps.minimize_levels = false;
+    bps.fast_mode = true;
+    aig_balance( aig, bps );
 
     const uint32_t size_before = aig.num_gates();
     const uint32_t depth_before = depth_view( aig ).depth();
 
     emap_params ps;
-    ps.matching_mode = emap_params::boolean;
+    ps.matching_mode = emap_params::hybrid;
     ps.area_oriented_mapping = false;
-    ps.map_multioutput = false;
-    ps.verbose = true;
+    ps.map_multioutput = true;
+    ps.relax_required = 0;
     emap_stats st;
-    cell_view<block_network> res = emap<6>( aig, tech_lib, ps, &st );
+    cell_view<block_network> res = emap<9>( aig, tech_lib, ps, &st );
 
     names_view res_names{ res };
     restore_network_name( aig, res_names );
     restore_pio_names_by_order( aig, res_names );
-    // const auto cec = benchmark == "hyp" ? true : abc_cec_mapped_cell( res_names, benchmark, library );
-    // std::cout << fmt::format( "[i] CEC = {}\n", cec );
-    const auto cec = false; /* don't run CEC */
+    const auto cec = benchmark == "hyp" ? true : abc_cec_mapped_cell( res_names, benchmark, library );
 
     /* write verilog netlist */
     // write_verilog_with_cell( res_names, benchmark + "_mapped.v" );

--- a/experiments/emap.cpp
+++ b/experiments/emap.cpp
@@ -66,9 +66,9 @@ int main()
 
   tech_library_params tps;
   tps.verbose = true;
-  tech_library<9> tech_lib( gates, tps );
+  tech_library<6> tech_lib( gates, tps );
 
-  for ( auto const& benchmark : epfl_benchmarks() )
+  for ( auto const& benchmark : iwls_benchmarks() )
   {
     fmt::print( "[i] processing {}\n", benchmark );
 
@@ -78,21 +78,25 @@ int main()
       continue;
     }
 
+    if ( aig.num_gates() > 100000 )
+      continue;
+
     /* remove structural redundancies */
     aig_balancing_params bps;
     bps.minimize_levels = false;
-    bps.fast_mode = false;
+    bps.fast_mode = true;
     aig_balance( aig, bps );
 
     const uint32_t size_before = aig.num_gates();
     const uint32_t depth_before = depth_view( aig ).depth();
 
     emap_params ps;
-    ps.matching_mode = emap_params::hybrid;
+    ps.matching_mode = emap_params::boolean;
     ps.area_oriented_mapping = false;
     ps.map_multioutput = true;
+    ps.verbose = true;
     emap_stats st;
-    cell_view<block_network> res = emap<9>( aig, tech_lib, ps, &st );
+    cell_view<block_network> res = emap<6>( aig, tech_lib, ps, &st );
 
     names_view res_names{ res };
     restore_network_name( aig, res_names );

--- a/experiments/emap.cpp
+++ b/experiments/emap.cpp
@@ -55,7 +55,7 @@ int main()
 
   /* library to map to technology */
   fmt::print( "[i] processing technology library\n" );
-  std::string library = "multioutput";
+  std::string library = "asap7";
   std::vector<gate> gates;
   std::ifstream in( cell_libraries_path( library ) );
 
@@ -66,9 +66,9 @@ int main()
 
   tech_library_params tps;
   tps.verbose = true;
-  tech_library<9> tech_lib( gates, tps );
+  tech_library<6> tech_lib( gates, tps );
 
-  for ( auto const& benchmark : epfl_benchmarks() )
+  for ( auto const& benchmark : iwls_benchmarks() )
   {
     fmt::print( "[i] processing {}\n", benchmark );
 
@@ -78,26 +78,32 @@ int main()
       continue;
     }
 
+    // if ( aig.num_gates() > 100000 )
+    //   continue;
+
     /* remove structural redundancies */
-    aig_balancing_params bps;
-    bps.minimize_levels = false;
-    bps.fast_mode = true;
-    aig_balance( aig, bps );
+    // aig_balancing_params bps;
+    // bps.minimize_levels = false;
+    // bps.fast_mode = true;
+    // aig_balance( aig, bps );
 
     const uint32_t size_before = aig.num_gates();
     const uint32_t depth_before = depth_view( aig ).depth();
 
     emap_params ps;
-    ps.matching_mode = emap_params::hybrid;
+    ps.matching_mode = emap_params::boolean;
     ps.area_oriented_mapping = false;
-    ps.map_multioutput = true;
+    ps.map_multioutput = false;
+    ps.verbose = true;
     emap_stats st;
-    cell_view<block_network> res = emap<9>( aig, tech_lib, ps, &st );
+    cell_view<block_network> res = emap<6>( aig, tech_lib, ps, &st );
 
     names_view res_names{ res };
     restore_network_name( aig, res_names );
     restore_pio_names_by_order( aig, res_names );
-    const auto cec = benchmark == "hyp" ? true : abc_cec_mapped_cell( res_names, benchmark, library );
+    // const auto cec = benchmark == "hyp" ? true : abc_cec_mapped_cell( res_names, benchmark, library );
+    // std::cout << fmt::format( "[i] CEC = {}\n", cec );
+    const auto cec = false; /* don't run CEC */
 
     /* write verilog netlist */
     // write_verilog_with_cell( res_names, benchmark + "_mapped.v" );

--- a/experiments/emap.cpp
+++ b/experiments/emap.cpp
@@ -65,6 +65,7 @@ int main()
   }
 
   tech_library_params tps;
+  tps.ignore_symmetries = false; // set to true to drastically speed-up mapping with minor delay increase
   tps.verbose = true;
   tech_library<9> tech_lib( gates, tps );
 

--- a/experiments/emap.cpp
+++ b/experiments/emap.cpp
@@ -66,9 +66,9 @@ int main()
 
   tech_library_params tps;
   tps.verbose = true;
-  tech_library<6> tech_lib( gates, tps );
+  tech_library<9> tech_lib( gates, tps );
 
-  for ( auto const& benchmark : iwls_benchmarks() )
+  for ( auto const& benchmark : epfl_benchmarks() )
   {
     fmt::print( "[i] processing {}\n", benchmark );
 
@@ -77,9 +77,6 @@ int main()
     {
       continue;
     }
-
-    if ( aig.num_gates() > 100000 )
-      continue;
 
     /* remove structural redundancies */
     aig_balancing_params bps;
@@ -91,12 +88,11 @@ int main()
     const uint32_t depth_before = depth_view( aig ).depth();
 
     emap_params ps;
-    ps.matching_mode = emap_params::boolean;
+    ps.matching_mode = emap_params::hybrid;
     ps.area_oriented_mapping = false;
     ps.map_multioutput = true;
-    ps.verbose = true;
     emap_stats st;
-    cell_view<block_network> res = emap<6>( aig, tech_lib, ps, &st );
+    cell_view<block_network> res = emap<9>( aig, tech_lib, ps, &st );
 
     names_view res_names{ res };
     restore_network_name( aig, res_names );

--- a/include/mockturtle/algorithms/emap.hpp
+++ b/include/mockturtle/algorithms/emap.hpp
@@ -682,8 +682,8 @@ struct best_gate_emap
   float area;
   float flow;
   unsigned phase : 16;
-  unsigned cut   : 12;
-  unsigned size  :  4;
+  unsigned cut : 12;
+  unsigned size : 4;
 };
 
 template<unsigned NInputs>
@@ -1114,7 +1114,6 @@ private:
     {
       if ( ntk.is_dont_touch( n ) )
       {
-        
         warning_box |= initialize_box( n );
         return false;
       }
@@ -2061,7 +2060,7 @@ private:
         if ( ps.use_match_alternatives )
           refine_best_matches( *it );
       }
-      
+
       unsigned use_phase = node_data.best_supergate[0] == nullptr ? 1u : 0u;
       if ( node_data.best_supergate[use_phase] == nullptr )
       {
@@ -2240,7 +2239,7 @@ private:
     /* return if mapping is area oriented */
     if ( ps.area_oriented_mapping )
       return;
-    
+
     set_output_required_time( iteration == 1 );
 
     if ( exit_early )
@@ -3306,7 +3305,7 @@ private:
         node_data.best_cut[mapped_phase] = cut_index[j];
         node_data.phase[mapped_phase] = pin_phase[j];
         node_data.arrival[mapped_phase] = arrival[j] + lib_inv_delay;
-        node_data.area[mapped_phase] = area[j];                  /* partial area contribution */
+        node_data.area[mapped_phase] = area[j]; /* partial area contribution */
         node_data.flows[mapped_phase] = flow_sum_neg;
 
         assert( node_data.arrival[mapped_phase] < node_data.required[mapped_phase] + epsilon );
@@ -5746,7 +5745,7 @@ private:
  * The function takes the size of the cuts in the template parameter `CutSize`.
  *
  * The function returns a block network that supports multi-output cells.
- * 
+ *
  * The novelties of this mapper are contained in 2 publications:
  * - A. Tempia Calvino and G. De Micheli, "Technology Mapping Using Multi-Output Library Cells," ICCAD, 2023.
  * - G. Radi, A. Tempia Calvino, and G. De Micheli, "In Medio Stat Virtus: Combining Boolean and Pattern Matching," ASP-DAC, 2024.
@@ -5805,7 +5804,7 @@ cell_view<block_network> emap( Ntk const& ntk, tech_library<NInputs, Configurati
  * The function takes the size of the cuts in the template parameter `CutSize`.
  *
  * The function returns a k-LUT network. Each LUT abstacts a gate of the technology library.
- * 
+ *
  * The novelties of this mapper are contained in 2 publications:
  * - A. Tempia Calvino and G. De Micheli, "Technology Mapping Using Multi-Output Library Cells," ICCAD, 2023.
  * - G. Radi, A. Tempia Calvino, and G. De Micheli, "In Medio Stat Virtus: Combining Boolean and Pattern Matching," ASP-DAC, 2024.

--- a/include/mockturtle/algorithms/emap.hpp
+++ b/include/mockturtle/algorithms/emap.hpp
@@ -2874,8 +2874,8 @@ private:
           cut_ref<false>( cuts[index][node_data.best_cut[1]], n, 1 );
         }
         /* evaluate based on inverter cost */
-        // use_zero = lib_inv_area < node_data.flows[1] + epsilon;
-        // use_one = lib_inv_area < node_data.flows[0] + epsilon;
+        use_zero = lib_inv_area < node_data.flows[1] + epsilon;
+        use_one = lib_inv_area < node_data.flows[0] + epsilon;
 
         if ( use_one && use_zero )
         {

--- a/include/mockturtle/algorithms/emap.hpp
+++ b/include/mockturtle/algorithms/emap.hpp
@@ -82,7 +82,7 @@ struct emap_params
   /*! \brief Parameters for cut enumeration
    *
    * The default cut limit is 16.
-   * The maximum cut limit is 31.
+   * The maximum cut limit is 19.
    * By default, truth table minimization
    * is performed.
    */
@@ -716,7 +716,7 @@ class emap_impl
 {
 public:
   static constexpr float epsilon = 0.0005;
-  static constexpr uint32_t max_cut_num = 32;
+  static constexpr uint32_t max_cut_num = 20;
   using cut_t = cut<CutSize, cut_enumeration_emap_cut<NInputs>>;
   using cut_set_t = emap_cut_set<cut_t, max_cut_num>;
   using cut_merge_t = typename std::array<cut_set_t*, Ntk::max_fanin_size + 1>;
@@ -1391,7 +1391,7 @@ private:
     /* round stats */
     if ( ps.verbose )
     {
-      st.round_stats.push_back( fmt::format( "[i] SCuts    : Cuts  = {:>12d}  Time = {:>5.2f}\n", cuts_total, to_seconds( clock::now() - time_begin ) ) );
+      st.round_stats.push_back( fmt::format( "[i] SCuts    : Cuts  = {:>12d}  Time = {:>12.2f}\n", cuts_total, to_seconds( clock::now() - time_begin ) ) );
     }
 
     return true;

--- a/include/mockturtle/algorithms/emap.hpp
+++ b/include/mockturtle/algorithms/emap.hpp
@@ -742,6 +742,7 @@ private:
       unsigned has_info : 1;
     };
   };
+
 public:
   static constexpr float epsilon = 0.0005;
   static constexpr uint32_t max_cut_num = 20;
@@ -3710,9 +3711,9 @@ private:
 
     /* find the corresponding cut */
     uint32_t cut_p = 0;
-    while( matches[cut_p].node_index != index )
+    while ( matches[cut_p].node_index != index )
       ++cut_p;
-    
+
     assert( cut_p < matches.size() );
     uint32_t cut_index = matches[cut_p].cut_index;
     auto& cut = multi_cut_set[cut_index][cut_p];

--- a/include/mockturtle/algorithms/emap.hpp
+++ b/include/mockturtle/algorithms/emap.hpp
@@ -5082,6 +5082,9 @@ private:
     /* add cut matches */
     for ( auto i = 0; i < max_multioutput_output_size; ++i )
     {
+      cut_tuple[order[i]]->supergates[0] = nullptr;
+      cut_tuple[order[i]]->supergates[1] = nullptr;
+      cut_tuple[order[i]]->ignore = false;
       std::vector<supergate<NInputs>> const* multigate = &( ( *multigates_match )[i] );
       cut_tuple[order[i]]->supergates[phase_order[i]] = multigate;
     }

--- a/include/mockturtle/algorithms/emap.hpp
+++ b/include/mockturtle/algorithms/emap.hpp
@@ -131,7 +131,7 @@ struct emap_params
   /*! \brief Number of patterns for switching activity computation. */
   uint32_t switching_activity_patterns{ 2048u };
 
-  /*! \brief Compute alternatives using a different cost functions */
+  /*! \brief Compute area-oriented alternative matches */
   bool use_match_alternatives{ true };
 
   /*! \brief Remove the cuts that are contained in others */

--- a/include/mockturtle/utils/struct_library.hpp
+++ b/include/mockturtle/utils/struct_library.hpp
@@ -371,6 +371,12 @@ private:
                                   perm,
                                   gate_pol };
 
+        /* permute pin-to-pin delays */
+        for ( uint32_t i = 0; i < gate.num_vars; ++i )
+        {
+          sg.tdelay[i] = gate.tdelay[perm[i]];
+        }
+
         auto& v = _label_to_gate[index_rule.data];
 
         auto it = std::lower_bound( v.begin(), v.end(), sg, [&]( auto const& s1, auto const& s2 ) {

--- a/include/mockturtle/utils/super_utils.hpp
+++ b/include/mockturtle/utils/super_utils.hpp
@@ -212,8 +212,8 @@ public:
 
     if ( _ps.verbose )
     {
-      std::cout << fmt::format( "[i] Loading {} simple cells in the library\n", simple_gates_size + large_gates );
-      std::cout << fmt::format( "[i] Loading {} multi-output cells in the library\n", _multioutput_gates.size() );
+      std::cout << fmt::format( "[i] Loading {} simple library cells\n", simple_gates_size + large_gates );
+      std::cout << fmt::format( "[i] Loading {} multi-output library cells\n", _multioutput_gates.size() );
     }
 
     if ( ignored > 0 )

--- a/include/mockturtle/utils/tech_library.hpp
+++ b/include/mockturtle/utils/tech_library.hpp
@@ -109,6 +109,9 @@ struct tech_library_params
   /*! \brief Loads multioutput gates in the library */
   bool load_multioutput_gates{ true };
 
+  /*! \brief Don't load symmetrical permutations of gate pins (drastically speeds-up mapping) */
+  bool ignore_symmetries{ false };
+
   /*! \brief Load gates with minimum size only */
   bool load_minimum_size_only{ true };
 
@@ -473,7 +476,7 @@ private:
             if ( sg.root->id == it->root->id )
             {
               /* if already in the library exit, else ignore permutations if with equal delay cost */
-              if ( sg.polarity == it->polarity && sg.tdelay == it->tdelay )
+              if ( sg.polarity == it->polarity && ( _ps.ignore_symmetries || sg.tdelay == it->tdelay ) )
               {
                 to_add = false;
                 break;
@@ -534,7 +537,7 @@ private:
               if ( sg.root->id == it->root->id )
               {
                 /* if already in the library exit, else ignore permutations if with equal delay cost */
-                if ( sg.polarity == it->polarity && sg.tdelay == it->tdelay )
+                if ( sg.polarity == it->polarity && ( _ps.ignore_symmetries || sg.tdelay == it->tdelay ) )
                 {
                   to_add = false;
                   break;

--- a/test/algorithms/emap.cpp
+++ b/test/algorithms/emap.cpp
@@ -382,15 +382,15 @@ TEST_CASE( "Emap on multiplier with multi-output gates", "[emap]" )
 
   const float eps{ 0.005f };
 
-  CHECK( luts.size() == 234u );
+  CHECK( luts.size() == 233u );
   CHECK( luts.num_pis() == 16u );
   CHECK( luts.num_pos() == 16u );
-  CHECK( luts.num_gates() == 216u );
-  CHECK( st.area > 577.0f - eps );
-  CHECK( st.area < 577.0f + eps );
+  CHECK( luts.num_gates() == 215u );
+  CHECK( st.area > 575.0f - eps );
+  CHECK( st.area < 575.0f + eps );
   CHECK( st.delay > 33.60f - eps );
   CHECK( st.delay < 33.60f + eps );
-  CHECK( st.multioutput_gates == 39 );
+  CHECK( st.multioutput_gates == 40 );
 }
 
 TEST_CASE( "Emap with inverters", "[emap]" )

--- a/test/algorithms/emap.cpp
+++ b/test/algorithms/emap.cpp
@@ -170,8 +170,7 @@ TEST_CASE( "Emap on full adder 2", "[emap]" )
 
   emap_params ps;
   ps.cut_enumeration_ps.minimize_truth_table = false;
-  ps.use_fast_area_recovery = false;
-  ps.ela_rounds = 0;
+  ps.ela_rounds = 1;
   ps.eswp_rounds = 2;
   emap_stats st;
   binding_view<klut_network> luts = emap_klut( aig, lib, ps, &st );
@@ -244,8 +243,7 @@ TEST_CASE( "Emap on full adder 2 with cells", "[emap]" )
 
   emap_params ps;
   ps.cut_enumeration_ps.minimize_truth_table = false;
-  ps.use_fast_area_recovery = false;
-  ps.ela_rounds = 0;
+  ps.ela_rounds = 1;
   ps.eswp_rounds = 2;
   emap_stats st;
   cell_view<block_network> luts = emap( aig, lib, ps, &st );
@@ -382,12 +380,12 @@ TEST_CASE( "Emap on multiplier with multi-output gates", "[emap]" )
 
   const float eps{ 0.005f };
 
-  CHECK( luts.size() == 233u );
+  CHECK( luts.size() == 235u );
   CHECK( luts.num_pis() == 16u );
   CHECK( luts.num_pos() == 16u );
-  CHECK( luts.num_gates() == 215u );
-  CHECK( st.area > 575.0f - eps );
-  CHECK( st.area < 575.0f + eps );
+  CHECK( luts.num_gates() == 217u );
+  CHECK( st.area > 612.0f - eps );
+  CHECK( st.area < 612.0f + eps );
   CHECK( st.delay > 33.60f - eps );
   CHECK( st.delay < 33.60f + eps );
   CHECK( st.multioutput_gates == 40 );


### PR DESCRIPTION
This PR contains improvements to emap:
- Adding alternative best matches to improve area recovery
- Adding custom arrival and required times
- Adding a `ignore_symmetries` option to `tech_library` for super fast mapping with limited delay increase
- Changing dropping phase heuristics (decrease the number of used inverters)
- Tuning estimated references and inverter insertion
- Removing deprecated methods
- Fix delay inaccuracy with structural matching
- Fix rare delay changes when using multi-output gates