### PR TITLE
Make `lbool` explicitly signed

### DIFF
--- a/lib/abcsat/abc/satVec.h
+++ b/lib/abcsat/abc/satVec.h
@@ -130,7 +130,9 @@ static inline void   vecp_remove(vecp* v, void* e)
 typedef int    lit;
 typedef int    cla;
 
-typedef char               lbool;
+// Explicitly make it signed so promotion-to-int behavior doesn't vary
+// across platforms that define signedness of char differently.
+typedef signed char lbool;
 
 // CryptoMinisat defines it's own var_Undef values.
 // When it's included we prefer the ABC version instead.

--- a/lib/bill/bill/sat/solver/abc/satVec.h
+++ b/lib/bill/bill/sat/solver/abc/satVec.h
@@ -130,7 +130,9 @@ static inline void   vecp_remove(vecp* v, void* e)
 typedef int    lit;
 typedef int    cla;
 
-typedef char               lbool;
+// Explicitly make it signed so promotion-to-int behavior doesn't vary
+// across platforms that define signedness of char differently.
+typedef signed char lbool;
 
 // CryptoMinisat defines it's own var_Undef values.
 // When it's included we prefer the ABC version instead.


### PR DESCRIPTION
This avoids issues due to some platforms making `char` signed and others unsigned. In particular, on platforms where `char` is unsigned, https://github.com/lsils/mockturtle/blob/50ffa108484ba65b44eee4a713832b7ee821d6d8/lib/bill/bill/sat/interface/abc_bsat2.hpp#L156 promotes an `lbool` to `int` and compares to -1 ... but promoting `(unsigned char)-1` to `int` produces 255.`