### PR TITLE
Clean up handling of temporary files in test suite

### DIFF
--- a/include/mockturtle/io/serialize.hpp
+++ b/include/mockturtle/io/serialize.hpp
@@ -93,7 +93,10 @@ public:
   bool operator()( phmap::BinaryOutputArchive& os, regular_node<Fanin, Size, PointerFieldSize> const& n ) const
   {
     uint64_t size = n.children.size();
-    os.dump( (char*)&size, sizeof( uint64_t ) );
+    if ( !os.dump( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
 
     for ( const auto& c : n.children )
     {
@@ -105,7 +108,10 @@ public:
     }
 
     size = n.data.size();
-    os.dump( (char*)&size, sizeof( uint64_t ) );
+    if ( !os.dump( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
     for ( const auto& d : n.data )
     {
       bool result = this->operator()( os, d );
@@ -122,7 +128,11 @@ public:
   bool operator()( phmap::BinaryInputArchive& ar_input, const regular_node<Fanin, Size, PointerFieldSize>* n ) const
   {
     uint64_t size;
-    ar_input.load( (char*)&size, sizeof( uint64_t ) );
+    if ( !ar_input.load( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
+
     for ( uint64_t i = 0; i < size; ++i )
     {
       pointer_type ptr;
@@ -163,7 +173,10 @@ public:
   {
     /* nodes */
     uint64_t size = storage.nodes.size();
-    os.dump( (char*)&size, sizeof( uint64_t ) );
+    if ( !os.dump( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
     for ( const auto& n : storage.nodes )
     {
       if ( !this->operator()( os, n ) )
@@ -174,7 +187,10 @@ public:
 
     /* inputs */
     size = storage.inputs.size();
-    os.dump( (char*)&size, sizeof( uint64_t ) );
+    if ( !os.dump( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
     for ( const auto& i : storage.inputs )
     {
       if ( !this->operator()( os, i ) )
@@ -185,7 +201,10 @@ public:
 
     /* outputs */
     size = storage.outputs.size();
-    os.dump( (char*)&size, sizeof( uint64_t ) );
+    if ( !os.dump( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
     for ( const auto& o : storage.outputs )
     {
       if ( !this->operator()( os, o ) )
@@ -200,7 +219,10 @@ public:
       return false;
     }
 
-    os.dump( (char*)&storage.trav_id, sizeof( uint32_t ) );
+    if ( !os.dump( (char*)&storage.trav_id, sizeof( uint32_t ) ) )
+    {
+      return false;
+    }
 
     return true;
   }
@@ -209,7 +231,10 @@ public:
   {
     /* nodes */
     uint64_t size;
-    ar_input.load( (char*)&size, sizeof( uint64_t ) );
+    if ( !ar_input.load( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
     for ( uint64_t i = 0; i < size; ++i )
     {
       node_type n;
@@ -221,16 +246,25 @@ public:
     }
 
     /* inputs */
-    ar_input.load( (char*)&size, sizeof( uint64_t ) );
+    if ( !ar_input.load( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
     for ( uint64_t i = 0; i < size; ++i )
     {
       uint64_t value;
-      ar_input.load( (char*)&value, sizeof( uint64_t ) );
+      if ( !ar_input.load( (char*)&value, sizeof( uint64_t ) ) )
+      {
+        return false;
+      }
       storage->inputs.push_back( value );
     }
 
     /* outputs */
-    ar_input.load( (char*)&size, sizeof( uint64_t ) );
+    if ( !ar_input.load( (char*)&size, sizeof( uint64_t ) ) )
+    {
+      return false;
+    }
     for ( uint64_t i = 0; i < size; ++i )
     {
       pointer_type ptr;
@@ -247,7 +281,10 @@ public:
       return false;
     }
 
-    ar_input.load( (char*)&storage->trav_id, sizeof( uint32_t ) );
+    if ( !ar_input.load( (char*)&storage->trav_id, sizeof( uint32_t ) ) )
+    {
+      return false;
+    }
 
     return true;
   }

--- a/lib/parallel_hashmap/parallel_hashmap/phmap_dump.h
+++ b/lib/parallel_hashmap/parallel_hashmap/phmap_dump.h
@@ -185,14 +185,19 @@ public:
 
     bool dump(const char *p, size_t sz) {
         ofs_.write(p, sz);
-        return true;
+        return ofs_.good();
     }
 
     template<typename V>
     typename std::enable_if<type_traits_internal::IsTriviallyCopyable<V>::value, bool>::type
     dump(const V& v) {
         ofs_.write(reinterpret_cast<const char *>(&v), sizeof(V));
-        return true;
+        return ofs_.good();
+    }
+
+    bool close() {
+        ofs_.close();
+        return ofs_.good();
     }
 
 private:
@@ -208,14 +213,14 @@ public:
 
     bool load(char* p, size_t sz) {
         ifs_.read(p, sz);
-        return true;
+        return ifs_.good();
     }
 
     template<typename V>
     typename std::enable_if<type_traits_internal::IsTriviallyCopyable<V>::value, bool>::type
     load(V* v) {
         ifs_.read(reinterpret_cast<char *>(v), sizeof(V));
-        return true;
+        return ifs_.good();
     }
 
 private:

--- a/test/io/serialize.cpp
+++ b/test/io/serialize.cpp
@@ -1,8 +1,18 @@
 #include <catch.hpp>
 
+#include <filesystem>
+
 #include <mockturtle/io/serialize.hpp>
 
 using namespace mockturtle;
+
+#if __GNUC__ == 7
+namespace fs = std::experimental::filesystem::v1;
+#else
+namespace fs = std::filesystem;
+#endif
+
+static constexpr char file_name[] = "aig.dmp" ;
 
 TEST_CASE( "serialize aig_network into a file", "[serialize]" )
 {
@@ -19,10 +29,10 @@ TEST_CASE( "serialize aig_network into a file", "[serialize]" )
   aig.create_po( f5 );
 
   /* serialize */
-  serialize_network( aig, "aig.dmp" );
+  serialize_network( aig, file_name );
 
   /* deserialize */
-  aig_network aig2 = deserialize_network( "aig.dmp" );
+  aig_network aig2 = deserialize_network( file_name );
 
   CHECK( aig.size() == aig2.size() );
   CHECK( aig.num_cis() == aig2.num_cis() );
@@ -45,4 +55,70 @@ TEST_CASE( "serialize aig_network into a file", "[serialize]" )
   CHECK( aig2._storage->nodes[f4.index].children[1u].index == f1.index );
   CHECK( aig2._storage->nodes[f5.index].children[0u].index == f4.index );
   CHECK( aig2._storage->nodes[f5.index].children[1u].index == f3.index );
+}
+
+static aig_network create_network()
+{
+  aig_network aig;
+
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+
+  const auto f1 = aig.create_nand( a, b );
+  const auto f3 = aig.create_nand( b, f1 );
+  const auto f4 = aig.create_nand( a, f1 );
+  const auto f5 = aig.create_nand( f4, f3 );
+  aig.create_po( f5 );
+
+  return aig;
+}
+
+// These numbers were chosen to get 100% coverage of the `return false`
+// error paths in `serialize.hpp`.
+//
+// To find a value that gives coverage of a particular `return false`
+// statement, change the loops below to iterate from 0 to 1000000,
+// configure with `-DCMAKE_BUILD_TYPE=DEBUG` and run in a debugger
+// with a breakpoint set at the line of interest. When the breakpoint
+// is hit, get the value of `size` from its stack frame and add it
+// to this list.
+static constexpr int truncate_sizes[] =
+{
+  0, 8, 16, 32, 40, 344, 352, 368, 376, 384, 672120
+};
+
+TEST_CASE( "write errors are propagated", "[serialize]" )
+{
+  aig_network aig = create_network();
+
+  serialize_network( aig, file_name );
+  size_t file_size = fs::file_size( file_name );
+  INFO("File size " << file_size);
+
+  for ( size_t size : truncate_sizes ) {
+    if ( size >= file_size )
+    {
+      break;
+    }
+    phmap::BinaryOutputArchive output ( file_name, size );
+    CHECK_FALSE( serialize_network_fallible( aig, output ) );
+  }
+}
+
+TEST_CASE( "read errors are propagated", "[serialize]" )
+{
+  aig_network aig = create_network();
+
+  serialize_network( aig, file_name );
+  size_t file_size = fs::file_size( file_name );
+  INFO("File size " << file_size);
+
+  for ( size_t size : truncate_sizes ) {
+    if ( size >= file_size )
+    {
+      break;
+    }
+    phmap::BinaryInputArchive input ( file_name, size );
+    CHECK_FALSE( deserialize_network_fallible( input ).has_value() );
+  }
 }

--- a/test/io/write_aiger.cpp
+++ b/test/io/write_aiger.cpp
@@ -78,7 +78,6 @@ TEST_CASE( "write AIG for XOR into AIGERfile", "[write_aiger]" )
   seq_buffer<char> buffer;
   std::ostream os( &buffer );
   write_aiger( aig, os );
-  write_aiger( aig, "test.aig" );
 
   CHECK( buffer.data() ==
          std::vector<char>{

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,6 +1,43 @@
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
+
 #include <catch.hpp>
 
-#include <mockturtle/mockturtle.hpp>
+#include <filesystem>
+#include <random>
 
-#include <iostream>
+#include <fmt/format.h>
+
+#if __GNUC__ == 7
+namespace fs = std::experimental::filesystem::v1;
+#else
+namespace fs = std::filesystem;
+#endif
+
+// Insecure but portable creation of a temporary directory
+static fs::path temp_directory()
+{
+  std::random_device rd;
+  std::mt19937_64 generator( rd() );
+  std::uniform_int_distribution<uint64_t> distribution( 0, std::numeric_limits<uint64_t>::max() );
+  uint64_t random_number = distribution( generator );
+
+  fs::path path = fs::temp_directory_path();
+  path /= fmt::format( "mockturtle_test_{:x}", random_number );
+  return path;
+}
+
+int main(int argc, char* argv[])
+{
+  auto temp_dir = temp_directory();
+  fs::create_directory( temp_dir );
+  fs::current_path( temp_dir );
+
+  int exit_code = Catch::Session().run(argc, argv);
+
+  if ( !exit_code ) {
+    fs::current_path( ".." );
+    fs::remove_all( temp_dir );
+  }
+
+  return exit_code;
+}


### PR DESCRIPTION
The current working directory may not be writable so it's better to write files explicitly to `/tmp` and clean them up afterward.