### PR TITLE
Fixing code based on reported issues

### DIFF
--- a/include/mockturtle/algorithms/emap.hpp
+++ b/include/mockturtle/algorithms/emap.hpp
@@ -100,7 +100,7 @@ struct emap_params
    * Structural uses pattern matching for fully-DSD cells,
    * Hybrid combines the two.
    */
-  enum
+  enum matching_mode_t
   {
     boolean,
     structural,

--- a/include/mockturtle/utils/tech_library.hpp
+++ b/include/mockturtle/utils/tech_library.hpp
@@ -248,6 +248,9 @@ public:
     }
   }
 
+  tech_library ( const tech_library& ) = delete;
+  tech_library& operator=( const tech_library& ) = delete;
+
   /*! \brief Get the gates matching the function.
    *
    * Returns a list of gates that match the function represented
@@ -1163,7 +1166,7 @@ private:
   bool _use_supergates;
 
   std::vector<gate> const _gates;    /* collection of gates */
-  super_lib const& _supergates_spec; /* collection of supergates declarations */
+  super_lib const _supergates_spec;  /* collection of supergates declarations */
   tech_library_params const _ps;
 
   std::vector<standard_cell> const _cells; /* collection of standard cells */


### PR DESCRIPTION
This PR fixes the following:
- Report #662 : removing reference from member `_supergates_spec` of `tech_library`
- Report #663 : added naming to enum in `emap`
- Report #664 : short fix by delating the default copy constructor and the assignment operator of `tech_library`