### PR TITLE
Refactor(Doc): blif reader missing rendering in readthedocs

### DIFF
--- a/include/mockturtle/io/blif_reader.hpp
+++ b/include/mockturtle/io/blif_reader.hpp
@@ -61,8 +61,11 @@ namespace mockturtle
  * - `get_constant`
  *
    \verbatim embed:rst
+
    Example
+
    .. code-block:: c++
+
       klut_network klut;
       lorina::read_blif( "file.blif", blif_reader( klut ) );
 


### PR DESCRIPTION
Minor change on doc rendering.
From 
![Screenshot 2024-10-28 at 17 07 16](https://github.com/user-attachments/assets/7ba6475e-d6a3-49cf-8ffd-de2b9c5d707d)
to
![Screenshot 2024-10-28 at 17 07 57](https://github.com/user-attachments/assets/776bf383-4e1f-4ddf-9c71-d1320de9b630)
