### PR TITLE
feat: simulator for XAIG index lists

### DIFF
--- a/include/mockturtle/algorithms/aig_resub.hpp
+++ b/include/mockturtle/algorithms/aig_resub.hpp
@@ -37,7 +37,7 @@
 #pragma once
 
 #include "../networks/aig.hpp"
-#include "../utils/index_list.hpp"
+#include "../utils/index_list/index_list.hpp"
 #include "../utils/truth_table_utils.hpp"
 #include "resubstitution.hpp"
 #include "resyn_engines/xag_resyn.hpp"

--- a/include/mockturtle/algorithms/circuit_validator.hpp
+++ b/include/mockturtle/algorithms/circuit_validator.hpp
@@ -34,7 +34,7 @@
 #pragma once
 
 #include "../networks/events.hpp"
-#include "../utils/index_list.hpp"
+#include "../utils/index_list/index_list.hpp"
 #include "../utils/node_map.hpp"
 #include "cnf.hpp"
 

--- a/include/mockturtle/algorithms/experimental/cost_generic_resub.hpp
+++ b/include/mockturtle/algorithms/experimental/cost_generic_resub.hpp
@@ -35,7 +35,7 @@
 #include "../../networks/aig.hpp"
 #include "../../networks/xag.hpp"
 #include "../../traits.hpp"
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../utils/stopwatch.hpp"
 #include "../../views/cost_view.hpp"
 #include "../../views/depth_view.hpp"

--- a/include/mockturtle/algorithms/experimental/cost_resyn.hpp
+++ b/include/mockturtle/algorithms/experimental/cost_resyn.hpp
@@ -37,7 +37,7 @@
 #pragma once
 
 #include "../../algorithms/cleanup.hpp"
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 
 #include <algorithm>
 #include <optional>

--- a/include/mockturtle/algorithms/experimental/sim_resub.hpp
+++ b/include/mockturtle/algorithms/experimental/sim_resub.hpp
@@ -37,7 +37,7 @@
 #include "../../networks/aig.hpp"
 #include "../../networks/xag.hpp"
 #include "../../traits.hpp"
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../views/depth_view.hpp"
 #include "../../views/fanout_view.hpp"
 #include "../circuit_validator.hpp"

--- a/include/mockturtle/algorithms/experimental/window_resub.hpp
+++ b/include/mockturtle/algorithms/experimental/window_resub.hpp
@@ -35,7 +35,7 @@
 #include "../../networks/aig.hpp"
 #include "../../networks/xag.hpp"
 #include "../../traits.hpp"
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../utils/null_utils.hpp"
 #include "../../views/depth_view.hpp"
 #include "../../views/fanout_view.hpp"

--- a/include/mockturtle/algorithms/mig_resub.hpp
+++ b/include/mockturtle/algorithms/mig_resub.hpp
@@ -36,7 +36,7 @@
 #pragma once
 
 #include "../networks/mig.hpp"
-#include "../utils/index_list.hpp"
+#include "../utils/index_list/index_list.hpp"
 #include "../utils/truth_table_utils.hpp"
 #include "resubstitution.hpp"
 #include "resyn_engines/mig_resyn.hpp"

--- a/include/mockturtle/algorithms/node_resynthesis/xag_minmc2.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/xag_minmc2.hpp
@@ -39,7 +39,7 @@
 #include <vector>
 
 #include "../../networks/xag.hpp"
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../detail/minmc_xags.hpp"
 #include "../equivalence_classes.hpp"
 

--- a/include/mockturtle/algorithms/node_resynthesis/xag_npn.hpp
+++ b/include/mockturtle/algorithms/node_resynthesis/xag_npn.hpp
@@ -47,7 +47,7 @@
 
 #include "../../algorithms/simulation.hpp"
 #include "../../networks/xag.hpp"
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../utils/node_map.hpp"
 #include "../../utils/stopwatch.hpp"
 

--- a/include/mockturtle/algorithms/resyn_engines/aig_enumerative.hpp
+++ b/include/mockturtle/algorithms/resyn_engines/aig_enumerative.hpp
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../utils/null_utils.hpp"
 #include <kitty/kitty.hpp>
 #include <optional>

--- a/include/mockturtle/algorithms/resyn_engines/mig_enumerative.hpp
+++ b/include/mockturtle/algorithms/resyn_engines/mig_enumerative.hpp
@@ -36,7 +36,7 @@
 
 #pragma once
 
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../utils/null_utils.hpp"
 #include <kitty/kitty.hpp>
 #include <optional>

--- a/include/mockturtle/algorithms/resyn_engines/mig_resyn.hpp
+++ b/include/mockturtle/algorithms/resyn_engines/mig_resyn.hpp
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 
 #include <fmt/format.h>
 #include <kitty/kitty.hpp>

--- a/include/mockturtle/algorithms/resyn_engines/mux_resyn.hpp
+++ b/include/mockturtle/algorithms/resyn_engines/mux_resyn.hpp
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../utils/null_utils.hpp"
 
 #include <fmt/format.h>

--- a/include/mockturtle/algorithms/resyn_engines/xag_resyn.hpp
+++ b/include/mockturtle/algorithms/resyn_engines/xag_resyn.hpp
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#include "../../utils/index_list.hpp"
+#include "../../utils/index_list/index_list.hpp"
 #include "../../utils/node_map.hpp"
 #include "../../utils/stopwatch.hpp"
 

--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -35,7 +35,7 @@
 #include "../networks/events.hpp"
 #include "../networks/xag.hpp"
 #include "../utils/debugging_utils.hpp"
-#include "../utils/index_list.hpp"
+#include "../utils/index_list/index_list.hpp"
 #include "../utils/network_utils.hpp"
 #include "../utils/node_map.hpp"
 #include "../utils/stopwatch.hpp"

--- a/include/mockturtle/algorithms/xag_resub.hpp
+++ b/include/mockturtle/algorithms/xag_resub.hpp
@@ -33,7 +33,7 @@
 #pragma once
 
 #include "../networks/xag.hpp"
-#include "../utils/index_list.hpp"
+#include "../utils/index_list/index_list.hpp"
 #include "../utils/truth_table_utils.hpp"
 #include "resubstitution.hpp"
 #include "resyn_engines/xag_resyn.hpp"

--- a/include/mockturtle/mockturtle.hpp
+++ b/include/mockturtle/mockturtle.hpp
@@ -185,7 +185,7 @@
 #include "mockturtle/utils/debugging_utils.hpp"
 #include "mockturtle/utils/hash_functions.hpp"
 #include "mockturtle/utils/include/percy.hpp"
-#include "mockturtle/utils/index_list.hpp"
+#include "mockturtle/utils/index_list/index_list.hpp"
 #include "mockturtle/utils/json_utils.hpp"
 #include "mockturtle/utils/mixed_radix.hpp"
 #include "mockturtle/utils/name_utils.hpp"

--- a/include/mockturtle/utils/index_list/list_simulator.hpp
+++ b/include/mockturtle/utils/index_list/list_simulator.hpp
@@ -1,0 +1,179 @@
+/* mockturtle: C++ logic network library
+ * Copyright (C) 2018-2022  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file list_simulator.hpp
+  \brief Simulator engine for index lists.
+
+  \author Andrea Costamagna
+*/
+
+#pragma once
+
+#include "index_list.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace mockturtle
+{
+
+/*! \brief Simulator engine for XAIG-index lists.
+ *
+ * This engine can be used to efficiently simulate many index lists.
+ * In this context, a simulation pattern is a truth table corresponding
+ * to a node’s Boolean behavior under the given input assignments.
+ * It pre-allocates the memory necessary to store the simulation patterns
+ * of an index list, and extends this memory when the evaluator is required
+ * to perform Boolean evaluation of a list that is larger than the current capacity
+ * of the simulator. To avoid unnecessary copies, the input simulation patterns
+ * must be passed as a vector of raw pointers.
+ *
+ * \tparam TT Truth table type.
+ * \tparam separate_header
+ *
+ * \verbatim embed:rst
+
+   Example
+
+   .. code-block:: c++
+
+      xag_list_simulator<kitty::static_truth_table<4u>> sim;
+      sim( list1, inputs1 );
+      sim( list2, inputs2 );
+   \endverbatim
+ */
+template<class TT>
+class xag_list_simulator
+{
+public:
+  /* Type of the literals of the index list */
+  using element_type = typename xag_index_list<true>::element_type;
+
+  xag_list_simulator()
+      : const0( TT().construct() )
+  {
+    /* The value 20 is chosen as it allows us to store most practical XAIG index lists */
+    sims.resize( 20u );
+  }
+
+  /*! \brief Extract the simulation of a literal
+   *
+   * Inline specifier used to ensure manual inlining.
+   *
+   * \param res Truth table where to store the result.
+   * \param list Index list to be simulated.
+   * \param inputs Vector of pointers to the input truth tables.
+   * \param lit Literal whose simulation we want to extract.
+   */
+  template<bool separate_header>
+  inline void get_simulation_inline( TT& res, xag_index_list<separate_header> const& list, std::vector<TT const*> const& inputs, element_type const& lit )
+  {
+    if ( list.is_constant( lit ) )
+    {
+      res = complement( const0, list.is_complemented( lit ) );
+      return;
+    }
+    if ( list.is_pi( lit ) )
+    {
+      uint32_t index = list.get_pi_index( lit );
+      TT const& sim = *inputs[index];
+      res = complement( sim, list.is_complemented( lit ) );
+      return;
+    }
+    uint32_t index = list.get_node_index( lit );
+    TT const& sim = sims[index];
+    res = complement( sim, list.is_complemented( lit ) );
+  }
+
+  /*! \brief Simulate the list in topological order.
+   *
+   * This method updates the internal state of the simulator by
+   * storing in `sims` the simulation patterns of the nodes in the list.
+   *
+   * \param list Index list to be simulated.
+   * \param inputs Vector of TT references corresponding to the input truth tables
+   */
+  template<bool separate_header>
+  void operator()( xag_index_list<separate_header> const& list, std::vector<TT const*> const& inputs )
+  {
+    /* update the allocated memory */
+    if ( sims.size() < list.num_gates() )
+      sims.resize( std::max<size_t>( sims.size(), list.num_gates() ) );
+    /* traverse the list in topological order and simulate each node */
+    size_t i = 0;
+    list.foreach_gate( [&]( element_type const& lit_lhs, element_type const& lit_rhs ) {
+      auto const [tt_lhs_ptr, is_lhs_compl] = get_simulation( list, inputs, lit_lhs );
+      auto const [tt_rhs_ptr, is_rhs_compl] = get_simulation( list, inputs, lit_rhs );
+      sims[i++] = list.is_and( lit_lhs, lit_rhs )
+                      ? complement( *tt_lhs_ptr, is_lhs_compl ) & complement( *tt_rhs_ptr, is_rhs_compl )
+                      : complement( *tt_lhs_ptr, is_lhs_compl ) ^ complement( *tt_rhs_ptr, is_rhs_compl );
+    } );
+  }
+
+private:
+  inline TT complement( TT const& tt, bool c )
+  {
+    return c ? ~tt : tt;
+  }
+
+  /*! \brief Return the simulation associated to the literal
+   *
+   * \param list An XAIG index list, with or without separated header.
+   * \param inputs A vector of pointers to the input simulation patterns.
+   * \param lit The literal whose simulation we want to extract.
+   *
+   * The size of `inputs` should be equal to the number of inputs of the list.
+   * Keep private to avoid giving external access to memory that could be later corrupted.
+   *
+   * \return A tuple containing a pointer to the simulation pattern and a flag for complementation.
+   */
+  template<bool separate_header>
+  [[nodiscard]] std::tuple<TT const*, bool> get_simulation( xag_index_list<separate_header> const& list, std::vector<TT const*> const& inputs, element_type const& lit )
+  {
+    if ( list.num_pis() != inputs.size() )
+      throw std::invalid_argument( "Mismatch between number of PIs and input simulations." );
+    if ( list.is_constant( lit ) )
+    {
+      return { &const0, list.is_complemented( lit ) };
+    }
+    if ( list.is_pi( lit ) )
+    {
+      uint32_t index = list.get_pi_index( lit );
+      TT const& sim = *inputs[index];
+      return { &sim, list.is_complemented( lit ) };
+    }
+    uint32_t index = list.get_node_index( lit );
+    TT const& sim = sims[index];
+    return { &sim, list.is_complemented( lit ) };
+  }
+
+private:
+  std::vector<TT> sims;
+  TT const0;
+
+}; /* list simulator */
+
+} /* namespace mockturtle */

--- a/test/algorithms/circuit_validator.cpp
+++ b/test/algorithms/circuit_validator.cpp
@@ -5,7 +5,7 @@
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/mig.hpp>
 #include <mockturtle/networks/xag.hpp>
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 #include <mockturtle/views/fanout_view.hpp>
 
 using namespace mockturtle;

--- a/test/algorithms/equivalence_classes.cpp
+++ b/test/algorithms/equivalence_classes.cpp
@@ -6,7 +6,7 @@
 #include <mockturtle/algorithms/equivalence_classes.hpp>
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/xag.hpp>
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 
 #include <kitty/constructors.hpp>
 #include <kitty/dynamic_truth_table.hpp>

--- a/test/algorithms/minmc_xags.cpp
+++ b/test/algorithms/minmc_xags.cpp
@@ -4,7 +4,7 @@
 #include <mockturtle/algorithms/detail/minmc_xags.hpp>
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/xag.hpp>
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 
 #include <algorithm>
 #include <cstdint>

--- a/test/algorithms/resyn_engines/xag_resyn.cpp
+++ b/test/algorithms/resyn_engines/xag_resyn.cpp
@@ -6,7 +6,7 @@
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/networks/xag.hpp>
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 
 using namespace mockturtle;
 

--- a/test/utils/index_list/index_list.cpp
+++ b/test/utils/index_list/index_list.cpp
@@ -3,9 +3,9 @@
 #include <kitty/static_truth_table.hpp>
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/mig.hpp>
-#include <mockturtle/networks/xag.hpp>
 #include <mockturtle/networks/muxig.hpp>
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 
 using namespace mockturtle;
 

--- a/test/utils/index_list/list_simulator.cpp
+++ b/test/utils/index_list/list_simulator.cpp
@@ -1,0 +1,115 @@
+#include <catch.hpp>
+
+#include <kitty/print.hpp>
+#include <kitty/static_truth_table.hpp>
+#include <mockturtle/algorithms/simulation.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
+#include <mockturtle/utils/index_list/list_simulator.hpp>
+
+using namespace mockturtle;
+
+TEST_CASE( "simulation of xag_index_list with static truth tables", "[list_simulator]" )
+{
+  xag_network xag;
+  auto const a = xag.create_pi();
+  auto const b = xag.create_pi();
+  auto const c = xag.create_pi();
+  auto const d = xag.create_pi();
+  auto const t0 = xag.create_and( a, b );
+  auto const t1 = xag.create_and( c, d );
+  auto const t2 = xag.create_xor( t0, t1 );
+  xag.create_po( t2 );
+
+  std::vector<kitty::static_truth_table<4u>> xs;
+  for ( auto i = 0u; i < 4u; ++i )
+  {
+    xs.emplace_back();
+    kitty::create_nth_var( xs[i], i );
+  }
+  xs.emplace_back( xs[0] & xs[1] ); // 4
+  xs.emplace_back( xs[2] & xs[3] ); // 5
+  xs.emplace_back( xs[4] ^ xs[5] ); // 6
+
+  std::vector<kitty::static_truth_table<4u> const*> xs_r;
+  for ( auto i = 0u; i < 4u; ++i )
+  {
+    xs_r.emplace_back( &xs[i] );
+  }
+  xag_index_list<true> list_separate;
+  encode( list_separate, xag );
+
+  xag_list_simulator<kitty::static_truth_table<4u>> sim_separate;
+  sim_separate( list_separate, xs_r );
+  kitty::static_truth_table<4u> tt4_separate, tt5_separate, tt6_separate;
+  sim_separate.get_simulation_inline( tt4_separate, list_separate, xs_r, 10u );
+  sim_separate.get_simulation_inline( tt5_separate, list_separate, xs_r, 12u );
+  sim_separate.get_simulation_inline( tt6_separate, list_separate, xs_r, 14u );
+  CHECK( kitty::equal( xs[4], tt4_separate ) );
+  CHECK( kitty::equal( xs[5], tt5_separate ) );
+  CHECK( kitty::equal( xs[6], tt6_separate ) );
+
+  xag_index_list<false> list_unified;
+  encode( list_unified, xag );
+  xag_list_simulator<kitty::static_truth_table<4u>> sim_unified;
+  sim_unified( list_unified, xs_r );
+  kitty::static_truth_table<4u> tt4_unified, tt5_unified, tt6_unified;
+  sim_unified.get_simulation_inline( tt4_unified, list_unified, xs_r, 10u );
+  sim_unified.get_simulation_inline( tt5_unified, list_unified, xs_r, 12u );
+  sim_unified.get_simulation_inline( tt6_unified, list_unified, xs_r, 14u );
+  CHECK( kitty::equal( xs[4], tt4_unified ) );
+  CHECK( kitty::equal( xs[5], tt5_unified ) );
+  CHECK( kitty::equal( xs[6], tt6_unified ) );
+}
+
+TEST_CASE( "simulation of xag_index_list with dynamic truth tables", "[list_simulator]" )
+{
+  xag_network xag;
+  auto const a = xag.create_pi();
+  auto const b = xag.create_pi();
+  auto const c = xag.create_pi();
+  auto const d = xag.create_pi();
+  auto const t0 = xag.create_and( a, b );
+  auto const t1 = xag.create_and( c, d );
+  auto const t2 = xag.create_xor( t0, t1 );
+  xag.create_po( t2 );
+
+  std::vector<kitty::dynamic_truth_table> xs;
+  for ( auto i = 0u; i < 4u; ++i )
+  {
+    xs.emplace_back( 4u );
+    kitty::create_nth_var( xs[i], i );
+  }
+  xs.emplace_back( xs[0] & xs[1] ); // 4
+  xs.emplace_back( xs[2] & xs[3] ); // 5
+  xs.emplace_back( xs[4] ^ xs[5] ); // 6
+
+  std::vector<kitty::dynamic_truth_table const*> xs_r;
+  for ( auto i = 0u; i < 4u; ++i )
+  {
+    xs_r.emplace_back( &xs[i] );
+  }
+  xag_index_list<true> list_separate;
+  encode( list_separate, xag );
+  xag_list_simulator<kitty::dynamic_truth_table> sim_separate;
+  sim_separate( list_separate, xs_r );
+  kitty::dynamic_truth_table tt4_separate( 4u ), tt5_separate( 4u ), tt6_separate( 4u );
+  sim_separate.get_simulation_inline( tt4_separate, list_separate, xs_r, 10u );
+  sim_separate.get_simulation_inline( tt5_separate, list_separate, xs_r, 12u );
+  sim_separate.get_simulation_inline( tt6_separate, list_separate, xs_r, 14u );
+  CHECK( kitty::equal( xs[4], tt4_separate ) );
+  CHECK( kitty::equal( xs[5], tt5_separate ) );
+  CHECK( kitty::equal( xs[6], tt6_separate ) );
+
+  xag_index_list<false> list_unified;
+  encode( list_unified, xag );
+  xag_list_simulator<kitty::dynamic_truth_table> sim_unified;
+  sim_unified( list_unified, xs_r );
+  kitty::dynamic_truth_table tt4_unified( 4u ), tt5_unified( 4u ), tt6_unified( 4u );
+  sim_unified.get_simulation_inline( tt4_unified, list_unified, xs_r, 10u );
+  sim_unified.get_simulation_inline( tt5_unified, list_unified, xs_r, 12u );
+  sim_unified.get_simulation_inline( tt6_unified, list_unified, xs_r, 14u );
+  CHECK( kitty::equal( xs[4], tt4_unified ) );
+  CHECK( kitty::equal( xs[5], tt5_unified ) );
+  CHECK( kitty::equal( xs[6], tt6_unified ) );
+}

--- a/test/utils/network_utils.cpp
+++ b/test/utils/network_utils.cpp
@@ -5,7 +5,7 @@
 #include <mockturtle/algorithms/simulation.hpp>
 #include <mockturtle/networks/aig.hpp>
 #include <mockturtle/utils/debugging_utils.hpp>
-#include <mockturtle/utils/index_list.hpp>
+#include <mockturtle/utils/index_list/index_list.hpp>
 #include <mockturtle/utils/network_utils.hpp>
 
 using namespace mockturtle;


### PR DESCRIPTION
This PR introduces a new engine to perform Boolean evaluation (simulation) of XAIG index lists, along with supporting changes to improve code structure and robustness.

**Changes introduced:**

1. Refactored and reorganized directories in `utils` for better readability.
2. Added helper functions (`is_complemented`, `get_pi_index`, `get_node_index`) to `xag_index_list` to encapsulate literal manipulations and reduce potential for errors.
3. Implemented a simulator for XAIG index lists that evaluates nodes in topological order and manages simulation patterns efficiently.

**TODO:**
Update remaining code that directly manipulates literals without using xag_index_list interface functions.