### PR TITLE
Fix compilation issue

### DIFF
--- a/include/mockturtle/views/choice_view.hpp
+++ b/include/mockturtle/views/choice_view.hpp
@@ -582,7 +582,7 @@ private:
 private:
   std::shared_ptr<std::vector<node>> _choice_repr;
   std::shared_ptr<std::vector<signal>> _choice_phase;
-  choice_view_params const _ps;
+  choice_view_params _ps;
   std::shared_ptr<typename network_events<Ntk>::add_event_type> _add_event;
 };
 


### PR DESCRIPTION
The field _ps of choice_view is marked as const. This conflicts with  "this->_ps = choice_ntk._ps;" in the assignment operator.

Compilation environment:
- clang version 19.1.7