### PR TITLE
corner case bug fixes

### DIFF
--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -349,7 +349,7 @@ public:
           }
           substitutions.clear();
         }
-                        
+
         /* ensure that no dead nodes are reachable */
         assert( count_reachable_dead_nodes( ntk ) == 0u );
         substitute_nodes( substitutions );

--- a/include/mockturtle/utils/window_utils.hpp
+++ b/include/mockturtle/utils/window_utils.hpp
@@ -725,10 +725,10 @@ void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::nod
 
   for ( uint32_t index = 0u; index < used.size(); ++index )
   {
-    std::vector<node>& level = levels.at( used[index] );
-    for ( auto j = 0u; j < level.size(); ++j )
+    int current_index = used[index];
+    for ( auto j = 0u; j < levels[current_index].size(); ++j )
     {
-      ntk.foreach_fanout( level[j], [&]( node const& fo, uint64_t index ) {
+      ntk.foreach_fanout( levels[current_index][j], [&]( node const& fo, uint64_t index ) {
         /* avoid getting stuck on nodes with many fanouts */
         if ( index == MAX_FANOUTS )
         {
@@ -768,7 +768,7 @@ void levelized_expand_towards_tfo( Ntk const& ntk, std::vector<typename Ntk::nod
         return true;
       } );
     }
-    level.clear();
+    levels[current_index].clear();
   }
 }
 


### PR DESCRIPTION
 - window rewriting (cyclic re-substitution)
 if a loop is found in the middle, the following nodes will not be removed (take_out_node).
 returning true/false in the function object does not affect insert_ntk, so it keeps going, possibly previously already removed nodes in the case where the same node is substituting multiple window outputs.
 
  - window construction (reallocation of vector with a referenced element)
 level is a reference to an element of levels, while levels may be resized within the loop, that may cause reallocation, invalidating the reference to the element.