### PR TITLE
Migrate to windows-2022 image

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,11 +12,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ windows-2019 ]
+        os: [ windows-2022 ]
         toolset: [ v142, ClangCL ]
         include:
-          - os: windows-2019
-            env: "Visual Studio 16 2019"
+          - os: windows-2022
+            env: "Visual Studio 17 2022"
 
     name: ${{matrix.os}} with ${{matrix.env}} and ${{matrix.toolset}} toolset
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
The windows-2019 runner image is being deprecated. This PR switches to windows-2022