### PR TITLE
Remove unnecessary fanout size value assignment in refactoring algorithm

### DIFF
--- a/include/mockturtle/algorithms/refactoring.hpp
+++ b/include/mockturtle/algorithms/refactoring.hpp
@@ -166,10 +166,6 @@ public:
         return true;
       }
 
-      ntk.foreach_node( [&]( auto n ){
-        ntk.set_value( n, ntk.fanout_size( n ) );
-      });
-
       const auto mffc = make_with_stopwatch<mffc_view<Ntk>>( st.time_mffc, ntk, n );
 
       pbar( i, i, _candidates, _estimated_gain );


### PR DESCRIPTION
The change removes a loop that sets node values to their fanout sizes in the refactoring_impl::run() method

Fix https://github.com/lsils/mockturtle/issues/684