### PR TITLE
Fix depth-preserving rewrite

### DIFF
--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -636,16 +636,25 @@ private:
     auto& db = library.get_database();
     db.incr_trav_id();
 
-    return evaluate_entry_rec( current_root, n, leaves );
+    unordered_node_map<uint32_t, std::decay_t<decltype( db )>> levels( db );
+    return evaluate_entry_rec( current_root, n, leaves, levels );
   }
 
-  std::pair<int32_t, uint32_t> evaluate_entry_rec( node<Ntk> const& current_root, node<Ntk> const& n, std::array<signal<Ntk>, num_vars> const& leaves )
+  template<typename Container>
+  std::pair<int32_t, uint32_t> evaluate_entry_rec( node<Ntk> const& current_root, node<Ntk> const& n, std::array<signal<Ntk>, num_vars> const& leaves, Container& levels )
   {
     auto& db = library.get_database();
     if ( db.is_pi( n ) || db.is_constant( n ) )
       return { 0, 0 };
     if ( db.visited( n ) == db.trav_id() )
+    {
+      if constexpr ( has_level_v<Ntk> )
+      {
+        assert( levels.has( n ) );
+        return { 0, levels[n] };
+      }
       return { 0, 0 };
+    }
 
     db.set_visited( n, db.trav_id() );
 
@@ -671,7 +680,7 @@ private:
         return;
       }
 
-      auto [area_rec, level_rec] = evaluate_entry_rec( current_root, g, leaves );
+      auto [area_rec, level_rec] = evaluate_entry_rec( current_root, g, leaves, levels );
       area += area_rec;
       level = std::max( level, level_rec );
 
@@ -687,6 +696,11 @@ private:
         hashed = false;
       }
     } );
+
+    if constexpr ( has_level_v<Ntk> )
+    {
+      levels[n] = level + 1;
+    }
 
     if ( hashed )
     {

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -777,7 +777,7 @@ private:
       auto const g = ntk.get_node( f );
 
       /* recur if it is still a node to explore and to update */
-      if ( ntk.node_to_index( g ) > root && ( ntk.node_to_index( g ) >= size || required[g] > req ) )
+      if ( ntk.node_to_index( g ) > root && ( ntk.node_to_index( g ) >= size || required[g] >= req ) )
         propagate_required_rec( root, g, size, req - 1 );
 
       /* update the required time */

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -1,12 +1,12 @@
 #include <catch.hpp>
 
-#include <mockturtle/algorithms/rewrite.hpp>
 #include <mockturtle/algorithms/node_resynthesis/mig_npn.hpp>
 #include <mockturtle/algorithms/node_resynthesis/xag_npn.hpp>
 #include <mockturtle/algorithms/node_resynthesis/xmg3_npn.hpp>
+#include <mockturtle/algorithms/rewrite.hpp>
 #include <mockturtle/networks/aig.hpp>
-#include <mockturtle/networks/xag.hpp>
 #include <mockturtle/networks/mig.hpp>
+#include <mockturtle/networks/xag.hpp>
 #include <mockturtle/networks/xmg.hpp>
 #include <mockturtle/traits.hpp>
 #include <mockturtle/utils/cost_functions.hpp>

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -11,6 +11,7 @@
 #include <mockturtle/traits.hpp>
 #include <mockturtle/utils/cost_functions.hpp>
 #include <mockturtle/utils/tech_library.hpp>
+#include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/fanout_view.hpp>
 
 using namespace mockturtle;
@@ -215,4 +216,36 @@ TEST_CASE( "Rewrite depth-preserving", "[rewrite]" )
   CHECK( aig.num_pis() == 3 );
   CHECK( aig.num_pos() == 2 );
   CHECK( aig.num_gates() == 8 );
+}
+
+TEST_CASE( "Rewrite AIG with zero-gain substitutions preserves depth", "[rewrite]" )
+{
+  aig_network aig;
+  const auto x0 = aig.create_pi();
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+  const auto x3 = aig.create_pi();
+  const auto x4 = aig.create_pi();
+
+  const auto n0 = aig.create_and( x2, !x0 );
+  const auto n1 = aig.create_and( x4, !x3 );
+  const auto n2 = aig.create_and( !n1, x1 );
+  const auto n3 = aig.create_and( !n2, !n0 );
+  const auto n4 = aig.create_and( !x2, x0 );
+  const auto n5 = aig.create_and( !n4, !n3 );
+  const auto n6 = aig.create_and( !n5, !x1 );
+  aig.create_po( n6 );
+  aig.create_po( !n1 );
+
+  auto const depth_before = depth_view{ aig }.depth();
+
+  xag_npn_resynthesis<aig_network> resyn;
+  exact_library<aig_network> exact_lib( resyn );
+
+  rewrite_params ps;
+  ps.preserve_depth = true;
+  ps.allow_zero_gain = true;
+  rewrite( aig, exact_lib, ps );
+
+  CHECK( depth_view{ aig }.depth() <= depth_before );
 }


### PR DESCRIPTION
regarding the issue #687
there was a wrong inequality.
also thinking to clean up code a bit: depth computation is duplicated (depth view already does it) and seemingly incomplete (it only updates two TFO levels for each replacement, which is probably okay for most cases, followed by one TFI level check per iteration, but it might not work when a target node has more than 2 levels of fanouts that are already visited or new, so the follow-up one TFI level check fetches old level).