### PR TITLE
Fix depth-preserving rewrite and depth view

### DIFF
--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -792,29 +792,11 @@ private:
   }
 
 private:
-  uint32_t compute_level( node<Ntk> const& n )
-  {
-    if constexpr ( has_level_v<Ntk> )
-    {
-      uint32_t level = 0;
-      ntk.foreach_fanin( n, [&]( const auto& f ) {
-        auto const p = ntk.get_node( f );
-        auto const fanin_level = ntk.level( p );
-        if ( fanin_level > level )
-        {
-          level = fanin_level;
-        }
-      } );
-      return level + 1;
-    }
-    return 0;
-  }
-
   bool update_level( node<Ntk> const& n )
   {
     if constexpr ( has_level_v<Ntk> )
     {
-      uint32_t level = compute_level( n );
+      uint32_t level = ntk.compute_level( n );
       if ( ntk.level( n ) != level )
       {
         ntk.set_level( n, level );
@@ -830,7 +812,7 @@ private:
     {
       if constexpr ( has_level_v<Ntk> )
       {
-        if ( ntk.level( n ) != compute_level( n ) )
+        if ( ntk.level( n ) != ntk.compute_level( n ) )
           deferred.push_back( n );
       }
       return;

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -828,8 +828,11 @@ private:
   {
     if ( ntk.visited( n ) == mark )
     {
-      if ( ntk.level( n ) != compute_level( n ) )
-        deferred.push_back( n );
+      if constexpr ( has_level_v<Ntk> )
+      {
+        if ( ntk.level( n ) != compute_level( n ) )
+          deferred.push_back( n );
+      }
       return;
     }
 

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -797,87 +797,6 @@ private:
   }
 
 private:
-  bool update_level( node<Ntk> const& n )
-  {
-    if constexpr ( has_level_v<Ntk> )
-    {
-      uint32_t level = ntk.compute_level( n );
-      if ( ntk.level( n ) != level )
-      {
-        ntk.set_level( n, level );
-        return true;
-      }
-    }
-    return false;
-  }
-
-  void update_levels_fast( node<Ntk> const& n, uint32_t mark, std::vector<node<Ntk>>& deferred )
-  {
-    if ( ntk.visited( n ) == mark )
-    {
-      if constexpr ( has_level_v<Ntk> )
-      {
-        if ( ntk.level( n ) != ntk.compute_level( n ) )
-          deferred.push_back( n );
-      }
-      return;
-    }
-
-    ntk.set_visited( n, mark );
-
-    if ( update_level( n ) )
-    {
-      ntk.foreach_fanout( n, [&]( auto const& fo ) {
-        update_levels_fast( fo, mark, deferred );
-      } );
-    }
-  }
-
-  void mark_tfo( node<Ntk> const& n, uint32_t mark, std::vector<node<Ntk>>& sinks )
-  {
-    if ( ntk.visited( n ) == mark )
-      return;
-
-    ntk.set_visited( n, mark );
-
-    bool f = false;
-    ntk.foreach_fanout( n, [&]( auto const& fo ) {
-      mark_tfo( fo, mark, sinks );
-      f = true;
-    } );
-
-    if ( !f )
-      sinks.push_back( n );
-  }
-
-  void collect_marked_tfi_topo( node<Ntk> const& n, uint32_t mark, uint32_t visited, std::vector<node<Ntk>>& tfi_topo )
-  {
-    if ( ntk.visited( n ) == visited )
-      return;
-
-    if ( ntk.visited( n ) != mark )
-      return;
-
-    ntk.set_visited( n, visited );
-
-    ntk.foreach_fanin( n, [&]( auto const& f ) {
-      auto const p = ntk.get_node( f );
-      collect_marked_tfi_topo( p, mark, visited, tfi_topo );
-    } );
-
-    tfi_topo.push_back( n );
-  }
-
-  void update_levels_naive( node<Ntk> const& n )
-  {
-    if ( update_level( n ) )
-    {
-      ntk.foreach_fanout( n, [&]( auto const& fo ) {
-        update_levels_naive( fo );
-      } );
-    }
-  }
-
   void update_levels( node<Ntk> const& n )
   {
     /*
@@ -931,6 +850,89 @@ private:
         } );
       }
     }
+  }
+
+  /*
+  void update_levels_naive( node<Ntk> const& n )
+  {
+    if ( update_level( n ) )
+    {
+      ntk.foreach_fanout( n, [&]( auto const& fo ) {
+        update_levels_naive( fo );
+      } );
+    }
+  }
+  */
+
+  void update_levels_fast( node<Ntk> const& n, uint32_t mark, std::vector<node<Ntk>>& deferred )
+  {
+    if ( ntk.visited( n ) == mark )
+    {
+      if constexpr ( has_level_v<Ntk> )
+      {
+        if ( ntk.level( n ) != ntk.compute_level( n ) )
+          deferred.push_back( n );
+      }
+      return;
+    }
+
+    ntk.set_visited( n, mark );
+
+    if ( update_level( n ) )
+    {
+      ntk.foreach_fanout( n, [&]( auto const& fo ) {
+        update_levels_fast( fo, mark, deferred );
+      } );
+    }
+  }
+
+  bool update_level( node<Ntk> const& n )
+  {
+    if constexpr ( has_level_v<Ntk> )
+    {
+      uint32_t level = ntk.compute_level( n );
+      if ( ntk.level( n ) != level )
+      {
+        ntk.set_level( n, level );
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void mark_tfo( node<Ntk> const& n, uint32_t mark, std::vector<node<Ntk>>& sinks )
+  {
+    if ( ntk.visited( n ) == mark )
+      return;
+
+    ntk.set_visited( n, mark );
+
+    bool f = false;
+    ntk.foreach_fanout( n, [&]( auto const& fo ) {
+      mark_tfo( fo, mark, sinks );
+      f = true;
+    } );
+
+    if ( !f )
+      sinks.push_back( n );
+  }
+
+  void collect_marked_tfi_topo( node<Ntk> const& n, uint32_t mark, uint32_t visited, std::vector<node<Ntk>>& tfi_topo )
+  {
+    if ( ntk.visited( n ) == visited )
+      return;
+
+    if ( ntk.visited( n ) != mark )
+      return;
+
+    ntk.set_visited( n, visited );
+
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      auto const p = ntk.get_node( f );
+      collect_marked_tfi_topo( p, mark, visited, tfi_topo );
+    } );
+
+    tfi_topo.push_back( n );
   }
 
 private:

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -792,7 +792,7 @@ private:
   }
 
 private:
-  bool update_level( node<Ntk> const& n )
+  uint32_t compute_level( node<Ntk> const& n )
   {
     if constexpr ( has_level_v<Ntk> )
     {
@@ -805,9 +805,19 @@ private:
           level = fanin_level;
         }
       } );
-      if ( ntk.level( n ) != level + 1 )
+      return level + 1;
+    }
+    return 0;
+  }
+
+  bool update_level( node<Ntk> const& n )
+  {
+    if constexpr ( has_level_v<Ntk> )
+    {
+      uint32_t level = compute_level( n );
+      if ( ntk.level( n ) != level )
       {
-        ntk.set_level( n, level + 1 );
+        ntk.set_level( n, level );
         return true;
       }
     }
@@ -818,7 +828,8 @@ private:
   {
     if ( ntk.visited( n ) == mark )
     {
-      deferred.push_back( n );
+      if ( ntk.level( n ) != compute_level( n ) )
+        deferred.push_back( n );
       return;
     }
 
@@ -830,7 +841,6 @@ private:
         update_levels_fast( fo, mark, deferred );
       } );
     }
-    // (we may permit second visit ignored if it does not cause update)
   }
 
   void mark_tfo( node<Ntk> const& n, uint32_t mark, std::vector<node<Ntk>>& sinks )

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -130,24 +130,11 @@ public:
   rewrite_impl( Ntk& ntk, Library&& library, rewrite_params const& ps, rewrite_stats& st, NodeCostFn const& cost_fn )
       : ntk( ntk ), library( library ), ps( ps ), st( st ), cost_fn( cost_fn ), required( ntk, UINT32_MAX )
   {
-    register_events();
-  }
-
-  ~rewrite_impl()
-  {
-    if constexpr ( has_level_v<Ntk> )
-    {
-      ntk.events().release_add_event( add_event );
-      ntk.events().release_modified_event( modified_event );
-      ntk.events().release_delete_event( delete_event );
-    }
   }
 
   void run()
   {
     stopwatch t( st.time_total );
-
-    ntk.incr_trav_id();
 
     if ( ps.preserve_depth )
     {
@@ -195,12 +182,7 @@ private:
       {
         if ( ps.preserve_depth )
         {
-          uint32_t level = 0;
-          ntk.foreach_fanin( n, [&]( auto const& f ) {
-            level = std::max( level, ntk.level( ntk.get_node( f ) ) );
-          } );
-          ntk.set_level( n, level + 1 );
-          best_level = level + 1;
+          best_level = ntk.level( n );
         }
       }
 
@@ -325,6 +307,9 @@ private:
           {
             propagate_required_rec( ntk.node_to_index( n ), ntk.get_node( new_f ), size, required[n] );
             assert( ntk.level( ntk.get_node( new_f ) ) <= required[n] );
+            ntk.foreach_fanout( ntk.get_node( new_f ), [&]( const auto& p ) {
+              update_node_level( p );
+            } );
           }
         }
 
@@ -377,12 +362,7 @@ private:
       {
         if ( ps.preserve_depth )
         {
-          uint32_t level = 0;
-          ntk.foreach_fanin( n, [&]( auto const& f ) {
-            level = std::max( level, ntk.level( ntk.get_node( f ) ) );
-          } );
-          ntk.set_level( n, level + 1 );
-          best_level = level + 1;
+          best_level = ntk.level( n );
         }
       }
 
@@ -551,6 +531,9 @@ private:
           {
             propagate_required_rec( ntk.node_to_index( n ), ntk.get_node( new_f ), size, required[n] );
             assert( ntk.level( ntk.get_node( new_f ) ) <= required[n] );
+            ntk.foreach_fanout( ntk.get_node( new_f ), [&]( const auto& p ) {
+              update_node_level( p );
+            } );
           }
         }
 
@@ -813,33 +796,7 @@ private:
   }
 
 private:
-  void register_events()
-  {
-    if constexpr ( has_level_v<Ntk> )
-    {
-      auto const update_level_of_new_node = [&]( const auto& n ) {
-        ntk.resize_levels();
-        update_node_level( n );
-      };
-
-      auto const update_level_of_existing_node = [&]( node<Ntk> const& n, const auto& old_children ) {
-        (void)old_children;
-        ntk.resize_levels();
-        update_node_level( n );
-      };
-
-      auto const update_level_of_deleted_node = [&]( node<Ntk> const& n ) {
-        ntk.set_level( n, -1 );
-      };
-
-      add_event = ntk.events().register_add_event( update_level_of_new_node );
-      modified_event = ntk.events().register_modified_event( update_level_of_existing_node );
-      delete_event = ntk.events().register_delete_event( update_level_of_deleted_node );
-    }
-  }
-
-  /* maybe it should be moved to depth_view */
-  void update_node_level( node<Ntk> const& n, bool top_most = true )
+  void update_node_level( node<Ntk> const& n )
   {
     if constexpr ( has_level_v<Ntk> )
     {
@@ -859,14 +816,9 @@ private:
       if ( curr_level != max_level )
       {
         ntk.set_level( n, max_level );
-
-        /* update only one more level */
-        if ( top_most )
-        {
-          ntk.foreach_fanout( n, [&]( const auto& p ) {
-            update_node_level( p, false );
-          } );
-        }
+        ntk.foreach_fanout( n, [&]( const auto& p ) {
+          update_node_level( p );
+        } );
       }
     }
   }
@@ -882,11 +834,6 @@ private:
 
   uint32_t _candidates{ 0 };
   uint32_t _estimated_gain{ 0 };
-
-  /* events */
-  std::shared_ptr<typename network_events<Ntk>::add_event_type> add_event;
-  std::shared_ptr<typename network_events<Ntk>::modified_event_type> modified_event;
-  std::shared_ptr<typename network_events<Ntk>::delete_event_type> delete_event;
 };
 
 } /* namespace detail */

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -307,9 +307,7 @@ private:
           {
             propagate_required_rec( ntk.node_to_index( n ), ntk.get_node( new_f ), size, required[n] );
             assert( ntk.level( ntk.get_node( new_f ) ) <= required[n] );
-            ntk.foreach_fanout( ntk.get_node( new_f ), [&]( const auto& p ) {
-              update_node_level( p );
-            } );
+            update_levels( ntk.get_node( new_f ) );
           }
         }
 
@@ -531,9 +529,7 @@ private:
           {
             propagate_required_rec( ntk.node_to_index( n ), ntk.get_node( new_f ), size, required[n] );
             assert( ntk.level( ntk.get_node( new_f ) ) <= required[n] );
-            ntk.foreach_fanout( ntk.get_node( new_f ), [&]( const auto& p ) {
-              update_node_level( p );
-            } );
+            update_levels( ntk.get_node( new_f ) );
           }
         }
 
@@ -796,28 +792,142 @@ private:
   }
 
 private:
-  void update_node_level( node<Ntk> const& n )
+  bool update_level( node<Ntk> const& n )
   {
     if constexpr ( has_level_v<Ntk> )
     {
-      uint32_t curr_level = ntk.level( n );
-
-      uint32_t max_level = 0;
+      uint32_t level = 0;
       ntk.foreach_fanin( n, [&]( const auto& f ) {
         auto const p = ntk.get_node( f );
         auto const fanin_level = ntk.level( p );
-        if ( fanin_level > max_level )
+        if ( fanin_level > level )
         {
-          max_level = fanin_level;
+          level = fanin_level;
         }
       } );
-      ++max_level;
-
-      if ( curr_level != max_level )
+      if ( ntk.level( n ) != level + 1 )
       {
-        ntk.set_level( n, max_level );
-        ntk.foreach_fanout( n, [&]( const auto& p ) {
-          update_node_level( p );
+        ntk.set_level( n, level + 1 );
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void update_levels_fast( node<Ntk> const& n, uint32_t mark, std::vector<node<Ntk>>& deferred )
+  {
+    if ( ntk.visited( n ) == mark )
+    {
+      deferred.push_back( n );
+      return;
+    }
+
+    ntk.set_visited( n, mark );
+
+    if ( update_level( n ) )
+    {
+      ntk.foreach_fanout( n, [&]( auto const& fo ) {
+        update_levels_fast( fo, mark, deferred );
+      } );
+    }
+    // (we may permit second visit ignored if it does not cause update)
+  }
+
+  void mark_tfo( node<Ntk> const& n, uint32_t mark, std::vector<node<Ntk>>& sinks )
+  {
+    if ( ntk.visited( n ) == mark )
+      return;
+
+    ntk.set_visited( n, mark );
+
+    bool f = false;
+    ntk.foreach_fanout( n, [&]( auto const& fo ) {
+      mark_tfo( fo, mark, sinks );
+      f = true;
+    } );
+
+    if ( !f )
+      sinks.push_back( n );
+  }
+
+  void collect_marked_tfi_topo( node<Ntk> const& n, uint32_t mark, uint32_t visited, std::vector<node<Ntk>>& tfi_topo )
+  {
+    if ( ntk.visited( n ) == visited )
+      return;
+
+    if ( ntk.visited( n ) != mark )
+      return;
+
+    ntk.set_visited( n, visited );
+
+    ntk.foreach_fanin( n, [&]( auto const& f ) {
+      auto const p = ntk.get_node( f );
+      collect_marked_tfi_topo( p, mark, visited, tfi_topo );
+    } );
+
+    tfi_topo.push_back( n );
+  }
+
+  void update_levels_naive( node<Ntk> const& n )
+  {
+    if ( update_level( n ) )
+    {
+      ntk.foreach_fanout( n, [&]( auto const& fo ) {
+        update_levels_naive( fo );
+      } );
+    }
+  }
+
+  void update_levels( node<Ntk> const& n )
+  {
+    /*
+    ntk.foreach_fanout( n, [&]( const auto& p ) {
+      update_levels_naive( p );
+    } );
+    return;
+    */
+
+    ntk.incr_trav_id();
+    auto const mark = ntk.trav_id();
+    std::vector<node<Ntk>> deferred;
+
+    ntk.foreach_fanout( n, [&]( const auto& p ) {
+      update_levels_fast( p, mark, deferred );
+    } );
+
+    if ( deferred.empty() )
+      return;
+
+    ntk.incr_trav_id();
+    auto const mark2 = ntk.trav_id();
+    std::vector<node<Ntk>> sinks;
+
+    for ( auto const& p : deferred )
+      mark_tfo( p, mark2, sinks );
+
+    ntk.incr_trav_id();
+    auto const mark3 = ntk.trav_id();
+    std::vector<node<Ntk>> tfi_topo;
+
+    for ( auto const& p : sinks )
+      collect_marked_tfi_topo( p, mark2, mark3, tfi_topo );
+
+    sinks.clear();
+
+    ntk.incr_trav_id();
+    auto const mark4 = ntk.trav_id();
+    for ( auto const& p : deferred )
+      ntk.set_visited( p, mark4 );
+
+    for ( auto const& p : tfi_topo )
+    {
+      if ( ntk.visited( p ) != mark4 )
+        continue;
+
+      if ( update_level( p ) )
+      {
+        ntk.foreach_fanout( p, [&]( const auto& q ) {
+          ntk.set_visited( q, mark4 );
         } );
       }
     }

--- a/include/mockturtle/algorithms/rewrite.hpp
+++ b/include/mockturtle/algorithms/rewrite.hpp
@@ -39,6 +39,7 @@
 #include "../views/color_view.hpp"
 #include "../views/depth_view.hpp"
 #include "../views/fanout_view.hpp"
+#include "../views/topo_view.hpp"
 #include "../views/window_view.hpp"
 #include "cleanup.hpp"
 #include "cut_enumeration.hpp"
@@ -305,7 +306,7 @@ private:
           /* propagate new required to leaves */
           if ( ps.preserve_depth )
           {
-            propagate_required_rec( ntk.node_to_index( n ), ntk.get_node( new_f ), size, required[n] );
+            propagate_required( ntk.get_node( new_f ), required[n] );
             assert( ntk.level( ntk.get_node( new_f ) ) <= required[n] );
             update_levels( ntk.get_node( new_f ) );
           }
@@ -527,7 +528,7 @@ private:
           /* propagate new required to leaves */
           if ( ps.preserve_depth )
           {
-            propagate_required_rec( ntk.node_to_index( n ), ntk.get_node( new_f ), size, required[n] );
+            propagate_required( ntk.get_node( new_f ), required[n] );
             assert( ntk.level( ntk.get_node( new_f ) ) <= required[n] );
             update_levels( ntk.get_node( new_f ) );
           }
@@ -748,35 +749,39 @@ private:
         required[f] = ntk.depth();
       } );
 
-      for ( uint32_t index = ntk.size() - 1; index > ntk.num_pis(); index-- )
-      {
-        node<Ntk> n = ntk.index_to_node( index );
-        uint32_t req = required[n];
+      topo_view<Ntk, false> topo{ ntk };
+
+      topo.foreach_node_reverse( [&]( auto const& n ) {
+        if ( ntk.is_constant( n ) || ntk.is_pi( n ) || required[n] == UINT32_MAX )
+          return;
 
         ntk.foreach_fanin( n, [&]( auto const& f ) {
-          required[f] = std::min( required[f], req - 1 );
+          required[f] = std::min( required[f], ntk.compute_fanin_required( n, f, required[n] ) );
         } );
-      }
+      } );
     }
   }
 
-  void propagate_required_rec( uint32_t root, node<Ntk> const& n, uint32_t size, uint32_t req )
+  void propagate_required_rec( node<Ntk> const& n, uint32_t req )
   {
     if ( ntk.is_constant( n ) || ntk.is_pi( n ) )
       return;
 
-    /* recursively update required time */
+    if ( required[n] <= req )
+      return;
+
+    required[n] = req;
+
     ntk.foreach_fanin( n, [&]( auto const& f ) {
       auto const g = ntk.get_node( f );
-
-      /* recur if it is still a node to explore and to update */
-      if ( ntk.node_to_index( g ) > root && ( ntk.node_to_index( g ) >= size || required[g] >= req ) )
-        propagate_required_rec( root, g, size, req - 1 );
-
-      /* update the required time */
-      if ( ntk.node_to_index( g ) < size )
-        required[g] = std::min( required[g], req - 1 );
+      propagate_required_rec( g, ntk.compute_fanin_required( n, f, req ) );
     } );
+  }
+
+  void propagate_required( node<Ntk> const& n, uint32_t req )
+  {
+    required.resize( UINT32_MAX );
+    propagate_required_rec( n, req );
   }
 
   void clear_cuts_fanout_rec( network_cuts_t& cuts, cut_manager_t& cut_manager, node<Ntk> const& n )

--- a/include/mockturtle/views/depth_view.hpp
+++ b/include/mockturtle/views/depth_view.hpp
@@ -93,7 +93,7 @@ struct depth_view_params
       std::cout << "Depth: " << aig_depth.depth() << "\n";
    \endverbatim
  */
-template<class Ntk, class NodeCostFn = unit_cost<Ntk>, bool has_depth_interface = has_depth_v<Ntk>&& has_level_v<Ntk>&& has_update_levels_v<Ntk>>
+template<class Ntk, class NodeCostFn = unit_cost<Ntk>, bool has_depth_interface = has_depth_v<Ntk> && has_level_v<Ntk> && has_update_levels_v<Ntk>>
 class depth_view
 {
 };
@@ -201,6 +201,20 @@ public:
     return _crit_path[n];
   }
 
+  uint32_t compute_level( node const& n ) const
+  {
+    uint32_t level{ 0 };
+    this->foreach_fanin( n, [&]( auto const& f ) {
+      auto clevel = _levels[f];
+      if ( _ps.count_complements && this->is_complemented( f ) )
+      {
+        clevel++;
+      }
+      level = std::max( level, clevel );
+    } );
+    return level + _cost_fn( *this, n );
+  }
+
   void set_level( node const& n, uint32_t level )
   {
     _levels[n] = level;
@@ -250,17 +264,11 @@ private:
       return _levels[n] = _ps.pi_cost ? _cost_fn( *this, n ) - 1 : 0;
     }
 
-    uint32_t level{ 0 };
     this->foreach_fanin( n, [&]( auto const& f ) {
-      auto clevel = compute_levels( this->get_node( f ) );
-      if ( _ps.count_complements && this->is_complemented( f ) )
-      {
-        clevel++;
-      }
-      level = std::max( level, clevel );
+      compute_levels( this->get_node( f ) );
     } );
 
-    return _levels[n] = level + _cost_fn( *this, n );
+    return _levels[n] = compute_level( n );
   }
 
   void compute_levels()
@@ -331,23 +339,12 @@ private:
   void on_add( node const& n )
   {
     _levels.resize();
-
-    uint32_t level{ 0 };
-    this->foreach_fanin( n, [&]( auto const& f ) {
-      auto clevel = _levels[f];
-      if ( _ps.count_complements && this->is_complemented( f ) )
-      {
-        clevel++;
-      }
-      level = std::max( level, clevel );
-    } );
-
-    _levels[n] = level + _cost_fn( *this, n );
+    _levels[n] = compute_level( n );
   }
 
   depth_view_params _ps;
   node_map<uint32_t, Ntk> _levels;
-  node_map<uint32_t, Ntk> _crit_path;
+  node_map<bool, Ntk> _crit_path;
   uint32_t _depth{};
   NodeCostFn _cost_fn;
 

--- a/include/mockturtle/views/depth_view.hpp
+++ b/include/mockturtle/views/depth_view.hpp
@@ -215,6 +215,17 @@ public:
     return level + _cost_fn( *this, n );
   }
 
+  uint32_t compute_fanin_required( node const& n, signal const& f, uint32_t required ) const
+  {
+    auto cost = _cost_fn( *this, n );
+
+    if ( _ps.count_complements && this->is_complemented( f ) )
+      ++cost;
+
+    assert( required >= cost );
+    return required - cost;
+  }
+
   void set_level( node const& n, uint32_t level )
   {
     _levels[n] = level;

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -250,7 +250,7 @@ TEST_CASE( "Rewrite AIG with zero-gain substitutions preserves depth", "[rewrite
   CHECK( depth_view{ aig }.depth() <= depth_before );
 }
 
-TEST_CASE( "Rewrite updates reconvergent fanout levels and don't cares", "[rewrite]" )
+TEST_CASE( "Rewrite updates reconvergent fanout levels", "[rewrite]" )
 {
   aig_network aig;
   const auto x0 = aig.create_pi();
@@ -267,6 +267,46 @@ TEST_CASE( "Rewrite updates reconvergent fanout levels and don't cares", "[rewri
   const auto n4 = aig.create_and( n2, x5 );
   const auto n5 = aig.create_and( n3, n4 );
   aig.create_po( n5 );
+
+  auto const depth_before = depth_view{ aig }.depth();
+
+  xag_npn_resynthesis<aig_network> resyn;
+  exact_library<aig_network> exact_lib( resyn );
+
+  rewrite_params ps;
+  ps.preserve_depth = true;
+  ps.allow_zero_gain = true;
+  rewrite( aig, exact_lib, ps );
+
+  CHECK( depth_view{ aig }.depth() <= depth_before );
+}
+
+TEST_CASE( "Rewrite updates larger reconvergent fanout levels with don't cares", "[rewrite]" )
+{
+  aig_network aig;
+  const auto x0 = aig.create_pi();
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+  const auto x3 = aig.create_pi();
+  const auto x4 = aig.create_pi();
+  const auto x5 = aig.create_pi();
+  const auto x6 = aig.create_pi();
+  const auto x7 = aig.create_pi();
+
+  const auto n0 = aig.create_and( x2, x3 );
+  const auto n1 = aig.create_and( x1, n0 );
+  const auto n2 = aig.create_and( x0, n1 );
+  const auto n3 = aig.create_and( n2, x4 );
+  const auto n4 = aig.create_and( n2, x5 );
+  const auto n5 = aig.create_and( n3, n4 );
+  const auto n6 = aig.create_and( n5, x6 );
+  const auto n7 = aig.create_and( n5, x7 );
+  const auto n8 = aig.create_and( n6, n7 );
+  const auto n9 = aig.create_and( n3, n8 );
+  const auto n10 = aig.create_and( n4, n8 );
+  const auto n11 = aig.create_and( n9, n10 );
+
+  aig.create_po( n11 );
 
   auto const depth_before = depth_view{ aig }.depth();
 

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -313,12 +313,13 @@ TEST_CASE( "Rewrite updates larger reconvergent fanout levels with don't cares",
   const auto n10 = aig.create_and( n9, x10 );
   const auto n11 = aig.create_and( n10, x11 );
 
-  const auto n12 = aig.create_and( n8, n11 );
-  const auto n13 = aig.create_and( n12, x6 );
-  const auto n14 = aig.create_and( n12, x7 );
-  const auto n15 = aig.create_and( n13, n14 );
+  const auto n12 = aig.create_and( n11, x6 );
+  const auto n13 = aig.create_and( n5, n12 );
+  const auto n14 = aig.create_and( n13, x7 );
+  const auto n15 = aig.create_and( n14, x8 );
+  const auto n16 = aig.create_and( n8, n15 );
 
-  aig.create_po( n15 );
+  aig.create_po( n16 );
 
   auto const depth_before = depth_view{ aig }.depth();
 

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -296,6 +296,9 @@ TEST_CASE( "Rewrite updates larger reconvergent fanout levels with don't cares",
   const auto x9 = aig.create_pi();
   const auto x10 = aig.create_pi();
   const auto x11 = aig.create_pi();
+  const auto x12 = aig.create_pi();
+  const auto x13 = aig.create_pi();
+  const auto x14 = aig.create_pi();
 
   const auto n0 = aig.create_and( x2, x3 );
   const auto n1 = aig.create_and( x1, n0 );
@@ -312,14 +315,16 @@ TEST_CASE( "Rewrite updates larger reconvergent fanout levels with don't cares",
   const auto n9 = aig.create_and( x8, x9 );
   const auto n10 = aig.create_and( n9, x10 );
   const auto n11 = aig.create_and( n10, x11 );
+  const auto n12 = aig.create_and( n11, x12 );
+  const auto n13 = aig.create_and( n12, x13 );
+  const auto n14 = aig.create_and( n13, x14 );
 
-  const auto n12 = aig.create_and( n11, x6 );
-  const auto n13 = aig.create_and( n5, n12 );
-  const auto n14 = aig.create_and( n13, x7 );
-  const auto n15 = aig.create_and( n14, x8 );
-  const auto n16 = aig.create_and( n8, n15 );
+  const auto n15 = aig.create_and( n5, n14 );
+  const auto n16 = aig.create_and( n15, x6 );
+  const auto n17 = aig.create_and( n16, x7 );
+  const auto n18 = aig.create_and( n8, n17 );
 
-  aig.create_po( n16 );
+  aig.create_po( n18 );
 
   auto const depth_before = depth_view{ aig }.depth();
 

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -249,3 +249,35 @@ TEST_CASE( "Rewrite AIG with zero-gain substitutions preserves depth", "[rewrite
 
   CHECK( depth_view{ aig }.depth() <= depth_before );
 }
+
+TEST_CASE( "Rewrite updates reconvergent fanout levels and don't cares", "[rewrite]" )
+{
+  aig_network aig;
+  const auto x0 = aig.create_pi();
+  const auto x1 = aig.create_pi();
+  const auto x2 = aig.create_pi();
+  const auto x3 = aig.create_pi();
+  const auto x4 = aig.create_pi();
+  const auto x5 = aig.create_pi();
+
+  const auto n0 = aig.create_and( x2, x3 );
+  const auto n1 = aig.create_and( x1, n0 );
+  const auto n2 = aig.create_and( x0, n1 );
+  const auto n3 = aig.create_and( n2, x4 );
+  const auto n4 = aig.create_and( n2, x5 );
+  const auto n5 = aig.create_and( n3, n4 );
+  aig.create_po( n5 );
+
+  auto const depth_before = depth_view{ aig }.depth();
+
+  xag_npn_resynthesis<aig_network> resyn;
+  exact_library<aig_network> exact_lib( resyn );
+
+  rewrite_params ps;
+  ps.preserve_depth = true;
+  ps.allow_zero_gain = true;
+  ps.use_dont_cares = true;
+  rewrite( aig, exact_lib, ps );
+
+  CHECK( depth_view{ aig }.depth() <= depth_before );
+}

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -320,11 +320,21 @@ TEST_CASE( "Rewrite updates larger reconvergent fanout levels with don't cares",
   const auto n14 = aig.create_and( n13, x14 );
 
   const auto n15 = aig.create_and( n5, n14 );
-  const auto n16 = aig.create_and( n15, x6 );
-  const auto n17 = aig.create_and( n16, x7 );
-  const auto n18 = aig.create_and( n8, n17 );
+  const auto n16 = aig.create_and( n3, n14 );
+  const auto n17 = aig.create_and( n4, n14 );
+  const auto n18 = aig.create_and( n8, n14 );
 
-  aig.create_po( n18 );
+  const auto n19 = aig.create_and( n15, x6 );
+  const auto n20 = aig.create_and( n16, x7 );
+  const auto n21 = aig.create_and( n17, x8 );
+  const auto n22 = aig.create_and( n18, x9 );
+
+  const auto n23 = aig.create_and( n19, n20 );
+  const auto n24 = aig.create_and( n21, n22 );
+  const auto n25 = aig.create_and( n8, n23 );
+  const auto n26 = aig.create_and( n24, n25 );
+
+  aig.create_po( n26 );
 
   auto const depth_before = depth_view{ aig }.depth();
 

--- a/test/algorithms/rewrite.cpp
+++ b/test/algorithms/rewrite.cpp
@@ -292,21 +292,33 @@ TEST_CASE( "Rewrite updates larger reconvergent fanout levels with don't cares",
   const auto x5 = aig.create_pi();
   const auto x6 = aig.create_pi();
   const auto x7 = aig.create_pi();
+  const auto x8 = aig.create_pi();
+  const auto x9 = aig.create_pi();
+  const auto x10 = aig.create_pi();
+  const auto x11 = aig.create_pi();
 
   const auto n0 = aig.create_and( x2, x3 );
   const auto n1 = aig.create_and( x1, n0 );
   const auto n2 = aig.create_and( x0, n1 );
+
   const auto n3 = aig.create_and( n2, x4 );
   const auto n4 = aig.create_and( n2, x5 );
   const auto n5 = aig.create_and( n3, n4 );
+
   const auto n6 = aig.create_and( n5, x6 );
   const auto n7 = aig.create_and( n5, x7 );
   const auto n8 = aig.create_and( n6, n7 );
-  const auto n9 = aig.create_and( n3, n8 );
-  const auto n10 = aig.create_and( n4, n8 );
-  const auto n11 = aig.create_and( n9, n10 );
 
-  aig.create_po( n11 );
+  const auto n9 = aig.create_and( x8, x9 );
+  const auto n10 = aig.create_and( n9, x10 );
+  const auto n11 = aig.create_and( n10, x11 );
+
+  const auto n12 = aig.create_and( n8, n11 );
+  const auto n13 = aig.create_and( n12, x6 );
+  const auto n14 = aig.create_and( n12, x7 );
+  const auto n15 = aig.create_and( n13, n14 );
+
+  aig.create_po( n15 );
 
   auto const depth_before = depth_view{ aig }.depth();
 


### PR DESCRIPTION
More extensive fix for #687.
Depth view now has public helper functions to compute the node level and required level using the given cost function.
I considered adding ALAP (#555) to depth view, but its recursion seems less efficient than reverse topological order traversal using topo view.

Level update is now first attempted by recurring the fanouts, and when it finds reconvergence, it falls back on topological order traversal from the sink nodes, collected by a couple of fanin/fanout recursions. I hope this is not too bad for performance.

Required level computation now records required levels of new nodes. This greatly helps runtime for MIG rewrite from AIGs of arithmetic functions (e.g., multiplier.aig). Didn't look into detailed profiles, but I guess creating many new nodes in the reconvergence regions caused the problem, requiring multiple traversals through them.

One note is that the current (and previous) required level computation is quite conservative. Update happens only when the previous required level is looser. For exact update, we need to check all fanouts, and the recursive approach will likely encounter performance issue. We may do something similar to what I did for level computation here. Or there may be a cleverer way by maintaining a topological order throughout optimization. I'll leave it for now.