### PR TITLE
Fix mig_inv_propagation crash when PO is a complement of constant or PI

### DIFF
--- a/include/mockturtle/algorithms/mig_inv_propagation.hpp
+++ b/include/mockturtle/algorithms/mig_inv_propagation.hpp
@@ -92,10 +92,16 @@ private:
   {
     // starting from primary outputs, propagate the inversions
     ntk.foreach_po( [this]( auto const& f ) {
+      auto const old_node = ntk.get_node( f );
+      // skip if it is a constant, PI
+      if ( ntk.is_constant( old_node ) || ntk.is_pi( old_node ) )
+      {
+        return;
+      }
+
       if ( ntk.is_complemented( f ) )
       {
         // if it is complemented, invert the node
-        auto const old_node = ntk.get_node( f );
         auto const new_node = invert_node( old_node );
 
         // replace the po with the inverted node
@@ -113,7 +119,7 @@ private:
       else
       {
         // propagate the inversions to the inputs
-        propagate_helper( ntk.get_node( f ) );
+        propagate_helper( old_node );
       }
     } );
   }
@@ -176,6 +182,7 @@ private:
   signal<Ntk> invert_node( const node<Ntk> n )
   {
     signal<Ntk> a, b, c;
+    assert( ntk.fanin_size( n ) == 3 );
 
     ntk.foreach_fanin( n, [&a, &b, &c]( auto const& f, auto idx ) {
       if ( idx == 0 )

--- a/test/algorithms/mig_inv_propagation.cpp
+++ b/test/algorithms/mig_inv_propagation.cpp
@@ -135,6 +135,23 @@ TEST_CASE( "MIG inverter propagation output", "[mig_inv_propagation]" )
   CHECK( st.node_increase == 0 );
 }
 
+TEST_CASE( "MIG inverter propagation complemented constant/PI", "[mig_inv_propagation]" )
+{
+  mig_network mig;
+  mig_inv_propagation_stats st;
+
+  const auto a = mig.create_pi();
+  mig.create_po( !a );
+  mig.create_po( mig.get_constant( true ) );
+
+  mig_inv_propagation( mig, &st );
+
+  CHECK( mig.num_gates() == 0u );
+  CHECK( inv_prop_test::number_of_inverted( mig ) == 2 );
+  CHECK( st.total_gain == 0 );
+  CHECK( st.node_increase == 0 );
+}
+
 TEST_CASE( "MIG inverter propagation complex", "[mig_inv_propagation]" )
 {
   mig_network mig;


### PR DESCRIPTION
This commit fixes an issue that PO is a complement of constant or PI. Actually in `propagate_helper` handled the propagation properly, so simply inserted the same condition `ntk.is_constant(...) || ntk.is_pi(...)`.

Fix https://github.com/lsils/mockturtle/issues/693. 