### PR TITLE
filter cyclic substitution by default

### DIFF
--- a/include/mockturtle/algorithms/window_rewriting.hpp
+++ b/include/mockturtle/algorithms/window_rewriting.hpp
@@ -86,7 +86,7 @@ struct window_rewriting_params
 
   uint64_t max_num_divs{ 100 };
 
-  bool filter_cyclic_substitutions{ false };
+  bool filter_cyclic_substitutions{ true };
 }; /* window_rewriting_params */
 
 struct window_rewriting_stats


### PR DESCRIPTION
Setting this option off sometimes causes logical bugs which should not be allowed at any runtime cost.