### PR TITLE
fix: the bug of genlib_reader parser

### DIFF
--- a/include/mockturtle/io/genlib_reader.hpp
+++ b/include/mockturtle/io/genlib_reader.hpp
@@ -148,6 +148,14 @@ public:
       formula.erase( found, found + 5 );
     }
 
+    /* detect constant gates (e.g., Z=1, Z=0, O=CONST0, O=CONST1) and
+       discard spurious pin names produced by tokenization of "0"/"1" */
+    if ( formula == "0" || formula == "1" )
+    {
+      pp.clear();
+      pin_names.clear();
+    }
+
     uint32_t num_vars = pin_names.size();
 
     kitty::dynamic_truth_table tt{ num_vars };


### PR DESCRIPTION
Fix Log: genlib_reader constant gate parsing (2026-07-07)

File: include/mockturtle/io/genlib_reader.hpp

Problem:
The genlib_reader incorrectly parses constant gates such as TIEHI (Z=1), TIELO (ZN=0), CONST0, and CONST1. During tokenization, the literal "0" or "1" in the expression is treated as a pin name, producing num_vars=1. When create_from_formula is then called with formula="1" and pin_names={"1"}, the literal collides with the pin name and is interpreted as a variable reference, yielding a 1-variable truth table [0,1] — identical to a buffer. This causes tie-high/tie-low cells to be matched as buffers during technology mapping.

Fix:
After CONST stripping (which converts CONST0/CONST1 to "0"/"1") and after tokenization, check whether the formula is a bare "0" or "1". If so, clear the pin vectors and pin names — these spurious entries were produced by mistaking the constant literal for a variable name. The truth table construction still goes through the standard create_from_formula path, which now correctly receives num_vars=0 and empty pin_names, producing a proper 0-variable constant truth table.

Change: 6 lines added after the CONST stripping block and before num_vars / create_from_formula. No existing code paths altered.
tcbn28hpcplusbwp40p140tt0p9v25c.lib:genlib write by abc 
GATE TIEHBWP40P140                 0.25  Z=1;                                                         PIN *  UNKNOWN   1 999     1.00     0.00     1.00     0.00
GATE TIELBWP40P140                 0.25  ZN=0;                                                        PIN *  UNKNOWN   1 999     1.00     0.00     1.00     0.00      
