### PR TITLE
✨ Support sequential networks in write_aiger

### DIFF
--- a/include/mockturtle/io/write_aiger.hpp
+++ b/include/mockturtle/io/write_aiger.hpp
@@ -37,12 +37,14 @@
 
 #pragma once
 
+#include "../networks/sequential.hpp"
 #include "../traits.hpp"
 
+#include <cassert>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <iostream>
-#include <cstring>
 
 namespace mockturtle
 {
@@ -65,10 +67,22 @@ inline void encode( std::vector<unsigned char>& buffer, uint32_t lit )
 
 } // namespace detail
 
-/*! \brief Writes a combinational AIG network in binary AIGER format into a file
+/*! \brief Writes an AIG network in binary AIGER format into a file
  *
  * This function should be only called on "clean" aig_networks, e.g.,
  * immediately after `cleanup_dangling`.
+ *
+ * Sequential networks (e.g., `sequential<aig_network>`) are supported: their
+ * registers are emitted as AIGER latches.  For a network type that does not
+ * implement `foreach_ri`/`num_registers`, a latch count of 0 is written and the
+ * network is asserted to be combinational.
+ *
+ * The binary AIGER format encodes the primary inputs and the register outputs
+ * implicitly, by requiring that variables `1..I` are the primary inputs and
+ * variables `I+1..I+L` are the register outputs.  Networks must therefore be
+ * built by creating all primary inputs first, then all register outputs, before
+ * any gate.  This matches the order in which `aiger_reader` constructs a network
+ * and is checked by an assertion.
  *
  * **Required network functions:**
  * - `num_cis`
@@ -80,7 +94,12 @@ inline void encode( std::vector<unsigned char>& buffer, uint32_t lit )
  * - `is_complemented`
  * - `node_to_index`
  *
- * \param aig Combinational AIG network
+ * **Optional network functions (enable sequential support):**
+ * - `num_registers`
+ * - `foreach_ri`
+ * - `register_at`
+ *
+ * \param aig AIG network
  * \param os Output stream
  */
 template<typename Ntk>
@@ -95,17 +114,65 @@ inline void write_aiger( Ntk const& aig, std::ostream& os )
   static_assert( has_get_node_v<Ntk>, "Ntk does not implement the get_node method" );
   static_assert( has_is_complemented_v<Ntk>, "Ntk does not implement the is_complemented method" );
 
-  assert( aig.is_combinational() && "Network has to be combinational" );
+  /* a network type is treated as sequential if it can report and iterate registers */
+  constexpr bool is_sequential = has_num_registers_v<Ntk> && has_foreach_ri_v<Ntk> && has_foreach_ro_v<Ntk>;
 
   using node = typename Ntk::node;
   using signal = typename Ntk::signal;
+
+  uint32_t num_latches = 0u;
+  if constexpr ( is_sequential )
+  {
+    num_latches = aig.num_registers();
+  }
+  else
+  {
+    assert( aig.is_combinational() && "Network has to be combinational" );
+  }
+
+#ifndef NDEBUG
+  /* the binary format encodes CIs implicitly: PIs must be variables 1..I and
+     register outputs must be variables I+1..I+L */
+  aig.foreach_pi( [&]( node const& n, uint32_t index ) {
+    assert( aig.node_to_index( n ) == index + 1u &&
+            "primary inputs must be the first nodes created in the network" );
+  } );
+  if constexpr ( is_sequential )
+  {
+    aig.foreach_ro( [&]( node const& n, uint32_t index ) {
+      assert( aig.node_to_index( n ) == aig.num_pis() + index + 1u &&
+              "register outputs must be created after all primary inputs and before any gate" );
+    } );
+  }
+#endif
 
   uint32_t const M = aig.num_cis() + aig.num_gates();
 
   /* HEADER */
   char string_buffer[1024];
-  sprintf( string_buffer, "aig %u %u %u %u %u\n", M, aig.num_pis(), /*latches*/ 0, aig.num_pos(), aig.num_gates() );
+  snprintf( string_buffer, sizeof( string_buffer ), "aig %u %u %u %u %u\n", M, aig.num_pis(), num_latches, aig.num_pos(), aig.num_gates() );
   os.write( &string_buffer[0], sizeof( unsigned char ) * std::strlen( string_buffer ) );
+
+  /* LATCHES */
+  if constexpr ( is_sequential )
+  {
+    aig.foreach_ri( [&]( signal const& f, uint32_t index ) {
+      uint32_t const next = 2 * aig.node_to_index( aig.get_node( f ) ) + aig.is_complemented( f );
+
+      /* The reset value is always written explicitly.  An omitted reset value
+         means 0 in the AIGER format, so leaving it out would silently turn an
+         uninitialized register into a zero-initialized one.  A register whose
+         reset is undefined is instead encoded the way the format prescribes:
+         by repeating the latch's own current-state literal. */
+      auto const init = aig.register_at( index ).init;
+      uint32_t const reset = init == register_init::zero  ? 0u
+                             : init == register_init::one ? 1u
+                                                          : 2 * ( aig.num_pis() + index + 1u );
+
+      snprintf( string_buffer, sizeof( string_buffer ), "%u %u\n", next, reset );
+      os.write( &string_buffer[0], sizeof( unsigned char ) * std::strlen( string_buffer ) );
+    } );
+  }
 
   /* POs */
   aig.foreach_po( [&]( signal const& f ) {
@@ -152,6 +219,20 @@ inline void write_aiger( Ntk const& aig, std::ostream& os )
                aig.get_name( aig.make_signal( i ) ).c_str() );
       os.write( &string_buffer[0], sizeof( unsigned char ) * std::strlen( string_buffer ) );
     } );
+
+    /* register outputs carry the latch names, mirroring `on_latch_name` */
+    if constexpr ( is_sequential )
+    {
+      aig.foreach_ro( [&]( node const& i, uint32_t index ) {
+        if ( !aig.has_name( aig.make_signal( i ) ) )
+          return;
+
+        snprintf( string_buffer, sizeof( string_buffer ), "l%u %s\n",
+                  uint32_t( index ),
+                  aig.get_name( aig.make_signal( i ) ).c_str() );
+        os.write( &string_buffer[0], sizeof( unsigned char ) * std::strlen( string_buffer ) );
+      } );
+    }
   }
   if constexpr ( has_has_output_name_v<Ntk> && has_get_output_name_v<Ntk> )
   {
@@ -170,10 +251,14 @@ inline void write_aiger( Ntk const& aig, std::ostream& os )
   os.put( 'c' );
 }
 
-/*! \brief Writes a combinational AIG network in binary AIGER format into a file
+/*! \brief Writes an AIG network in binary AIGER format into a file
  *
  * This function should be only called on "clean" aig_networks, e.g.,
  * immediately after `cleanup_dangling`.
+ *
+ * Sequential networks (e.g., `sequential<aig_network>`) are supported: their
+ * registers are emitted as AIGER latches.  See the `std::ostream` overload for
+ * the requirements this places on the order in which the network was built.
  *
  * **Required network functions:**
  * - `num_cis`
@@ -185,7 +270,12 @@ inline void write_aiger( Ntk const& aig, std::ostream& os )
  * - `is_complemented`
  * - `node_to_index`
  *
- * \param aig Combinational AIG network
+ * **Optional network functions (enable sequential support):**
+ * - `num_registers`
+ * - `foreach_ri`
+ * - `register_at`
+ *
+ * \param aig AIG network
  * \param filename Filename
  */
 template<typename Ntk>

--- a/test/io/write_aiger.cpp
+++ b/test/io/write_aiger.cpp
@@ -1,7 +1,15 @@
 #include <catch.hpp>
 
+#include <mockturtle/io/aiger_reader.hpp>
 #include <mockturtle/io/write_aiger.hpp>
 #include <mockturtle/networks/aig.hpp>
+#include <mockturtle/networks/sequential.hpp>
+#include <mockturtle/views/names_view.hpp>
+
+#include <lorina/aiger.hpp>
+
+#include <sstream>
+#include <string>
 
 template<
     typename T,
@@ -94,4 +102,175 @@ TEST_CASE( "write AIG for XOR into AIGERfile", "[write_aiger]" )
              0x01, 0x02,
              0x63 // comment
          } );
+}
+
+TEST_CASE( "write sequential AIG into AIGER file", "[write_aiger]" )
+{
+  sequential<aig_network> aig;
+
+  const auto a = aig.create_pi();  /* var 1 */
+  const auto ro = aig.create_ro(); /* var 2 */
+
+  const auto f1 = aig.create_and( a, ro ); /* var 3 */
+  aig.create_po( f1 );
+  aig.create_ri( f1 );
+
+  seq_buffer<char> buffer;
+  std::ostream os( &buffer );
+  write_aiger( aig, os );
+
+  CHECK( buffer.data() ==
+         std::vector<char>{
+             0x61, 0x69, 0x67, 0x20, // aig
+             0x33, 0x20,             // M=3 (I+L+A)
+             0x31, 0x20,             // I=1
+             0x31, 0x20,             // L=1
+             0x31, 0x20,             // O=1
+             0x31, 0x0a,             // A=1
+             0x36, 0x20, 0x34, 0x0a, // 1 latch, reset == own literal (undefined)
+             0x36, 0x0a,             // 1 PO
+             0x02, 0x02,             // 1 AND gate
+             0x63                    // comment
+         } );
+}
+
+TEST_CASE( "write sequential AIG with register initialization values", "[write_aiger]" )
+{
+  for ( uint8_t const init : { uint8_t( 0 ), uint8_t( 1 ) } )
+  {
+    sequential<aig_network> aig;
+
+    const auto a = aig.create_pi();
+    const auto ro = aig.create_ro();
+
+    const auto f1 = aig.create_and( a, ro );
+    aig.create_po( f1 );
+    aig.create_ri( f1 );
+
+    mockturtle::register_t reg;
+    reg.init = init;
+    aig.set_register( 0, reg );
+
+    seq_buffer<char> buffer;
+    std::ostream os( &buffer );
+    write_aiger( aig, os );
+
+    /* the latch line carries an explicit reset value: "6 <init>\n" */
+    std::vector<char> expected{
+        0x61, 0x69, 0x67, 0x20, // aig
+        0x33, 0x20,             // M=3
+        0x31, 0x20,             // I=1
+        0x31, 0x20,             // L=1
+        0x31, 0x20,             // O=1
+        0x31, 0x0a,             // A=1
+        0x36, 0x20              // latch next state, followed by reset value
+    };
+    expected.push_back( static_cast<char>( '0' + init ) );
+    expected.insert( expected.end(), { 0x0a, 0x36, 0x0a, 0x02, 0x02, 0x63 } );
+
+    CHECK( buffer.data() == expected );
+  }
+}
+
+TEST_CASE( "write and read back a sequential AIG in AIGER format", "[write_aiger]" )
+{
+  sequential<aig_network> aig;
+
+  const auto a = aig.create_pi();
+  const auto b = aig.create_pi();
+  const auto ro0 = aig.create_ro();
+  const auto ro1 = aig.create_ro();
+
+  const auto f1 = aig.create_and( a, ro0 );
+  const auto f2 = aig.create_and( b, ro1 );
+  const auto f3 = aig.create_and( f1, f2 );
+
+  aig.create_po( f3 );
+  aig.create_ri( f1 );
+  aig.create_ri( f2 );
+
+  mockturtle::register_t reg0;
+  reg0.init = 0u;
+  aig.set_register( 0, reg0 );
+  mockturtle::register_t reg1;
+  reg1.init = 1u;
+  aig.set_register( 1, reg1 );
+
+  std::ostringstream out;
+  write_aiger( aig, out );
+
+  sequential<aig_network> read_aig;
+  std::istringstream in( out.str() );
+  CHECK( lorina::read_aiger( in, aiger_reader( read_aig ) ) == lorina::return_code::success );
+
+  CHECK( read_aig.num_pis() == aig.num_pis() );
+  CHECK( read_aig.num_pos() == aig.num_pos() );
+  CHECK( read_aig.num_registers() == aig.num_registers() );
+  CHECK( read_aig.num_gates() == aig.num_gates() );
+  CHECK( read_aig.register_at( 0 ).init == 0u );
+  CHECK( read_aig.register_at( 1 ).init == 1u );
+}
+
+TEST_CASE( "write latch names into the AIGER symbol table", "[write_aiger]" )
+{
+  names_view<sequential<aig_network>> aig;
+
+  const auto a = aig.create_pi();
+  const auto ro = aig.create_ro();
+
+  const auto f1 = aig.create_and( a, ro );
+  aig.create_po( f1 );
+  aig.create_ri( f1 );
+
+  aig.set_name( a, "x0" );
+  aig.set_name( ro, "state" );
+  aig.set_output_name( 0, "y0" );
+
+  std::ostringstream out;
+  write_aiger( aig, out );
+
+  const auto written = out.str();
+  CHECK( written.find( "i0 x0\n" ) != std::string::npos );
+  CHECK( written.find( "l0 state\n" ) != std::string::npos );
+  CHECK( written.find( "o0 y0\n" ) != std::string::npos );
+
+  /* the names must survive a round trip through the reader */
+  names_view<sequential<aig_network>> read_aig;
+  std::istringstream in( written );
+  CHECK( lorina::read_aiger( in, aiger_reader( read_aig ) ) == lorina::return_code::success );
+
+  CHECK( read_aig.get_name( read_aig.make_signal( read_aig.pi_at( 0 ) ) ) == "x0" );
+  CHECK( read_aig.get_name( read_aig.make_signal( read_aig.ro_at( 0 ) ) ) == "state" );
+  CHECK( read_aig.get_output_name( 0 ) == "y0" );
+}
+
+TEST_CASE( "write sequential AIG with an undefined register reset", "[write_aiger]" )
+{
+  sequential<aig_network> aig;
+
+  const auto a = aig.create_pi();
+  const auto ro = aig.create_ro();
+
+  const auto f1 = aig.create_and( a, ro );
+  aig.create_po( f1 );
+  aig.create_ri( f1 );
+
+  /* the register keeps its default (undefined) reset value */
+  CHECK( aig.register_at( 0 ).init != 0u );
+  CHECK( aig.register_at( 0 ).init != 1u );
+
+  std::ostringstream out;
+  write_aiger( aig, out );
+
+  /* an undefined reset is encoded by repeating the latch's own literal, not by
+     omitting the field -- an omitted field means 0 in the AIGER format */
+  CHECK( out.str().find( "6 4\n" ) != std::string::npos );
+
+  sequential<aig_network> read_aig;
+  std::istringstream in( out.str() );
+  CHECK( lorina::read_aiger( in, aiger_reader( read_aig ) ) == lorina::return_code::success );
+
+  CHECK( read_aig.num_registers() == 1u );
+  CHECK( read_aig.register_at( 0 ).init != 0u );
+  CHECK( read_aig.register_at( 0 ).init != 1u );
 }


### PR DESCRIPTION
> **Part of a three-PR chain**, please review in this order:
> #700 (AIGER reader fixes) → #701 (register initialization) → **#699 (this PR)**.
> Each builds on the previous one; the diff shown here collapses to the sequential
> `write_aiger` change alone once the other two land.

## Description

`write_aiger` hardcoded a latch count of `0` and asserted the network was combinational,
so a `sequential<aig_network>` could be passed in but silently lost its registers — they
degrade into extra PI/PO pairs, and the assertion is a no-op in release builds.

This adds real latch support, gated on `num_registers` / `foreach_ri` / `foreach_ro` via
`if constexpr`. The combinational path is untouched and still produces byte-identical
output — the two pre-existing byte-exact tests pass unchanged.

### Reset values

Reset values are now always written explicitly, which matters more than it first looks:

- An **omitted** reset field means `0` in the AIGER format, so omitting it for an
  uninitialized register would silently convert it into a zero-initialized one.
- An **undefined** reset is therefore encoded the way the format prescribes: by
  repeating the latch's own current-state literal.

Verified in both directions — ABC reports the expected `Init0 = 1. Init1 = 1. InitDC = 1.`
for a network carrying one register of each kind, and the output round-trips through
`aiger_reader` preserving register count, reset values, and names.

### CI ordering

The binary format encodes CIs implicitly, requiring variables `1..I` to be the primary
inputs and `I+1..I+L` the register outputs. That invariant was previously assumed
silently; it is now documented and checked by a debug assertion.

### Drive-by

Added the missing `<cassert>` include. The header uses `assert` but only ever compiled
because its includers happened to provide it — a TU that includes `write_aiger.hpp`
first currently fails to build.

## Testing

Five new test cases in `test/io/write_aiger.cpp` (26 assertions total), passing in both
debug and `NDEBUG` builds:

- byte-exact output for a sequential AIG with an undefined reset
- byte-exact output for reset values `0` and `1`
- write → `aiger_reader` round trip preserving PI/PO/register counts and reset values
- latch names emitted as `l<n>` and surviving a round trip
- undefined reset encoded as the self-literal and read back as undefined

---

Context: this came out of building a Python-side ABC bridge in
[aigverse](https://github.com/marcelwa/aigverse), where sequential designs could not be
handed to ABC at all because there was no way to write them. Offering it upstream since
it seems generally useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbUqcnZayPooFgekEXVSjz
