### PR TITLE
🐛 Fix reading sequential AIGER files produced by ABC

### DIFF
--- a/include/mockturtle/io/aiger_reader.hpp
+++ b/include/mockturtle/io/aiger_reader.hpp
@@ -97,9 +97,10 @@ public:
       {
         if ( !std::get<1>( out ).empty() )
         {
-          _ntk.set_output_name( output_id++, std::get<1>( out ) );
+          _ntk.set_output_name( output_id, std::get<1>( out ) );
         }
       }
+      ++output_id;
       _ntk.create_po( signal );
     }
 
@@ -218,13 +219,33 @@ public:
   {
     (void)index;
     assert( index == outputs.size() );
+    ++_num_outputs;
     outputs.emplace_back( lit, "" );
+  }
+
+  void on_bad_state( uint32_t index, uint32_t lit ) const override
+  {
+    /* A bad-state property is a signal that must never become 1. Logic networks
+       have no notion of properties, so it is kept as a primary output; dropping
+       it would silently discard logic. Writers that emit the AIGER 1.9 extended
+       header move the primary outputs into this section -- ABC does so for any
+       design with a non-zero latch initialization -- so reading them back as
+       primary outputs restores the original network. */
+    (void)index;
+    outputs.emplace_back( lit, "" );
+  }
+
+  void on_bad_state_name( uint32_t pos, const std::string& name ) const override
+  {
+    /* bad states are appended behind the primary outputs, see `on_bad_state` */
+    std::get<1>( outputs[_num_outputs + pos] ) = name;
   }
 
 private:
   Ntk& _ntk;
 
   mutable uint32_t _num_inputs{ 0 };
+  mutable uint32_t _num_outputs{ 0 };
   mutable std::vector<std::tuple<unsigned, std::string>> outputs;
   mutable std::vector<typename Ntk::signal> signals;
   mutable std::vector<std::tuple<unsigned, int8_t, std::string>> latches;

--- a/lib/lorina/lorina/aiger.hpp
+++ b/lib/lorina/lorina/aiger.hpp
@@ -520,16 +520,24 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
     const auto index = std::atol( std::string(tokens[0u]).c_str() ) / 2u;
     const auto next_lit = std::atol( std::string(tokens[1u]).c_str() );
 
-    aiger_reader::latch_init_value init_value = aiger_reader::latch_init_value::NONDETERMINISTIC;
+    /* An omitted reset value means 0: the original AIGER format initialized every
+       latch to zero, and the reset field added in AIGER 1.9 is optional. A reset
+       value that is neither 0 nor 1 -- by convention the latch's own literal --
+       denotes an undefined initial value. */
+    aiger_reader::latch_init_value init_value = aiger_reader::latch_init_value::ZERO;
     if ( tokens.size() == 3u )
     {
       if ( tokens[2u] == "0" )
       {
         init_value = aiger_reader::latch_init_value::ZERO;
       }
-      else if ( tokens[1u] == "1" )
+      else if ( tokens[2u] == "1" )
       {
         init_value = aiger_reader::latch_init_value::ONE;
+      }
+      else
+      {
+        init_value = aiger_reader::latch_init_value::NONDETERMINISTIC;
       }
     }
 
@@ -754,7 +762,9 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
     detail::getline( in, line );
     const auto tokens = detail::split( line, " " );
     const auto next = std::atoi( tokens[0u].c_str() );
-    aiger_reader::latch_init_value init_value = aiger_reader::latch_init_value::NONDETERMINISTIC;
+    /* See the ASCII reader above: an omitted reset value means 0, and a value that
+       is neither 0 nor 1 denotes an undefined initial value. */
+    aiger_reader::latch_init_value init_value = aiger_reader::latch_init_value::ZERO;
     if ( tokens.size() == 2u )
     {
       if ( tokens[1u] == "0" )
@@ -764,6 +774,10 @@ static std::regex fairness( R"(^f(\d+) (.*)$)" );
       else if ( tokens[1u] == "1" )
       {
         init_value = aiger_reader::latch_init_value::ONE;
+      }
+      else
+      {
+        init_value = aiger_reader::latch_init_value::NONDETERMINISTIC;
       }
     }
 

--- a/test/io/aiger_reader.cpp
+++ b/test/io/aiger_reader.cpp
@@ -9,6 +9,8 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 using namespace mockturtle;
 
@@ -115,4 +117,107 @@ TEST_CASE( "read a sequential ASCII Aiger file into an AIG network", "[aiger_rea
   CHECK( named_aig.get_name( aig.ri_at( 0 ) ) == "barfoo_next" );
   CHECK( named_aig.get_output_name( 0 ) == "foobar" );
   CHECK( named_aig.get_output_name( 1 ) == "barbar" );
+}
+
+TEST_CASE( "read latches with omitted reset values", "[aiger_reader]" )
+{
+  /* An omitted reset value means 0. The original AIGER format initialized every
+     latch to zero and the reset field added in 1.9 is optional, so a writer that
+     leaves it out -- ABC does -- must not be read as an undefined value. */
+  sequential<aig_network> aig;
+
+  std::string file{ "aag 3 1 1 1 1\n"
+                    "2\n"
+                    "4 6\n"
+                    "6\n"
+                    "6 2 4\n" };
+
+  std::istringstream in( file );
+  CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
+
+  CHECK( aig.num_registers() == 1u );
+  CHECK( aig.register_at( 0 ).init == 0u );
+}
+
+TEST_CASE( "read latches with explicit reset values", "[aiger_reader]" )
+{
+  for ( auto const& [token, expected] : std::vector<std::pair<std::string, uint8_t>>{ { "0", 0u }, { "1", 1u } } )
+  {
+    sequential<aig_network> aig;
+
+    std::string file{ "aag 3 1 1 1 1\n"
+                      "2\n"
+                      "4 6 " +
+                      token + "\n"
+                              "6\n"
+                              "6 2 4\n" };
+
+    std::istringstream in( file );
+    CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
+
+    CHECK( aig.num_registers() == 1u );
+    CHECK( aig.register_at( 0 ).init == expected );
+  }
+}
+
+TEST_CASE( "read a latch with an undefined reset value", "[aiger_reader]" )
+{
+  /* a reset value that is neither 0 nor 1 -- by convention the latch's own
+     literal -- denotes an undefined initial value */
+  sequential<aig_network> aig;
+
+  std::string file{ "aag 3 1 1 1 1\n"
+                    "2\n"
+                    "4 6 4\n"
+                    "6\n"
+                    "6 2 4\n" };
+
+  std::istringstream in( file );
+  CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
+
+  CHECK( aig.num_registers() == 1u );
+  CHECK( aig.register_at( 0 ).init != 0u );
+  CHECK( aig.register_at( 0 ).init != 1u );
+}
+
+TEST_CASE( "read bad state properties as primary outputs", "[aiger_reader]" )
+{
+  /* Writers emitting the AIGER 1.9 extended header move the primary outputs into
+     the bad-state section; ABC does so for any design with a non-zero latch
+     initialization. Dropping them would silently discard logic. */
+  sequential<aig_network> aig;
+
+  std::string file{ "aag 3 1 1 0 1 1\n"
+                    "2\n"
+                    "4 6 1\n"
+                    "6\n"
+                    "6 2 4\n" };
+
+  std::istringstream in( file );
+  CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
+
+  CHECK( aig.num_pis() == 1u );
+  CHECK( aig.num_registers() == 1u );
+  CHECK( aig.num_pos() == 1u );
+  CHECK( aig.register_at( 0 ).init == 1u );
+}
+
+TEST_CASE( "read output names when only some outputs are named", "[aiger_reader]" )
+{
+  /* the symbol table is sparse, so a name must land on the output it belongs to */
+  names_view<aig_network> aig;
+
+  std::string file{ "aag 3 2 0 2 1\n"
+                    "2\n"
+                    "4\n"
+                    "2\n"
+                    "6\n"
+                    "6 2 4\n"
+                    "o1 second\n" };
+
+  std::istringstream in( file );
+  CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
+
+  CHECK( aig.num_pos() == 2u );
+  CHECK( aig.get_output_name( 1 ) == "second" );
 }


### PR DESCRIPTION
> **Part of a three-PR chain**, please review in this order:
> **#700 (this PR)** → #701 (register initialization) → #699 (sequential `write_aiger`).
> This one is the base and stands on its own.

## Description

A sequential network written by ABC cannot currently be read back correctly. Three
separate defects in the AIGER latch and output handling.

### 1. Omitted latch reset values are read as undefined

Both the binary and the ASCII reader default to `NONDETERMINISTIC` when a latch line
carries no reset field. The format specifies the opposite — AIGER's `FORMAT` document
states *"Latches are always assumed to be initialized to zero"*, and the reset field
added in 1.9 is optional, so its absence means `0`.

ABC relies on this and omits the field for zero-initialized latches, so **every**
zero-initialized register comes back undefined. This affects even the simplest
sequential round trip.

### 2. The ASCII reader compares the wrong token

```cpp
if ( tokens[2u] == "0" )      { ... ZERO; }
else if ( tokens[1u] == "1" ) { ... ONE;  }   // tokens[1u] is the next-state literal
```

An explicit reset of `1` is therefore never recognized, and a latch whose *next-state
literal* happens to be `1` is wrongly reported as one-initialized.

### 3. Bad state properties are dropped

A writer emitting the AIGER 1.9 extended header moves the primary outputs into the
bad-state section. ABC does this for any design with a non-zero latch initialization —
from `ioWriteAiger.c`:

```c
fExtended = Abc_NtkConstrNum(pNtk);
Abc_NtkForEachLatch( pNtk, pObj, i )
    if ( !Abc_LatchIsInit0(pObj) ) { fExtended = 1; break; }
```

`on_bad_state` is not overridden, so those outputs disappear and the network comes back
with none at all. They are now kept as primary outputs — which is what they were —
together with their names from the symbol table.

### Drive-by

The `aiger_reader` destructor advances the output index only for outputs that carry a
name, so with a sparse symbol table every name after the first unnamed output lands on
the wrong output.

## Verification

End to end against ABC, with a network carrying three registers initialized to `0`, `1`,
and undefined, put through `resyn2`:

```
before:  read ok=1  pis=3 pos=0 regs=3 gates=5  init0=255 init1=1   <- output lost, init corrupted
after:   read ok=1  pis=3 pos=1 regs=3 gates=5  init0=0   init1=1   <- intact
```

Five new test cases in `test/io/aiger_reader.cpp` cover omitted, explicit `0`/`1`, and
undefined resets, the extended header with a bad state, and the sparse symbol table.

## Notes

- The reset-value fixes touch the vendored copy of lorina in `lib/lorina`. Happy to open
  the equivalent change against `hriener/lorina` as well — let me know if you would
  prefer to take it that way round.
- AIGER **constraints** remain ignored. They are assumptions rather than outputs, so
  mapping them onto primary outputs would change the meaning of the network.

---

Context: this came out of building a Python-side ABC bridge in
[aigverse](https://github.com/marcelwa/aigverse), where sequential designs survived the
trip *to* ABC but not back. Companion to #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbUqcnZayPooFgekEXVSjz
