### PR TITLE
♻️ Unify how register initialization is represented

### DIFF
--- a/include/mockturtle/io/aiger_reader.hpp
+++ b/include/mockturtle/io/aiger_reader.hpp
@@ -210,7 +210,11 @@ public:
     if constexpr ( has_create_ri_v<Ntk> && has_create_ro_v<Ntk> )
     {
       (void)index;
-      int8_t r = reset == latch_init_value::NONDETERMINISTIC ? -1 : ( reset == latch_init_value::ONE ? 1 : 0 );
+      /* AIGER cannot express `unknown`: a latch either has a defined reset value
+         or is explicitly nondeterministic. */
+      uint8_t const r = reset == latch_init_value::NONDETERMINISTIC ? register_init::dont_care
+                        : reset == latch_init_value::ONE            ? register_init::one
+                                                                    : register_init::zero;
       latches.push_back( std::make_tuple( next, r, "" ) );
     }
   }
@@ -248,7 +252,7 @@ private:
   mutable uint32_t _num_outputs{ 0 };
   mutable std::vector<std::tuple<unsigned, std::string>> outputs;
   mutable std::vector<typename Ntk::signal> signals;
-  mutable std::vector<std::tuple<unsigned, int8_t, std::string>> latches;
+  mutable std::vector<std::tuple<unsigned, uint8_t, std::string>> latches;
 };
 
 } /* namespace mockturtle */

--- a/include/mockturtle/io/blif_reader.hpp
+++ b/include/mockturtle/io/blif_reader.hpp
@@ -174,24 +174,24 @@ public:
         }
       }
 
-      uint32_t r = 3;
+      uint8_t r = register_init::unknown;
       if ( reset )
       {
         switch ( *reset )
         {
         case latch_init_value::NONDETERMINISTIC:
         {
-          r = 2;
+          r = register_init::dont_care;
         }
         break;
         case latch_init_value::ONE:
         {
-          r = 1;
+          r = register_init::one;
         }
         break;
         case latch_init_value::ZERO:
         {
-          r = 0;
+          r = register_init::zero;
         }
         break;
         default:

--- a/include/mockturtle/io/write_blif.hpp
+++ b/include/mockturtle/io/write_blif.hpp
@@ -208,7 +208,7 @@ void write_blif( Ntk const& ntk, std::ostream& os, write_blif_params const& ps =
                 topo_ntk.get_output_name( index ) 
               : latch_name;
             std::string const ro_name = topo_ntk.has_name( ro_signal ) ? topo_ntk.get_name( ro_signal ) : fmt::format( "new_n{}", topo_ntk.get_node( ro_signal ) );
-            os << fmt::format( "{} {} {} {} {}\n", ri_name, ro_name, latch_info.type, latch_info.control, latch_info.init );
+            os << fmt::format( "{} {} {} {} {}\n", ri_name, ro_name, latch_info.type, latch_info.control, register_init::sanitize( latch_info.init ) );
             defined_names.insert( ro_name ); /* we should not have collision here */
           }
           else
@@ -217,7 +217,7 @@ void write_blif( Ntk const& ntk, std::ostream& os, write_blif_params const& ps =
                 fmt::format( "new_n{}", topo_ntk.get_node( topo_ntk.ri_at( latch_idx ) ) )
               : fmt::format( "li{}", latch_idx );
             std::string const ro_name = fmt::format( "new_n{}", topo_ntk.get_node( ro_signal ) );
-            os << fmt::format( "{} {} {} {} {}\n", ri_name, ro_name, latch_info.type, latch_info.control, latch_info.init );
+            os << fmt::format( "{} {} {} {} {}\n", ri_name, ro_name, latch_info.type, latch_info.control, register_init::sanitize( latch_info.init ) );
             defined_names.insert( ro_name ); /* we should not have collision here */
           }
           latch_idx++;

--- a/include/mockturtle/networks/sequential.hpp
+++ b/include/mockturtle/networks/sequential.hpp
@@ -79,13 +79,50 @@ inline constexpr bool is_aig_like_v = is_aig_like<Ntk>::value;
 
 } // namespace detail
 
+/*! \brief Initial (reset) values a register can take
+ *
+ * The encoding follows the initialization field of the BLIF `.latch` statement,
+ * which is the most expressive of the supported file formats. Formats that
+ * cannot express every state map onto the closest one: AIGER, for instance, has
+ * no counterpart for `unknown` and encodes a latch without a defined reset as
+ * `dont_care`.
+ *
+ * Only `zero` and `one` denote a defined reset value. Code reacting to a
+ * register's initialization should therefore test for those two explicitly
+ * rather than comparing against `dont_care` or `unknown`, so that it stays
+ * correct if a format introduces further undefined states.
+ */
+struct register_init
+{
+  /*! \brief The register is reset to 0 */
+  static constexpr uint8_t zero = 0u;
+  /*! \brief The register is reset to 1 */
+  static constexpr uint8_t one = 1u;
+  /*! \brief Any initial value is acceptable */
+  static constexpr uint8_t dont_care = 2u;
+  /*! \brief No initial value is specified */
+  static constexpr uint8_t unknown = 3u;
+
+  /*! \brief Returns whether `value` denotes a defined reset value */
+  static constexpr bool is_defined( uint8_t value )
+  {
+    return value == zero || value == one;
+  }
+
+  /*! \brief Returns `value` if it is a valid initialization, `unknown` otherwise */
+  static constexpr uint8_t sanitize( uint8_t value )
+  {
+    return value <= unknown ? value : unknown;
+  }
+};
+
 /*! \brief Register information */
 struct register_t
 {
   /*! \brief Control (clocking or enabling) signal */
   std::string control = "";
-  /*! \brief Initial (reset) value */
-  uint8_t init = 3;
+  /*! \brief Initial (reset) value, see `register_init` */
+  uint8_t init = register_init::unknown;
   /*! \brief Type of register or latch (active high/low, rising/falling edge) */
   std::string type = "";
 };

--- a/test/io/aiger_reader.cpp
+++ b/test/io/aiger_reader.cpp
@@ -221,3 +221,28 @@ TEST_CASE( "read output names when only some outputs are named", "[aiger_reader]
   CHECK( aig.num_pos() == 2u );
   CHECK( aig.get_output_name( 1 ) == "second" );
 }
+
+TEST_CASE( "register initialization stays valid across formats", "[aiger_reader]" )
+{
+  /* `write_blif` emits the initialization verbatim, and the BLIF `.latch`
+     statement accepts only the four values of `register_init`. A reader that
+     produced anything else would silently write a malformed BLIF file. */
+  for ( auto const& [latch_line, expected] :
+        std::vector<std::pair<std::string, uint8_t>>{
+            { "4 6", register_init::zero }, /* omitted reset means 0 */
+            { "4 6 0", register_init::zero },
+            { "4 6 1", register_init::one },
+            { "4 6 4", register_init::dont_care } /* self-literal: undefined */ } )
+  {
+    sequential<aig_network> aig;
+
+    std::string const file = "aag 3 1 1 1 1\n2\n" + latch_line + "\n6\n6 2 4\n";
+    std::istringstream in( file );
+    CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
+
+    REQUIRE( aig.num_registers() == 1u );
+    CHECK( aig.register_at( 0 ).init == expected );
+    CHECK( aig.register_at( 0 ).init <= register_init::unknown );
+    CHECK( register_init::is_defined( aig.register_at( 0 ).init ) == ( expected <= register_init::one ) );
+  }
+}


### PR DESCRIPTION
> **Part of a three-PR chain**, please review in this order:
> #700 (AIGER reader fixes) → **#701 (this PR)** → #699 (sequential `write_aiger`).
> Once #700 lands this diff reduces to the register-initialization change alone.
>
> The dependency on #700 is real rather than incidental: on `master` the ASCII reader
> compares the wrong token, so an explicit latch reset of `1` is never recognised and the
> mapping this PR introduces cannot be observed correctly.

## Description

`register_t::init` carries **three** different encodings of "undefined" at the same time:

| Surface | "undefined" is |
| --- | --- |
| `register_t` default | `3` |
| `blif_reader` | `2` (nondeterministic) / `3` (unspecified) |
| `aiger_reader` | `255` |

The `255` is not a choice. The reader computes `int8_t r = ... ? -1 : ...` and assigns it
into a `uint8_t` field, so `-1` narrows to `255`.

### This corrupts output

`write_blif` emits the initialization verbatim, and the BLIF `.latch` statement accepts
only `0`, `1`, `2` and `3`. So a sequential AIGER file with an undefined latch reset, read
back and written as BLIF, produces:

```
.latch li0 new_n2   255
```

which no BLIF consumer accepts — ABC included. This is reproducible on `master` today.

## Approach

Introduce `register_init` with the four documented values, following the BLIF `.latch`
field since it is the most expressive of the supported formats, and use it consistently
across `aiger_reader`, `blif_reader` and `write_blif`. AIGER has no counterpart for
`unknown`, so a latch without a defined reset maps to `dont_care`.

Two helpers come with it:

- `register_init::is_defined( value )` expresses the test callers actually want — whether
  a reset is `0` or `1` — so code stays correct if a format ever introduces further
  undefined states.
- `register_init::sanitize( value )` keeps `write_blif` from emitting a value the format
  cannot represent, whatever a caller may have stored.

`write_aiger` is updated in #699 rather than here, since the latch-writing code it touches
is introduced by that PR.

## Compatibility

The only value that changes is the one AIGER produced for a nondeterministic latch,
`255` → `2`. Comparisons of the form `init > 1` or `init != 0 && init != 1` are
unaffected; only code testing against `255` would notice, and that value was never
intentional API.

## Verification

The AIGER file that previously produced `255` now yields `.latch li0 new_n2   2`, which
ABC reads back as `Total latches = 1. Init0 = 0. Init1 = 0. InitDC = 1.`

New test case covers explicit `0`/`1` and self-literal resets, asserting each stays within
the representable range and that `is_defined` agrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbUqcnZayPooFgekEXVSjz
