### PR TITLE
write_blif: name CIs after the node, not the topological index

### DIFF
--- a/include/mockturtle/io/write_blif.hpp
+++ b/include/mockturtle/io/write_blif.hpp
@@ -143,16 +143,24 @@ void write_blif( Ntk const& ntk, std::ostream& os, write_blif_params const& ps =
     topo_ntk.foreach_ci( [&]( auto const& n, auto index ) {
       if ( ( ( index + 1 ) <= topo_ntk.num_cis() - num_latches ) )
       {
+        /* NOTE: the default name MUST be derived from the node itself, not from
+         * `node_to_index`. `topo_view` reimplements `node_to_index` as the position in the
+         * topological order, whereas every other place in this writer (fanin references,
+         * PO bridges) names a node `pi<node>` / `new_n<node>` using the raw node id. When
+         * the network's CI node ids are not contiguous -- which happens for a `klut_network`
+         * produced by `lut_map` -- the two disagree, and the resulting BLIF declares inputs
+         * that nothing reads while referencing inputs that were never declared. ABC ties
+         * those to constant 0 and the netlist is silently wrong. */
         if constexpr ( has_has_name_v<Ntk> && has_get_name_v<Ntk> )
         {
-          signal<Ntk> const s = topo_ntk.make_signal( topo_ntk.node_to_index( n ) );
+          signal<Ntk> const s = topo_ntk.make_signal( n );
           std::string const input_name = topo_ntk.has_name( s ) ? topo_ntk.get_name( s ) : fmt::format( "pi{}", topo_ntk.get_node( s ) );
           os << input_name << ' ';
           defined_names.insert( input_name ); /* we should not have collision here */
         }
         else
         {
-          std::string const input_name = fmt::format( "pi{}", topo_ntk.node_to_index( n ) );
+          std::string const input_name = fmt::format( "pi{}", n );
           os << input_name << ' ';
           defined_names.insert( input_name ); /* we should not have collision here */
         }

--- a/test/io/write_blif.cpp
+++ b/test/io/write_blif.cpp
@@ -548,3 +548,42 @@ TEST_CASE( "write a sequential k-LUT with name view and rename ris", "[write_bli
   ps.rename_ri_using_node = false;
   blif_read_after_write_test( klut, ps );
 }
+TEST_CASE( "write a k-LUT with non-contiguous CI node ids into BLIF file", "[write_blif]" )
+{
+  /* Creating a primary input after a gate leaves gaps in the CI node ids, which is also
+     what `lut_map` produces on larger networks. The names the writer declares in `.inputs`
+     must be the same ones it references in the `.names` bodies. */
+  klut_network klut;
+
+  auto const a = klut.create_pi();
+  auto const b = klut.create_pi();
+  auto const f = klut.create_and( a, b );
+  auto const c = klut.create_pi();
+  auto const g = klut.create_and( f, c );
+  klut.create_po( g );
+
+  std::vector<klut_network::node> cis;
+  klut.foreach_ci( [&]( auto const& n ) { cis.push_back( n ); } );
+  REQUIRE( cis.size() == 3u );
+  CHECK( cis[2] != cis[1] + 1 ); /* the gap this test is about */
+
+  std::ostringstream out;
+  write_blif( klut, out );
+
+  CHECK( out.str() == ".model top\n"
+                      ".inputs pi2 pi3 pi5 \n"
+                      ".outputs po0 \n"
+                      ".names new_n0\n"
+                      "0\n"
+                      ".names new_n1\n"
+                      "1\n"
+                      ".names pi2 pi3 new_n4\n"
+                      "11 1\n"
+                      ".names new_n4 pi5 new_n6\n"
+                      "11 1\n"
+                      ".names new_n6 po0\n"
+                      "1 1\n"
+                      ".end\n" );
+
+  blif_read_after_write_test( klut );
+}


### PR DESCRIPTION
`write_blif` names combinational inputs `pi{topo_ntk.node_to_index(n)}`, while every other reference in the same writer — fanin lists and the PO bridges — names a node by its raw id. `topo_view` reimplements `node_to_index` as the position in the topological order, so the two agree only for as long as the CI node ids happen to be contiguous.

They are not contiguous in general. A `klut_network` produced by `lut_map` has gaps in them, and so does any network where a primary input is created after a gate.

### What it produces

The smallest case — two PIs, an AND, then a third PI:

```cpp
klut_network klut;
auto const a = klut.create_pi();
auto const b = klut.create_pi();
auto const f = klut.create_and( a, b );
auto const c = klut.create_pi();       // CI ids are now 2, 3, 5
klut.create_po( klut.create_and( f, c ) );
```

```
.model top
.inputs pi2 pi3 pi4        <- pi4 is declared and never read
.outputs po0
...
.names new_n4 pi5 new_n6   <- pi5 is read and never declared
```

### Why it is worth fixing rather than working around

The output is not malformed in a way anything reports. `lorina::read_blif` does reject it, but ABC accepts it and ties the undeclared signal to constant 0 — so the file reads back as a well-formed circuit that computes a different function, silently, with the right port count.

I hit this running combinational equivalence checking over LUT-mapped EPFL circuits: `mem_ctrl` came back NOT_EQUIVALENT with 39 phantom inputs, and it took a while to believe the writer rather than the mapper.

### The change

Two lines: derive the name from the node, which is what the rest of the writer already does. The named-network branch has the same problem — it calls `make_signal(node_to_index(n))`, so `has_name`/`get_name` are looked up against the wrong signal — and is fixed the same way.

The added test builds the smallest network with a CI gap and pins the exact output. It fails on master (both the string comparison and the `blif_read_after_write_test` on top of it) and passes with the change; the rest of the suite is unaffected — 917 test cases, 133227 assertions green.
