### PR TITLE
🐛 Fix reading a latched AIGER file into a combinational network

### DIFF
--- a/include/mockturtle/io/aiger_reader.hpp
+++ b/include/mockturtle/io/aiger_reader.hpp
@@ -55,6 +55,14 @@ namespace mockturtle
  * - `create_ri`
  * - `create_ro`
  *
+ * A network type that implements neither cannot hold registers.  Reading a
+ * latched AIGER file into one flattens a single timeframe of the design: each
+ * latch output becomes a primary input, appended behind the file's own primary
+ * inputs, and each latch next-state function becomes a primary output, appended
+ * behind the file's own primary outputs.  No logic is lost, but the sequential
+ * behaviour is: the registers become free inputs.  Use a `sequential<Ntk>` to
+ * read the design as the sequential network it is.
+ *
    \verbatim embed:rst
 
    Example
@@ -82,6 +90,9 @@ public:
     static_assert( has_create_and_v<Ntk>, "Ntk does not implement the create_and function" );
   }
 
+  /*! \brief Whether the network type can hold registers. */
+  static constexpr bool has_registers = has_create_ri_v<Ntk> && has_create_ro_v<Ntk>;
+
   ~aiger_reader()
   {
     uint32_t output_id{ 0 };
@@ -104,41 +115,42 @@ public:
       _ntk.create_po( signal );
     }
 
-    if constexpr ( has_create_ri_v<Ntk> )
+    for ( auto i = 0u; i < latches.size(); ++i )
     {
-      for ( auto i = 0u; i < latches.size(); ++i )
+      auto& latch = latches[i];
+      auto const lit = std::get<0>( latch );
+
+      auto signal = signals[lit >> 1];
+      if ( lit & 1 )
       {
-        auto& latch = latches[i];
-        auto const lit = std::get<0>( latch );
-        auto const reset = std::get<1>( latch );
+        signal = _ntk.create_not( signal );
+      }
 
-        auto signal = signals[lit >> 1];
-        if ( lit & 1 )
-        {
-          signal = _ntk.create_not( signal );
-        }
+      if constexpr ( has_set_name_v<Ntk> )
+      {
+        _ntk.set_name( signal, std::get<2>( latch ) + "_next" );
+      }
 
-        if constexpr ( has_set_name_v<Ntk> )
-        {
-          _ntk.set_name( signal, std::get<2>( latch ) + "_next" );
-        }
-
+      if constexpr ( has_registers )
+      {
         _ntk.create_ri( signal );
         register_t reg;
-        reg.init = reset;
+        reg.init = std::get<1>( latch );
         _ntk.set_register( i, reg );
+      }
+      else
+      {
+        /* The network cannot hold registers.  `on_header` materialized the latch
+           outputs as primary inputs, so keep their next-state functions by
+           appending them as primary outputs; dropping them would silently
+           discard every gate that only feeds a register. */
+        _ntk.create_po( signal );
       }
     }
   }
 
   void on_header( uint64_t, uint64_t num_inputs, uint64_t num_latches, uint64_t, uint64_t ) const override
   {
-    (void)num_latches;
-    if constexpr ( !has_create_ri_v<Ntk> || !has_create_ro_v<Ntk> )
-    {
-      assert( num_latches == 0 && "network type does not support the creation of latches" );
-    }
-
     _num_inputs = static_cast<uint32_t>( num_inputs );
 
     /* constant */
@@ -150,12 +162,20 @@ public:
       signals.push_back( _ntk.create_pi() );
     }
 
-    if constexpr ( has_create_ro_v<Ntk> )
+    /* create latch outputs (ro), or primary inputs standing in for them.  Every
+       AIGER literal above `1 + num_inputs` refers to one of these, so a signal
+       must be pushed for each of them whether the network can hold registers or
+       not: skipping them leaves `signals` short and `on_and` reads past its
+       end. */
+    for ( auto i = 0u; i < num_latches; ++i )
     {
-      /* create latch outputs (ro) */
-      for ( auto i = 0u; i < num_latches; ++i )
+      if constexpr ( has_registers )
       {
         signals.push_back( _ntk.create_ro() );
+      }
+      else
+      {
+        signals.push_back( _ntk.create_pi() );
       }
     }
   }
@@ -175,14 +195,11 @@ public:
 
   void on_latch_name( unsigned index, const std::string& name ) const override
   {
-    if constexpr ( has_create_ri_v<Ntk> && has_create_ro_v<Ntk> )
+    if constexpr ( has_set_name_v<Ntk> )
     {
-      if constexpr ( has_set_name_v<Ntk> )
-      {
-        _ntk.set_name( signals[1 + _num_inputs + index], name );
-      }
-      std::get<2>( latches[index] ) = name;
+      _ntk.set_name( signals[1 + _num_inputs + index], name );
     }
+    std::get<2>( latches[index] ) = name;
   }
 
   void on_and( unsigned index, unsigned left_lit, unsigned right_lit ) const override
@@ -207,16 +224,13 @@ public:
 
   void on_latch( unsigned index, unsigned next, latch_init_value reset ) const override
   {
-    if constexpr ( has_create_ri_v<Ntk> && has_create_ro_v<Ntk> )
-    {
-      (void)index;
-      /* AIGER cannot express `unknown`: a latch either has a defined reset value
-         or is explicitly nondeterministic. */
-      uint8_t const r = reset == latch_init_value::NONDETERMINISTIC ? register_init::dont_care
-                        : reset == latch_init_value::ONE            ? register_init::one
-                                                                    : register_init::zero;
-      latches.push_back( std::make_tuple( next, r, "" ) );
-    }
+    (void)index;
+    /* AIGER cannot express `unknown`: a latch either has a defined reset value
+       or is explicitly nondeterministic. */
+    uint8_t const r = reset == latch_init_value::NONDETERMINISTIC ? register_init::dont_care
+                      : reset == latch_init_value::ONE            ? register_init::one
+                                                                  : register_init::zero;
+    latches.push_back( std::make_tuple( next, r, "" ) );
   }
 
   void on_output( unsigned index, unsigned lit ) const override

--- a/include/mockturtle/io/aiger_reader.hpp
+++ b/include/mockturtle/io/aiger_reader.hpp
@@ -38,6 +38,7 @@
 #include "../networks/sequential.hpp"
 #include "../traits.hpp"
 #include <lorina/aiger.hpp>
+#include <iostream>
 
 namespace mockturtle
 {
@@ -151,6 +152,14 @@ public:
 
   void on_header( uint64_t, uint64_t num_inputs, uint64_t num_latches, uint64_t, uint64_t ) const override
   {
+    if constexpr ( !has_registers )
+    {
+      if ( num_latches != 0u )
+      {
+        std::cerr << "[w] network type does not support latches, applying comb: ROs become PIs, RIs become POs\n";
+      }
+    }
+
     _num_inputs = static_cast<uint32_t>( num_inputs );
 
     /* constant */

--- a/test/io/aiger_reader.cpp
+++ b/test/io/aiger_reader.cpp
@@ -246,3 +246,88 @@ TEST_CASE( "register initialization stays valid across formats", "[aiger_reader]
     CHECK( register_init::is_defined( aig.register_at( 0 ).init ) == ( expected <= register_init::one ) );
   }
 }
+
+TEST_CASE( "read a latched Aiger file into a combinational network", "[aiger_reader]" )
+{
+  /* a network that cannot hold registers flattens one timeframe of the design:
+     the latch outputs become primary inputs and their next-state functions
+     become primary outputs.  The latch outputs used to be skipped entirely,
+     which left the reader's signal vector short of every literal above the
+     primary inputs and made `on_and` read past its end. */
+  aig_network combinational;
+  sequential<aig_network> seq;
+
+  std::string const file{ "aag 7 2 1 2 4\n"
+                          "2\n"
+                          "4\n"
+                          "6 8\n"
+                          "6\n"
+                          "7\n"
+                          "8 2 6\n"
+                          "10 3 7\n"
+                          "12 9 11\n"
+                          "14 4 12\n" };
+
+  std::istringstream in( file );
+  CHECK( lorina::read_ascii_aiger( in, aiger_reader( combinational ) ) == lorina::return_code::success );
+
+  std::istringstream seq_in( file );
+  CHECK( lorina::read_ascii_aiger( seq_in, aiger_reader( seq ) ) == lorina::return_code::success );
+
+  /* the latch output is an input and its next-state function an output */
+  CHECK( combinational.num_pis() == 3 );
+  CHECK( combinational.num_pos() == 3 );
+
+  /* no logic is gained or lost by flattening */
+  CHECK( combinational.num_gates() == seq.num_gates() );
+  CHECK( combinational.size() == seq.size() );
+  CHECK( combinational.num_cis() == seq.num_cis() );
+  CHECK( combinational.num_cos() == seq.num_cos() );
+}
+
+TEST_CASE( "read a latched Aiger file with no primary inputs", "[aiger_reader]" )
+{
+  /* a design driven only by its registers -- an LFSR, say -- reaches every one
+     of its literals through a latch output, so it flattens into a network whose
+     inputs are all former latch outputs */
+  aig_network combinational;
+
+  std::string const file{ "aag 3 0 2 1 1\n"
+                          "2 6\n"
+                          "4 2\n"
+                          "6\n"
+                          "6 2 4\n" };
+
+  std::istringstream in( file );
+  CHECK( lorina::read_ascii_aiger( in, aiger_reader( combinational ) ) == lorina::return_code::success );
+
+  CHECK( combinational.num_pis() == 2 );
+  CHECK( combinational.num_pos() == 3 );
+  CHECK( combinational.num_gates() == 1 );
+}
+
+TEST_CASE( "name a flattened latch output", "[aiger_reader]" )
+{
+  /* the symbol table still applies: a latch name belongs to the input that
+     stands in for it, and its next-state function keeps the `_next` suffix */
+  names_view<aig_network> aig;
+
+  std::string const file{ "aag 7 2 1 2 4\n"
+                          "2\n"
+                          "4\n"
+                          "6 8\n"
+                          "6\n"
+                          "7\n"
+                          "8 2 6\n"
+                          "10 3 7\n"
+                          "12 9 11\n"
+                          "14 4 12\n"
+                          "i0 x0\n"
+                          "l0 s0\n" };
+
+  std::istringstream in( file );
+  CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
+
+  CHECK( aig.get_name( aig.make_signal( aig.pi_at( 0 ) ) ) == "x0" );
+  CHECK( aig.get_name( aig.make_signal( aig.pi_at( 2 ) ) ) == "s0" );
+}

--- a/test/io/aiger_reader.cpp
+++ b/test/io/aiger_reader.cpp
@@ -7,6 +7,7 @@
 
 #include <lorina/aiger.hpp>
 
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -268,8 +269,13 @@ TEST_CASE( "read a latched Aiger file into a combinational network", "[aiger_rea
                           "12 9 11\n"
                           "14 4 12\n" };
 
+  std::stringstream err;
+  auto* old_err = std::cerr.rdbuf( err.rdbuf() );
+
   std::istringstream in( file );
   CHECK( lorina::read_ascii_aiger( in, aiger_reader( combinational ) ) == lorina::return_code::success );
+
+  std::cerr.rdbuf( old_err );
 
   std::istringstream seq_in( file );
   CHECK( lorina::read_ascii_aiger( seq_in, aiger_reader( seq ) ) == lorina::return_code::success );
@@ -283,6 +289,7 @@ TEST_CASE( "read a latched Aiger file into a combinational network", "[aiger_rea
   CHECK( combinational.size() == seq.size() );
   CHECK( combinational.num_cis() == seq.num_cis() );
   CHECK( combinational.num_cos() == seq.num_cos() );
+  CHECK( err.str().find( "applying comb: ROs become PIs, RIs become POs" ) != std::string::npos );
 }
 
 TEST_CASE( "read a latched Aiger file with no primary inputs", "[aiger_reader]" )
@@ -298,12 +305,18 @@ TEST_CASE( "read a latched Aiger file with no primary inputs", "[aiger_reader]" 
                           "6\n"
                           "6 2 4\n" };
 
+  std::stringstream err;
+  auto* old_err = std::cerr.rdbuf( err.rdbuf() );
+
   std::istringstream in( file );
   CHECK( lorina::read_ascii_aiger( in, aiger_reader( combinational ) ) == lorina::return_code::success );
+
+  std::cerr.rdbuf( old_err );
 
   CHECK( combinational.num_pis() == 2 );
   CHECK( combinational.num_pos() == 3 );
   CHECK( combinational.num_gates() == 1 );
+  CHECK( err.str().find( "applying comb: ROs become PIs, RIs become POs" ) != std::string::npos );
 }
 
 TEST_CASE( "name a flattened latch output", "[aiger_reader]" )
@@ -325,9 +338,15 @@ TEST_CASE( "name a flattened latch output", "[aiger_reader]" )
                           "i0 x0\n"
                           "l0 s0\n" };
 
+  std::stringstream err;
+  auto* old_err = std::cerr.rdbuf( err.rdbuf() );
+
   std::istringstream in( file );
   CHECK( lorina::read_ascii_aiger( in, aiger_reader( aig ) ) == lorina::return_code::success );
 
+  std::cerr.rdbuf( old_err );
+
   CHECK( aig.get_name( aig.make_signal( aig.pi_at( 0 ) ) ) == "x0" );
   CHECK( aig.get_name( aig.make_signal( aig.pi_at( 2 ) ) ) == "s0" );
+  CHECK( err.str().find( "applying comb: ROs become PIs, RIs become POs" ) != std::string::npos );
 }


### PR DESCRIPTION
## The bug

`aiger_reader::on_header` only materializes the latch outputs when the network type implements `create_ro`:

```cpp
if constexpr ( has_create_ro_v<Ntk> )
{
  /* create latch outputs (ro) */
  for ( auto i = 0u; i < num_latches; ++i )
  {
    signals.push_back( _ntk.create_ro() );
  }
}
```

For a network type that does not — a plain `aig_network`, or the `mig_network` in this reader's own documented example — `signals` is left short by exactly the latch count, while every AIGER literal above the primary inputs still assumes those slots exist. `on_and` then does `signals[left_lit >> 1]` past the end of the vector and hands the result to `create_and`.

The only thing standing between that and undefined behaviour is one line in `on_header`:

```cpp
assert( num_latches == 0 && "network type does not support the creation of latches" );
```

That condition is data-dependent — it comes from a user-supplied file, not from a programming invariant — so guarding it with `assert` means it does nothing at all under `NDEBUG`, i.e. in any release build.

Two failure modes follow:

- **Crash.** On a design whose logic reaches far enough past the latch outputs, the out-of-bounds read faults. Reading a 4-bit LFSR (0 inputs, 4 latches, 3 ANDs) into an `aig_network` segfaults.
- **Silent corruption.** On a design whose literals happen to stay inside the allocation it does not fault, and the file parses with `return_code::success` into a network quietly missing its registers. A one-latch file came back reporting 0 inputs and 1 output, having dropped the sequential half of the design without a word.

Confirmed with an ASan build against these headers. With assertions live it trips `aiger_reader.hpp:139`, the `on_header` guard. Under `-DNDEBUG` it reports `std::vector<aig_network::signal>::operator[]` with `__n=4` on a size-1 vector, called from `on_and( index=5, left_lit=8, right_lit=7 )` at `aiger_reader.hpp:193`.

## The fix

Reading a latched file into a combinational network now flattens one timeframe of the design. Each latch output becomes a primary input, appended behind the file's own primary inputs, and each latch next-state function becomes a primary output, appended behind the file's own primary outputs — the transformation ABC calls `comb`.

I picked flattening over erroring out for three reasons. It is lossless, where refusing the file or dropping the latches is not. It keeps every literal resolving to the signal the file names, which is what actually fixes the memory error rather than papering over it. And it makes the `mig_network` example in this class's own documentation work on a sequential file instead of crashing on one — right now that example is only safe for combinational input, which the docs do not say. The `sequential<Ntk>` path is untouched.

Happy to switch it to a hard error instead if you would rather the reader refuse; I avoided that mainly because there is no `throw` anywhere in `include/mockturtle/io/` today and lorina's callbacks have no way to abort a parse, so it would have been a departure in both style and mechanism.

Two supporting changes: recording and naming latches is no longer conditional on the network type, since the flattened path needs both. And `on_header` and the destructor disagreed about which trait decides whether a network can hold registers — `create_ro` in one, `create_ri` in the other — so both now consult a single `has_registers` predicate. That drift is what allowed the two halves to get out of step to begin with.

## Tests

Three cases added to `test/io/aiger_reader.cpp`:

- flattening a latched file into an `aig_network`, checked against the same file read into a `sequential<aig_network>` — same size, same gate count, same CI and CO counts, only distributed differently
- the zero-primary-input shape that segfaulted, where every literal is reached through a latch output
- the symbol table, which must still put a latch's name on the input standing in for it

The `[aiger_reader]` suite passes under `-fsanitize=address` on this branch, and the LFSR and an 8-bit accumulator both round-trip cleanly through the standalone reproducer that used to fault.

## Note on behaviour

This does change what a caller sees: reading a sequential design into a combinational network now yields registers as free primary inputs rather than a crash. That is lossless and it is the documented meaning of the operation, but it is not the same circuit, so equivalence checking against the sequential original will not agree. A consumer that wants to refuse rather than flatten can check the latch count itself.

Found while tracking down a segfault in [aigverse](https://github.com/marcelwa/aigverse), which reads AIGER through this reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)