### PR TITLE
Make lorina's shared regexes inline const

### DIFF
--- a/lib/lorina/lorina/aiger.hpp
+++ b/lib/lorina/lorina/aiger.hpp
@@ -427,15 +427,15 @@ public:
 
 namespace aig_regex
 {
-static std::regex header( R"(^aig (\d+) (\d+) (\d+) (\d+) (\d+)( \d+)?( \d+)?( \d+)?( \d+)?$)" );
-static std::regex ascii_header( R"(^aag (\d+) (\d+) (\d+) (\d+) (\d+)( \d+)?( \d+)?( \d+)?( \d+)?$)" );
-static std::regex input( R"(^i(\d+) (.*)$)" );
-static std::regex latch( R"(^l(\d+) (.*)$)" );
-static std::regex output( R"(^o(\d+) (.*)$)" );
-static std::regex bad_state( R"(^b(\d+) (.*)$)" );
-static std::regex constraint( R"(^c(\d+) (.*)$)" );
-static std::regex justice( R"(^j(\d+) (.*)$)" );
-static std::regex fairness( R"(^f(\d+) (.*)$)" );
+inline const std::regex header( R"(^aig (\d+) (\d+) (\d+) (\d+) (\d+)( \d+)?( \d+)?( \d+)?( \d+)?$)" );
+inline const std::regex ascii_header( R"(^aag (\d+) (\d+) (\d+) (\d+) (\d+)( \d+)?( \d+)?( \d+)?( \d+)?$)" );
+inline const std::regex input( R"(^i(\d+) (.*)$)" );
+inline const std::regex latch( R"(^l(\d+) (.*)$)" );
+inline const std::regex output( R"(^o(\d+) (.*)$)" );
+inline const std::regex bad_state( R"(^b(\d+) (.*)$)" );
+inline const std::regex constraint( R"(^c(\d+) (.*)$)" );
+inline const std::regex justice( R"(^j(\d+) (.*)$)" );
+inline const std::regex fairness( R"(^f(\d+) (.*)$)" );
 } // namespace aig_regex
 
 /*! \brief Reader function for ASCII AIGER format.

--- a/lib/lorina/lorina/bench.hpp
+++ b/lib/lorina/lorina/bench.hpp
@@ -155,12 +155,12 @@ public:
 
 namespace bench_regex
 {
-static std::regex input( R"(INPUT\((.*)\))" );
-static std::regex output( R"(OUTPUT\((.*)\))" );
-static std::regex gate( R"((.*)\s+=\s+(.*)\((.*)\))" );
-static std::regex dff( R"((.*)\s+=\s+DFF\((.+)\))" );
-static std::regex lut( R"((.*)\s+=\s+LUT\s+(.*)\((.*)\))" );
-static std::regex gate_asgn( R"((.*)\s+=\s+(.*))" );
+inline const std::regex input( R"(INPUT\((.*)\))" );
+inline const std::regex output( R"(OUTPUT\((.*)\))" );
+inline const std::regex gate( R"((.*)\s+=\s+(.*)\((.*)\))" );
+inline const std::regex dff( R"((.*)\s+=\s+DFF\((.+)\))" );
+inline const std::regex lut( R"((.*)\s+=\s+LUT\s+(.*)\((.*)\))" );
+inline const std::regex gate_asgn( R"((.*)\s+=\s+(.*))" );
 } // namespace bench_regex
 
 /*! \brief Reader function for the BENCH format.

--- a/lib/lorina/lorina/blif.hpp
+++ b/lib/lorina/lorina/blif.hpp
@@ -258,10 +258,10 @@ public:
 
 namespace blif_regex
 {
-static std::regex model( R"(.model\s+(.*))" );
-static std::regex names( R"(.names\s+(.*))" );
-static std::regex line_of_truthtable( R"(([01\-]*)\s*([01\-]))" );
-static std::regex end( R"(.end)" );
+inline const std::regex model( R"(.model\s+(.*))" );
+inline const std::regex names( R"(.names\s+(.*))" );
+inline const std::regex line_of_truthtable( R"(([01\-]*)\s*([01\-]))" );
+inline const std::regex end( R"(.end)" );
 } // namespace blif_regex
 
 /*! \brief Reader function for the BLIF format.

--- a/lib/lorina/lorina/dimacs.hpp
+++ b/lib/lorina/lorina/dimacs.hpp
@@ -98,8 +98,8 @@ public:
 
 namespace dimacs_regex
 {
-static std::regex problem_spec( R"(^p\s+([cd]nf)\s+([0-9]+)\s+([0-9]+)$)" );
-static std::regex clause( R"(((-?[1-9]+)+ +)+0)" );
+inline const std::regex problem_spec( R"(^p\s+([cd]nf)\s+([0-9]+)\s+([0-9]+)$)" );
+inline const std::regex clause( R"(((-?[1-9]+)+ +)+0)" );
 
 } // namespace dimacs_regex
 

--- a/lib/lorina/lorina/pla.hpp
+++ b/lib/lorina/lorina/pla.hpp
@@ -236,8 +236,8 @@ public:
 
 namespace pla_regex
 {
-static std::regex keyword( R"(^\.([^\s]*)(?:\s+(.+))?$)" );
-static std::regex term( R"(^([01\-]+)\s+([01\-]+)$)" );
+inline const std::regex keyword( R"(^\.([^\s]*)(?:\s+(.+))?$)" );
+inline const std::regex term( R"(^([01\-]+)\s+([01\-]+)$)" );
 
 } // namespace pla_regex
 

--- a/lib/lorina/lorina/verilog_regex.hpp
+++ b/lib/lorina/lorina/verilog_regex.hpp
@@ -40,12 +40,12 @@ namespace lorina
 
 namespace verilog_regex
 {
-static std::regex immediate_assign( R"(^(~)?\(?([[:alnum:]\[\]_']+)\)?$)" );
-static std::regex binary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)$)" );
-static std::regex ternary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^?])(~)?([[:alnum:]\[\]_']+)([&|^:])(~)?([[:alnum:]\[\]_']+)$)" );
-static std::regex maj3_expression( R"(^\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)$)" );
-static std::regex negated_binary_expression( R"(^~\((~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)\)$)" );
-static std::regex const_size_range( R"(^(\d+):(\d+)$)" );
+inline const std::regex immediate_assign( R"(^(~)?\(?([[:alnum:]\[\]_']+)\)?$)" );
+inline const std::regex binary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)$)" );
+inline const std::regex ternary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^?])(~)?([[:alnum:]\[\]_']+)([&|^:])(~)?([[:alnum:]\[\]_']+)$)" );
+inline const std::regex maj3_expression( R"(^\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)$)" );
+inline const std::regex negated_binary_expression( R"(^~\((~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)\)$)" );
+inline const std::regex const_size_range( R"(^(\d+):(\d+)$)" );
 } // namespace verilog_regex
 
 } // namespace lorina


### PR DESCRIPTION
Hi — a small, declaration-only patch to the vendored lorina copy, offered as a courtesy.

The six lorina format headers under `lib/lorina/lorina/` declare their compiled patterns `static` at namespace scope — `aig_regex`, `pla_regex`, `verilog_regex`, `bench_regex`, `blif_regex` and `dimacs_regex`, 29 patterns in all. This makes them `inline const`. No call site changes.

**This same patch is open upstream at hriener/lorina#90.** If you would rather take it by re-vendoring once that lands, please just close this — I opened both so the fix is available whichever route you prefer, not to pre-empt the upstream one.

### `static` in a header duplicates per translation unit

`static` gives internal linkage, so every TU that includes `aiger.hpp` gets its own private set of nine `std::regex` objects, each constructed during that TU's static initialization. `inline` is the C++17 spelling for the single shared definition intended, and `MOCKTURTLE_CXX_STANDARD` already defaults to `"17"`.

Measured on two TUs that each include `lorina/aiger.hpp`, linked together:

| | distinct `aig_regex` objects | `.bss` |
| --- | --- | --- |
| before | 18 (9 × 2 TUs) | 4224 B |
| after | 9 | 3512 B |

`nm` agrees: each pattern goes from a `b` (local BSS) symbol private to its object file to a `u` (GNU unique) symbol shared across them. mockturtle's readers are included from many TUs in a typical build, so this repeats.

### `const` is the half that prompted this

These objects live in public namespaces under public names, and only convention stops a caller doing `lorina::aig_regex::header.assign(...)`. Every use is `std::regex_match` or an `sregex_iterator` constructor, both taking a `const std::regex&` — so they are already read-only in practice, and that is exactly what makes it safe for several threads to parse at once, since `std::regex`'s const member functions carry the standard's usual thread-safety guarantee.

The context: we maintain [aigverse](https://github.com/marcelwa/aigverse), which wraps mockturtle's readers for Python, and recently released the GIL around them so threaded corpus loading actually overlaps. The audit justifying that rests on the "only ever reached through a const reference" argument, which today must be re-established by reading every call site and could be silently invalidated by a caller. `const` makes it compiler-checked.

### Testing

Compiles and links clean at C++17 across two TUs including all six patched headers. Upstream lorina's own suite passes with this change — 835 assertions in 74 test cases. End-to-end, aigverse's full suite passes against a mockturtle carrying it (426 passed, 94 skipped), exercising the AIGER binary and ASCII, PLA and Verilog readers, including a suite that parses each format from eight threads at once. It is also green across this repository's full CI matrix — g++-10/11/12, clang++-14 through 17, macOS, and both MSVC toolsets — via the equivalent change on our fork.

### One behavior note

C++17 inline variables in a shared library emit `STB_GNU_UNIQUE` symbols, which make the `.so` ineligible for `dlclose` unloading. That holds for every C++17 inline variable and is irrelevant to header-only consumption, but it is a real difference from `static` and worth flagging.

### Not included

The patterns themselves are untouched. Several — the AIGER header's nine optional capture groups, `^i(\d+) (.*)$` — parse space-separated integers with a backtracking engine and would likely be faster as a hand-written scanner, most of all in `verilog_regex` and `pla_regex` where the match runs per line. That is a separate change wanting a profile behind it.

Happy to adjust or drop this.
